### PR TITLE
chore: bump CAPI stack, charts, and mise tool versions

### DIFF
--- a/capi-mgmt/addons/flux-apps/flux-operator.yaml
+++ b/capi-mgmt/addons/flux-apps/flux-operator.yaml
@@ -15,7 +15,7 @@ spec:
       fluxcd: enabled
   repoURL: oci://ghcr.io/controlplaneio-fluxcd/charts
   chartName: flux-operator
-  version: "0.53.0"
+  version: "0.58.0"
   namespace: flux-system
   options:
     waitForJobs: true

--- a/capi-mgmt/capi-providers/caaph-system/addon-provider.yaml
+++ b/capi-mgmt/capi-providers/caaph-system/addon-provider.yaml
@@ -5,4 +5,4 @@ metadata:
   name: helm
   namespace: caaph-system
 spec:
-  version: "v0.6.2"
+  version: "v0.6.4"

--- a/capi-mgmt/capi-providers/capa-system/providers.yaml
+++ b/capi-mgmt/capi-providers/capa-system/providers.yaml
@@ -6,7 +6,7 @@ metadata:
   name: aws
   namespace: capa-system
 spec:
-  version: "v2.10.2"
+  version: "v2.13.0"
   configSecret:
     name: aws-credentials
   deployment:

--- a/capi-mgmt/capi-providers/capi-system/providers.yaml
+++ b/capi-mgmt/capi-providers/capi-system/providers.yaml
@@ -5,7 +5,7 @@ metadata:
   name: cluster-api
   namespace: capi-system
 spec:
-  version: "v1.12.5"
+  version: "v1.14.0"
 ---
 # ── Kubeadm Bootstrap Provider ────────────────────────────────────────
 apiVersion: operator.cluster.x-k8s.io/v1alpha2
@@ -14,7 +14,7 @@ metadata:
   name: kubeadm
   namespace: capi-system
 spec:
-  version: "v1.12.5"
+  version: "v1.14.0"
 ---
 # ── Kubeadm Control Plane Provider ──────────────────────────────────────
 apiVersion: operator.cluster.x-k8s.io/v1alpha2
@@ -23,4 +23,4 @@ metadata:
   name: kubeadm
   namespace: capi-system
 spec:
-  version: "v1.12.5"
+  version: "v1.14.0"

--- a/capi-mgmt/infrastructure/capi-operator/helmrelease.yaml
+++ b/capi-mgmt/infrastructure/capi-operator/helmrelease.yaml
@@ -17,7 +17,7 @@ spec:
   chart:
     spec:
       chart: cluster-api-operator
-      version: "0.27.0"
+      version: "0.28.0"
       sourceRef:
         kind: HelmRepository
         name: capi-operator

--- a/capi-mgmt/infrastructure/cert-manager/helmrelease.yaml
+++ b/capi-mgmt/infrastructure/cert-manager/helmrelease.yaml
@@ -15,7 +15,7 @@ spec:
   chart:
     spec:
       chart: cert-manager
-      version: "1.16.0"
+      version: "1.21.1"
       sourceRef:
         kind: HelmRepository
         name: cert-manager

--- a/mise.toml
+++ b/mise.toml
@@ -1,11 +1,11 @@
 [tools]
-go = "1.24"
-kubectl = "1.34"
-kind = "0.31"
-helm = "4.1"
+go = "1.26"
+kubectl = "1.35"
+kind = "0.32"
+helm = "4.2"
 aws-cli = "latest"
-clusterctl = "1.12.5"
-clusterawsadm = {version = "2.10.2", binary = "clusterawsadm"}
+clusterctl = "1.14.0"
+clusterawsadm = {version = "2.13.0", binary = "clusterawsadm"}
 flux2 = "latest"
 sops = "latest"
 age = "latest"


### PR DESCRIPTION
Bumps all outdated version pins found in the repo. Validated with the `mise run validate` overlay loop: every kustomize overlay builds.

## Provider versions (CAPI operator CRs)

| Component | Old | New | Notes |
|---|---|---|---|
| CAPI core + kubeadm bootstrap/control-plane | v1.12.5 | v1.14.0 | |
| CAPA | v2.10.2 | v2.13.0 | builds against CAPI v1.13.4; compatible with core v1.14.0 (v1beta2 contract). Existing EKS feature gates unchanged |
| CAAPH (helm addon) | v0.6.2 | v0.6.4 | bumps its own CAPI dep to v1.13.0 |

## Helm charts

| Chart | Old | New |
|---|---|---|
| flux-operator | 0.53.0 | 0.58.0 |
| cert-manager | 1.16.0 | 1.21.1 |
| cluster-api-operator | 0.27.0 | 0.28.0 |

## mise tool pins

| Tool | Old | New | Notes |
|---|---|---|---|
| clusterctl | 1.12.5 | 1.14.0 | matches CAPI core |
| clusterawsadm | 2.10.2 | 2.13.0 | matches CAPA |
| kind | 0.31 | 0.32 | default node image now k8s v1.36.1; multi-control-plane LB switched from HAProxy to Envoy |
| helm | 4.1 | 4.2 | |
| go | 1.24 | 1.26 | |
| kubectl | 1.34 | 1.35 | deliberately not 1.36: stays within the ±1 minor skew window of both the kind node (1.36) and the EKS clusters (1.34) |

## Not changed

- EKS control plane (`1.34.6`) and EKS addon `eksbuild` versions in `capi-mgmt/clusters/`: these are version-locked to each other and can only be verified against the AWS API (`aws eks describe-addon-versions`), which needs credentials. Worth a follow-up if 1.35/1.36 is available in your regions.
- `flux2`, `aws-cli`, `sops`, `age` track `latest` already.

Note for live clusters: CAPI providers upgrade one minor release at a time, so apply through intermediate minors rather than jumping straight to these pins on an existing management cluster.