### PR TITLE
ci: run konflate in GitHub Actions on every PR

### DIFF
--- a/.github/workflows/konflate.yml
+++ b/.github/workflows/konflate.yml
@@ -1,0 +1,97 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: konflate
+
+# Renders the PR as a Flux diff with konflate (https://github.com/home-operations/konflate)
+# and gates the merge on the render. konflate runs as a service container
+# inside the job: the in-cluster instance is not reachable from GitHub-hosted
+# runners, so CI runs its own one-shot instance scoped to the triggering PR.
+#
+# Auth uses only the workflow's GITHUB_TOKEN; no PATs or stored secrets.
+# Fork PRs are skipped: rendering one runs untrusted sources through flate.
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read        # konflate clones this repo with the token
+  pull-requests: write  # post/edit the summary comment on the PR
+  issues: write         # PR comments ride the issues comments API
+  checks: read          # konflate's CI-status reads (checks API)
+  statuses: read        # konflate's CI-status reads (legacy commit statuses)
+
+concurrency:
+  group: konflate-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  render:
+    name: Rendered Flux diff
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    services:
+      konflate:
+        image: ghcr.io/home-operations/konflate:0.5.0
+        ports:
+          - 8080:8080
+        env:
+          KONFLATE_REPO: github://polarsquad/knr-ops
+          KONFLATE_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Render only the PR that triggered this run.
+          KONFLATE_PR_FILTER_EXPR: pr.number == ${{ github.event.pull_request.number }}
+          # One-shot: render at startup, no periodic refresh afterwards.
+          KONFLATE_REFRESH_INTERVAL: "0"
+          KONFLATE_METRICS_ENABLED: "false"
+          KONFLATE_LOG_FORMAT: text
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+    steps:
+      - name: Wait for konflate
+        run: |
+          for i in $(seq 1 60); do
+            curl -fsS http://localhost:8080/readyz >/dev/null 2>&1 && exit 0
+            sleep 2
+          done
+          echo "::error::konflate did not become ready in time"
+          exit 1
+
+      - name: Fetch rendered summary
+        run: |
+          # The Markdown path answers 503 + Retry-After until the render
+          # reaches a terminal state, so --retry waits it out. 404s while the
+          # PR list loads at startup are covered by --retry-all-errors.
+          status=$(curl -fsS --retry 30 --retry-delay 5 --retry-all-errors --retry-max-time 600 \
+            -H 'Accept: text/markdown' \
+            -o body.md -w '%header{x-konflate-render-status}' \
+            "http://localhost:8080/api/prs/${PR_NUMBER}/summary?forge=github")
+          echo "status=${status}" >> "$GITHUB_ENV"
+          [ -s body.md ] || echo "konflate produced no summary (render status: ${status})" > body.md
+
+      - name: Post or update the summary comment
+        run: |
+          # konflate embeds a hidden marker (<!-- konflate:pr-N -->) at the top
+          # of the summary body; upsert the one comment carrying it.
+          marker="konflate:pr-${PR_NUMBER}"
+          repo="${{ github.repository }}"
+          comment_id=$(gh api "repos/${repo}/issues/${PR_NUMBER}/comments" --paginate \
+            --jq ".[] | select(.body | contains(\"${marker}\")) | .id" | head -1)
+          if [ -n "${comment_id}" ]; then
+            gh api -X PATCH "repos/${repo}/issues/comments/${comment_id}" -F body=@body.md >/dev/null
+            echo "updated comment ${comment_id}"
+          else
+            gh api "repos/${repo}/issues/${PR_NUMBER}/comments" -F body=@body.md >/dev/null
+            echo "posted new comment"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Gate on the render verdict
+        run: |
+          # ok = rendered cleanly; failures = some resources failed to render;
+          # error = no diff produced. Only a clean render passes.
+          if [ "${{ env.status }}" != "ok" ]; then
+            echo "::error::konflate render verdict: ${{ env.status }}"
+            exit 1
+          fi

--- a/capi-mgmt/infrastructure/konflate/helm.yaml
+++ b/capi-mgmt/infrastructure/konflate/helm.yaml
@@ -34,7 +34,7 @@ spec:
   interval: 1h
   url: oci://ghcr.io/home-operations/charts/konflate
   ref:
-    tag: "0.3.0"
+    tag: "0.5.0"
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/docs/konflate.md
+++ b/docs/konflate.md
@@ -13,10 +13,16 @@ two, so a review shows:
   merge, not at reconcile time.
 - **Danger lint** — cautions on risky changes.
 
-Reporting uses konflate's **write-back** mode: konflate itself posts the
-results to GitHub from inside the cluster. Write-back is outbound-only — the
-local kind management cluster needs no inbound reachability from GitHub, so
-there is no CI job and nothing to expose publicly.
+Reporting happens two ways:
+
+- **GitHub Actions** (the reliable merge gate): the `konflate` workflow runs a
+  one-shot konflate as a service container on each PR push and fails the job
+  unless the render is clean. It needs no inbound reachability and no stored
+  secrets. See [GitHub Actions](#github-actions).
+- **In-cluster write-back**: the konflate instance on the management cluster
+  posts results to GitHub itself, outbound-only, so the local kind cluster
+  needs no inbound reachability and nothing is exposed publicly. It also hosts
+  the review UI. See [Write-back](#write-back).
 
 ## Deployment
 
@@ -35,6 +41,36 @@ A single instance runs on the **management cluster**, deployed from
 | `config.statusChecks` | `true` — post the `Konflate` commit status with the render verdict |
 | Secret | `konflate-token` (SOPS-encrypted, `konflate-token.sops.yaml`) |
 | Persistence | Enabled (kind's default local-path StorageClass) so source caches and rendered diffs survive pod restarts |
+
+## GitHub Actions
+
+`.github/workflows/konflate.yml` runs konflate on every PR push, independent
+of whether the kind management cluster is online:
+
+- konflate runs as a **service container** inside the job
+  (`ghcr.io/home-operations/konflate`, pinned to the same version as the
+  in-cluster chart). `KONFLATE_PR_FILTER_EXPR` scopes it to render only the
+  triggering PR, and `KONFLATE_REFRESH_INTERVAL=0` makes it a one-shot
+  render: the job ends when the render does.
+- The job pulls the summary Markdown from
+  `GET /api/prs/{n}/summary?forge=github`. The endpoint answers
+  `503 + Retry-After` until the render reaches a terminal state, so
+  `curl --retry` waits it out with no polling loop.
+- The summary is upserted as a single PR comment keyed by konflate's hidden
+  `<!-- konflate:pr-N -->` marker. The in-cluster write-back keys on the same
+  marker, so the two share one comment instead of piling up duplicates.
+- The job gates on the `X-Konflate-Render-Status` header: only `ok` passes.
+  `failures` (some resources did not render) and `error` (no diff produced)
+  fail the job. To gate merges on the render, require the
+  `konflate / Rendered Flux diff` check in branch protection.
+- Auth is the workflow's own `GITHUB_TOKEN` (konflate clones the repo and
+  lists PRs with it; the job posts the comment with it). There are no PATs or
+  stored secrets to rotate. Fork PRs are skipped: rendering a fork runs
+  untrusted sources through flate.
+
+The in-cluster instance remains useful when online: it hosts the review UI
+and posts the `Konflate` commit status. The workflow is what makes the render
+verdict a dependable gate.
 
 ## Authentication
 


### PR DESCRIPTION
## What

Adds `.github/workflows/konflate.yml` so every PR gets a rendered Flux diff review from konflate in CI, plus the merge gate. The in-cluster instance keeps working (UI + write-back) but is no longer required for PR review.

## How it works

- konflate runs as a **service container** in the job (`ghcr.io/home-operations/konflate:0.5.0`), scoped by `KONFLATE_PR_FILTER_EXPR` to render only the triggering PR, with `KONFLATE_REFRESH_INTERVAL=0` for one-shot behavior.
- The job fetches `GET /api/prs/{n}/summary?forge=github`. The endpoint returns `503 + Retry-After` while rendering, so `curl --retry` waits for a terminal verdict with no polling loop.
- The summary is upserted as **one PR comment** keyed by konflate's hidden `<!-- konflate:pr-N -->` marker. The in-cluster write-back uses the same marker, so the two share a comment rather than duplicating.
- The job passes only on `X-Konflate-Render-Status: ok`; `failures` and `error` fail it. Require the `konflate / Rendered Flux diff` check in branch protection to gate merges.
- Auth is the workflow's own `GITHUB_TOKEN` (konflate clones the repo + lists PRs with it; the job posts the comment with it). No PATs or stored secrets. Fork PRs are skipped.

## Also in this PR

- Bumps the in-cluster konflate chart `0.3.0` -> `0.5.0` so both renderers run the same konflate version.
- `docs/konflate.md`: documents the two reporting paths (GHA gate + in-cluster write-back/UI).

## Verification

- All kustomize overlays still build (the `mise run validate` loop).
- konflate 0.5.0 smoke-tested locally in Docker against this repo: starts, authenticates with a token, lists PRs, and serves the summary endpoint.

This PR is itself the first live test: the `konflate` workflow should run on it and post the rendered-diff comment below.
