### PR TITLE
docs: add other-provider recipes (Azure, Talos, k0smotron) to extending.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ mise run teardown       # full teardown (EKS, AWS resources, kind)
 Load these only when the task touches their domain:
 
 - `docs/architecture.md`: reconciliation order, how workload apps are delivered.
-- `docs/extending.md`: adding a workload cluster, adding apps.
+- `docs/extending.md`: adding a workload cluster, adding apps, adding other providers (Azure, Talos, k0smotron).
 - `docs/secrets.md`: SOPS + age setup, credential rotation.
 - `docs/konflate.md`: rendered PR review, tokens, write-back.
 - `docs/aws-iam.md`: EKS Pod Identity, ACK controller roles, reader user.

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ mise run teardown           # full teardown (EKS, AWS resources, kind)
 | [docs/konflate.md](docs/konflate.md) | Rendered Flux PR review: in-cluster konflate instance, write-back to PRs, tokens |
 | [docs/secrets.md](docs/secrets.md) | SOPS + age secret management, key setup, credential rotation |
 | [docs/operations.md](docs/operations.md) | Prerequisites, AWS service quotas, configuration, bootstrap, verification, teardown, validation |
-| [docs/extending.md](docs/extending.md) | Adding a workload cluster, adding apps to the workload clusters |
+| [docs/extending.md](docs/extending.md) | Adding a workload cluster, adding apps to the workload clusters, adding other providers (Azure, Talos, k0smotron) |
 
 ## Repository layout
 

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -31,3 +31,177 @@ Follow the `aws-operators` / `s3-buckets` pattern in `apps/base/`:
 2. Register the `flux-ks.yaml` in `apps/base/kustomization.yaml`.
 3. Run `mise run validate`, commit, and push — every workload cluster picks it
    up on its next sync.
+
+## Using other providers
+
+The management cluster is not AWS-only. Providers are declared as CAPI
+operator CRs (`operator.cluster.x-k8s.io/v1alpha2`) under
+`capi-mgmt/capi-providers/`, one directory per provider namespace, and
+registered in `capi-mgmt/capi-providers/flux-ks.yaml`. The operator resolves
+the well-known provider names (`aws`, `azure`, `talos`,
+`k0sproject-k0smotron`) from the same built-in registry `clusterctl` uses, so
+a provider is just a typed CR with a pinned version:
+
+```
+capi-mgmt/capi-providers/<name>-system/
+  namespace.yaml
+  kustomization.yaml        # lists namespace.yaml + providers.yaml (+ secrets)
+  providers.yaml            # the typed provider CR(s)
+  <credentials>.sops.yaml   # optional cloud credentials, SOPS-encrypted
+```
+
+The Flux registration in `flux-ks.yaml` follows the existing entries:
+`dependsOn: [capi-system]`, `decryption.provider: sops` when credentials ship
+in Git, and a `healthChecks` entry naming one CRD the provider installs so
+Flux waits for it.
+
+Contract note: this repo pins CAPI core v1.14.0, which speaks the v1beta2
+contract and still accepts v1beta1-contract providers until the v1beta1
+removal (tentatively CAPI v1.16, April 2027). Prefer providers that already
+speak v1beta2.
+
+### AWS (CAPA): the reference wiring
+
+CAPA is the provider this repo already runs; use it as the template:
+
+- `capi-mgmt/capi-providers/capa-system/providers.yaml` declares
+  `InfrastructureProvider aws` v2.13.0 with `configSecret: aws-credentials`
+  and the EKS feature gates
+  (`EKS=true,EKSEnableIAM=true,EKSAllowAddRoles=true,MachinePool=true`).
+- `aws-credentials.sops.yaml` carries `AWS_B64ENCODED_CREDENTIALS`, produced
+  by `mise run aws-credentials` (rotation: [docs/secrets.md](./secrets.md)).
+- Cluster definitions in `capi-mgmt/clusters/<region>/<env>/` use
+  `AWSManagedControlPlane` + `AWSManagedMachinePool` (EKS). Per-cluster IAM
+  for the ACK controllers is wired through
+  `capi-mgmt/infrastructure/ack-pod-identity/` (see
+  [docs/aws-iam.md](./aws-iam.md)).
+
+### Azure (CAPZ)
+
+CAPZ v1.26.0 speaks v1beta2 and bundles Azure Service Operator (ASO) v2.18.0,
+which backs the managed-AKS path.
+
+1. Create a service principal (`az ad sp create-for-rbac`) and store two
+   SOPS secrets in `capi-mgmt/capi-providers/capz-system/`:
+   - the SP client secret, referenced by an `AzureClusterIdentity` CR
+     (environment-variable auth is deprecated upstream; see the CAPZ
+     multitenancy docs);
+   - `aso-credentials.sops.yaml` with `AZURE_SUBSCRIPTION_ID`,
+     `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET` for the
+     bundled ASO controller.
+2. Declare the provider in `capz-system/providers.yaml`:
+
+   ```yaml
+   apiVersion: operator.cluster.x-k8s.io/v1alpha2
+   kind: InfrastructureProvider
+   metadata:
+     name: azure
+     namespace: capz-system
+   spec:
+     version: "v1.26.0"
+   ```
+
+   No feature gates are needed for the ASO managed-cluster path.
+3. Register a `capz-system` Kustomization in `flux-ks.yaml` with SOPS
+   decryption and a healthCheck on
+   `azureclusters.infrastructure.cluster.x-k8s.io` (add the
+   `azureasomanagedclusters...` CRD when using the AKS path).
+4. Define AKS clusters in `capi-mgmt/clusters/<location>/<env>/` with the
+   `AzureASOManagedCluster` / `AzureASOManagedControlPlane` /
+   `AzureASOManagedMachinePool` types, keeping the repo conventions:
+   `namePrefix` kustomization, `capi-nameref.yaml`, the `fluxcd: enabled` and
+   region labels, and `cluster-vars` substitutions for the Azure location in
+   place of `${AWS_REGION}`. The AWS-only steps (Pod Identity associations,
+   ACK controllers) have no Azure equivalent; skip them.
+
+### Talos (CABPT + CACPT)
+
+Talos supplies the bootstrap and control plane providers only; pair it with
+any infrastructure provider (CAPA, CAPZ, k0smotron RemoteMachine, ...) that
+supplies the machines.
+
+1. Two directories, matching the upstream namespace conventions:
+
+   ```yaml
+   # capi-mgmt/capi-providers/cabpt-system/providers.yaml
+   apiVersion: operator.cluster.x-k8s.io/v1alpha2
+   kind: BootstrapProvider
+   metadata:
+     name: talos
+     namespace: cabpt-system
+   spec:
+     version: "v0.6.11"
+   ---
+   # capi-mgmt/capi-providers/cacppt-system/providers.yaml
+   apiVersion: operator.cluster.x-k8s.io/v1alpha2
+   kind: ControlPlaneProvider
+   metadata:
+     name: talos
+     namespace: cacppt-system
+   spec:
+     version: "v0.5.13"
+   ```
+
+2. No cloud credentials: Talos machine secrets are generated per cluster by
+   `TalosControlPlane` / `TalosConfig`. Always set `talosVersion` explicitly
+   (e.g. `v1.12`) so a provider upgrade does not silently change the
+   generated machine config.
+3. Contract caveat: the stable Talos providers still implement the v1beta1
+   contract, which CAPI serves only until ~April 2027. The v1beta2 line is
+   CABPT v0.7.0 (in alpha at time of writing); adopt it once it goes stable.
+4. In cluster definitions, swap `KubeadmControlPlane` for `TalosControlPlane`
+   and `KubeadmConfigTemplate` for `TalosConfigTemplate`; the infrastructure
+   templates stay whatever the paired infra provider supplies.
+
+### k0smotron
+
+k0smotron v2.1.0 is v1beta2-native and ships bootstrap, control plane, and
+infrastructure providers under one name:
+
+```yaml
+# capi-mgmt/capi-providers/k0smotron-system/providers.yaml
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
+kind: BootstrapProvider
+metadata:
+  name: k0sproject-k0smotron
+  namespace: k0smotron-system
+spec:
+  version: "v2.1.0"
+---
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
+kind: ControlPlaneProvider
+metadata:
+  name: k0sproject-k0smotron
+  namespace: k0smotron-system
+spec:
+  version: "v2.1.0"
+---
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
+kind: InfrastructureProvider
+metadata:
+  name: k0sproject-k0smotron
+  namespace: k0smotron-system
+spec:
+  version: "v2.1.0"
+```
+
+- No cloud credentials are needed, and the cert-manager the repo already
+  installs covers its webhooks.
+- Hosted control planes: `K0smotronControlPlane` runs the child cluster's
+  control plane as pods on the management cluster; workers come from any
+  infra provider.
+- Remote machines: `RemoteMachine` provisions k0s onto existing machines over
+  SSH (bare metal, arbitrary VMs, anywhere with no CAPI cloud provider).
+- Drop the `InfrastructureProvider` CR if you only want hosted control
+  planes.
+
+### After adding a provider
+
+1. `mise run validate` builds every overlay, including the new directory.
+2. Open the PR; konflate renders the blast radius (new CRDs, provider
+   deployments) into the PR comment and the `konflate / Rendered Flux diff`
+   check.
+3. After merge, confirm the provider came up:
+   `kubectl get pods -n <name>-system` and
+   `kubectl get <kind>providers.operator.cluster.x-k8s.io -A` (e.g.
+   `infrastructureproviders`).


### PR DESCRIPTION
## What

Adds a "Using other providers" section to `docs/extending.md` with explicit, current-version recipes for four providers, following this repo's CAPI-operator pattern (typed CR under `capi-mgmt/capi-providers/<name>-system/` + registration in `flux-ks.yaml` + optional SOPS credentials).

## Providers covered

| Provider | Version | Contract | Credentials |
|---|---|---|---|
| AWS (CAPA) | v2.13.0 (already wired) | v1beta2 | `aws-credentials` SOPS secret (`AWS_B64ENCODED_CREDENTIALS`) |
| Azure (CAPZ) | v1.26.0 | v1beta2 | `AzureClusterIdentity` + SP secret, `aso-credentials` for bundled ASO v2.18.0 |
| Talos (CABPT + CACPT) | v0.6.11 / v0.5.13 | v1beta1 (deprecated, served until ~Apr 2027) | none (per-cluster machine secrets generated) |
| k0smotron | v2.1.0 | v1beta2-native | none |

Each recipe covers: the provider CRs with pinned versions, credential setup, the `flux-ks.yaml` registration pattern (`dependsOn`, SOPS decryption, CRD healthChecks), and what cluster definitions look like for that provider.

## Verified facts behind the docs

- All four provider names (`aws`, `azure`, `talos`, `k0sproject-k0smotron`) resolve from the built-in registry in CAPI v1.14.0 (`cmd/clusterctl/client/config/providers_client.go`), so no `fetchConfig` is needed.
- CAPI v1.14 accepts v1beta1-contract providers temporarily; v1beta1 removal is tentatively CAPI v1.16 (April 2027). The Talos section calls this out and points at the v1beta2 line (CABPT v0.7.0, currently alpha).
- CAPZ env-var auth is deprecated upstream; the recipe uses `AzureClusterIdentity` per the current CAPZ book.
- k0smotron v2.x aligns with CAPI v1beta2; the infrastructure CR (RemoteMachine over SSH) is optional for hosted-control-plane-only use.

Also updates the README docs table and the AGENTS.md pointer for `docs/extending.md`.
