### PR TITLE
feat: make management lifecycle profile aware

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,7 +29,7 @@ AGE_KEY_FILE="age.agekey"
 # capi-mgmt/capi-providers/capa-system/aws-credentials.sops.yaml and are
 # decrypted in-cluster by Flux. To set/rotate them:
 #
-#   1. Run: mise run aws-bootstrap     (provisions IAM via CloudFormation)
+#   1. Run: mise -E aws run aws-bootstrap (provisions IAM via CloudFormation)
 #   2. Run: mise run aws-credentials   (exports profile to .sops.yaml)
 #   3. Run: mise run sops-encrypt capi-mgmt/capi-providers/capa-system/aws-credentials.sops.yaml
 #

--- a/README.md
+++ b/README.md
@@ -69,8 +69,17 @@ mise run teardown           # full teardown (EKS, AWS resources, kind)
 
 The shared toolchain is defined in `mise.toml`. AWS-specific tools are layered
 through `mise.aws.toml`; use the `aws` profile when those tools are needed.
-The `mac` profile is still work in progress and currently only identifies the
-profile without performing any additional action.
+The `mac` profile is still work in progress. It can create the management kind
+cluster without installing Flux or provisioning AWS resources:
+
+```sh
+mise -E mac install
+mise -E mac run bootstrap
+mise -E mac run teardown
+```
+
+The Mac teardown deletes only the `capi-mgmt` kind cluster. The default
+teardown path suspends Flux and removes the AWS-managed infrastructure.
 
 ## Documentation
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -3,28 +3,39 @@
 # Everything after this script runs is driven by GitOps (Flux).
 set -euo pipefail
 
+PROFILE="${KNR_OPS_PROFILE:-${1:-aws}}"
+case "$PROFILE" in
+  mac|aws) ;;
+  *)
+    echo "ERROR: unsupported profile '$PROFILE' (expected 'mac' or 'aws')" >&2
+    exit 1
+    ;;
+esac
+
 # ── Prerequisites check ───────────────────────────────────────────────────────
 for cmd in kind helm kubectl; do
   command -v "$cmd" >/dev/null 2>&1 || { echo "ERROR: $cmd not found in PATH"; exit 1; }
 done
 
-: "${GITHUB_TOKEN:?GITHUB_TOKEN must be set (a PAT with read access to the repo)}"
-: "${GIT_REPO_URL:?GIT_REPO_URL must be set}"
+if [ "$PROFILE" = aws ]; then
+  : "${GITHUB_TOKEN:?GITHUB_TOKEN must be set (a PAT with read access to the repo)}"
+  : "${GIT_REPO_URL:?GIT_REPO_URL must be set}"
 
-# GITHUB_USER is only used as the basic-auth username; any non-empty value
-# works with a GitHub PAT, so default to "git".
-GITHUB_USER="${GITHUB_USER:-git}"
+  # GITHUB_USER is only used as the basic-auth username; any non-empty value
+  # works with a GitHub PAT, so default to "git".
+  GITHUB_USER="${GITHUB_USER:-git}"
 
-# ── SOPS age key ──────────────────────────────────────────────────────────────
-# Flux decrypts SOPS-encrypted secrets in Git (e.g. the CAPA AWS credentials)
-# using an age private key loaded into the cluster as the `sops-age` secret.
-# AGE_KEY_FILE defaults to ./age.agekey (gitignored).
-AGE_KEY_FILE="${AGE_KEY_FILE:-age.agekey}"
-if [ ! -f "$AGE_KEY_FILE" ]; then
-  echo "ERROR: age key file not found at '$AGE_KEY_FILE'." >&2
-  echo "       Generate one with:  mise run sops-keygen" >&2
-  echo "       and add its PUBLIC key to .sops.yaml. See docs/secrets.md." >&2
-  exit 1
+  # ── SOPS age key ────────────────────────────────────────────────────────────
+  # Flux decrypts SOPS-encrypted secrets in Git (e.g. the CAPA AWS credentials)
+  # using an age private key loaded into the cluster as the `sops-age` secret.
+  # AGE_KEY_FILE defaults to ./age.agekey (gitignored).
+  AGE_KEY_FILE="${AGE_KEY_FILE:-age.agekey}"
+  if [ ! -f "$AGE_KEY_FILE" ]; then
+    echo "ERROR: age key file not found at '$AGE_KEY_FILE'." >&2
+    echo "       Generate one with:  mise run sops-keygen" >&2
+    echo "       and add its PUBLIC key to .sops.yaml. See docs/secrets.md." >&2
+    exit 1
+  fi
 fi
 
 # ── Prerequisite: container engine (Docker or Podman) ────────────────────────
@@ -96,6 +107,13 @@ echo ">>> Waiting for cluster node to be ready..."
 # Explicitly switch kubectl to use the kind cluster context
 kubectl config use-context kind-capi-mgmt
 kubectl wait --for=condition=Ready node --all --timeout=120s
+
+if [ "$PROFILE" = mac ]; then
+  echo ""
+  echo ">>> Mac profile complete: management kind cluster is ready"
+  echo ">>> No Flux or AWS resources were provisioned"
+  exit 0
+fi
 
 # ── Step 2: Install the Flux Operator via Helm ────────────────────────────────
 echo ">>> Installing Flux Operator..."

--- a/mise.aws.toml
+++ b/mise.aws.toml
@@ -1,3 +1,10 @@
+[env]
+KNR_OPS_PROFILE = "aws"
+
 [tools]
 aws-cli = "latest"
 clusterawsadm = { version = "2.13.0", binary = "clusterawsadm" }
+
+[tasks.aws-bootstrap]
+description = "Provision the clusterawsadm IAM CloudFormation stack for CAPA"
+run = "clusterawsadm bootstrap iam create-cloudformation-stack --region ${AWS_REGION:-eu-north-1}"

--- a/mise.mac.toml
+++ b/mise.mac.toml
@@ -1,3 +1,2 @@
-[tasks.profile]
-description = "Identify the mac profile without performing any action"
-run = "echo mac"
+[env]
+KNR_OPS_PROFILE = "mac"

--- a/mise.toml
+++ b/mise.toml
@@ -57,12 +57,8 @@ done
 """
 
 [tasks.bootstrap]
-description = "Bootstrap the kind management cluster and hand off to Flux"
+description = "Bootstrap the management kind cluster and hand off to Flux/GitOps"
 run = "./bootstrap.sh"
-
-[tasks.aws-bootstrap]
-description = "Provision the clusterawsadm IAM CloudFormation stack for CAPA"
-run = "clusterawsadm bootstrap iam create-cloudformation-stack --region ${AWS_REGION:-eu-north-1}"
 
 [tasks.aws-credentials]
 description = "Export AWS credentials as a profile string for SOPS-encrypted secrets"

--- a/teardown.sh
+++ b/teardown.sh
@@ -20,8 +20,37 @@
 #
 # Usage:
 #   ./teardown.sh              # Full teardown (k8s + AWS)
+#   KNR_OPS_PROFILE=mac ./teardown.sh  # Delete the management kind cluster
 #   AWS_ONLY=1 ./teardown.sh   # AWS orphan cleanup only (skip k8s steps)
 set -euo pipefail
+
+PROFILE="${KNR_OPS_PROFILE:-${1:-aws}}"
+case "$PROFILE" in
+  mac|aws) ;;
+  *)
+    echo "ERROR: unsupported profile '$PROFILE' (expected 'mac' or 'aws')" >&2
+    exit 1
+    ;;
+esac
+
+if [ "$PROFILE" = mac ] && [ "${AWS_ONLY:-0}" = "1" ]; then
+  echo "ERROR: AWS_ONLY=1 cannot be combined with the mac profile" >&2
+  echo "       Use the AWS profile for AWS-only orphan cleanup" >&2
+  exit 1
+fi
+
+if [ "$PROFILE" = mac ]; then
+  command -v kind >/dev/null 2>&1 \
+    || { echo "ERROR: kind not found in PATH" >&2; exit 1; }
+  if kind get clusters 2>/dev/null | grep -q '^capi-mgmt$'; then
+    echo ">>> Deleting kind management cluster 'capi-mgmt'..."
+    kind delete cluster --name capi-mgmt
+    echo "✓   kind cluster 'capi-mgmt' deleted"
+  else
+    echo ">>> kind management cluster 'capi-mgmt' is not present"
+  fi
+  exit 0
+fi
 
 # Never let the AWS CLI open an interactive pager (it would hang the script).
 export AWS_PAGER=""


### PR DESCRIPTION
## Summary
- make bootstrap select mac or AWS behavior from the mise profile environment
- keep the management kind cluster command shared by both profiles
- move the AWS bootstrap task into mise.aws.toml
- make teardown delete only kind for mac and retain full AWS cleanup for AWS
- document the profile-aware lifecycle in the README

## Validation
- bash -n bootstrap.sh teardown.sh
- mise -E mac tasks
- mise -E aws tasks
- git diff --check