### PR TITLE
fix: pull Flux charts anonymously, require PAT only for git sync

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,13 +3,15 @@
 #
 #   cp .env.example .env
 
-# ── GitOps source (required) ──────────────────────────────────────────────────
-# HTTPS URL of THIS repository. Flux syncs the capi-mgmt/ path from here.
+# ── GitOps source (AWS profile) ───────────────────────────────────────────────
+# HTTPS URL of THIS repository. The AWS profile uses it for Flux sync.
+# Flux syncs the capi-mgmt/ path from here.
 GIT_REPO_URL="https://github.com/polarsquad/knr-ops"
 
-# ── GitHub PAT for Flux (required) ────────────────────────────────────────────
-# Create a fine-grained personal access token with read-only Contents access
-# to this repository (a classic token with `repo` scope also works).
+# ── GitHub PAT for Flux (AWS profile) ─────────────────────────────────────────
+# Create a fine-grained token with read-only Contents access, or a classic token
+# with the `repo` scope. The AWS profile uses it for Flux to clone this
+# repository; the Flux Operator chart is pulled anonymously.
 GITHUB_TOKEN=""
 # Basic-auth username paired with the token. Any non-empty value works for
 # GitHub PATs; "git" is a safe default.

--- a/README.md
+++ b/README.md
@@ -49,15 +49,16 @@ not a developer self-service portal; you are the consumer.
 ## Prerequisites
 
 - Mise
-- GitHub personal access token (PAT) with read access to this repo
-- AWS credentials and quotas established
+- GitHub personal access token (PAT) with read access to this repo for the AWS
+  profile
+- AWS credentials and quotas established for the AWS profile
 
 ## Quickstart
 
 ```sh
 mise trust                  # to enable mise in this repository
 mise install                # installs tools pinned in mise.toml (kubectl, kind, flux, ...)
-cp .env.example .env        # fill in GitHub PAT + AWS settings; gitignored
+cp .env.example .env        # AWS profile: fill in GitHub PAT and AWS settings
 mise run sops-keygen        # first time only: age key for SOPS
 mise run bootstrap          # kind cluster + Flux; everything else is GitOps
 flux get kustomizations --watch
@@ -69,14 +70,19 @@ mise run teardown           # full teardown (EKS, AWS resources, kind)
 
 The shared toolchain is defined in `mise.toml`. AWS-specific tools are layered
 through `mise.aws.toml`; use the `aws` profile when those tools are needed.
-The `mac` profile is still work in progress. It can create the management kind
-cluster without installing Flux or provisioning AWS resources:
+The `mac` profile is still work in progress. It creates the management kind
+cluster and installs the Flux Operator, but does not configure GitOps sync or
+provision AWS resources:
 
 ```sh
 mise -E mac install
 mise -E mac run bootstrap
 mise -E mac run teardown
 ```
+
+The Flux Operator chart is pulled anonymously. The AWS profile requires a
+GitHub PAT so Flux can clone this repository; the Mac profile does not require
+GitHub or AWS credentials.
 
 The Mac teardown deletes only the `capi-mgmt` kind cluster. The default
 teardown path suspends Flux and removes the AWS-managed infrastructure.

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -108,19 +108,26 @@ echo ">>> Waiting for cluster node to be ready..."
 kubectl config use-context kind-capi-mgmt
 kubectl wait --for=condition=Ready node --all --timeout=120s
 
-if [ "$PROFILE" = mac ]; then
-  echo ""
-  echo ">>> Mac profile complete: management kind cluster is ready"
-  echo ">>> No Flux or AWS resources were provisioned"
-  exit 0
-fi
-
-# ── Step 2: Install the Flux Operator via Helm ────────────────────────────────
+# ── Step 2: Install the Flux Operator ────────────────────────────────────────
 echo ">>> Installing Flux Operator..."
+ANONYMOUS_REGISTRY_CONFIG="$(mktemp)"
+printf '{}\n' > "$ANONYMOUS_REGISTRY_CONFIG"
+cleanup_registry_config() {
+  rm -f "$ANONYMOUS_REGISTRY_CONFIG"
+}
+trap cleanup_registry_config EXIT
 helm install flux-operator oci://ghcr.io/controlplaneio-fluxcd/charts/flux-operator \
   --namespace flux-system \
   --create-namespace \
-  --wait
+  --wait \
+  --registry-config "$ANONYMOUS_REGISTRY_CONFIG"
+
+if [ "$PROFILE" = mac ]; then
+  echo ""
+  echo ">>> Mac profile complete: management kind cluster and Flux Operator are ready"
+  echo ">>> No GitOps sync or AWS resources were provisioned"
+  exit 0
+fi
 
 # ── Step 3: Create GitHub PAT credentials secret ─────────────────────────────
 # Basic-auth secret consumed by Flux's source-controller to clone the repo.
@@ -178,7 +185,8 @@ helm upgrade --install flux \
   --set instance.sync.url="${GIT_REPO_URL}" \
   --set instance.sync.ref=refs/heads/main \
   --set instance.sync.path=capi-mgmt \
-  --set instance.sync.pullSecret=flux-github-pat
+  --set instance.sync.pullSecret=flux-github-pat \
+  --registry-config "$ANONYMOUS_REGISTRY_CONFIG"
 
 # ── Post-bootstrap health check ───────────────────────────────────────────────
 # Verify the Flux controllers are running before declaring success.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -18,8 +18,9 @@ You also need:
   by `bootstrap.sh`; set `CONTAINER_ENGINE=docker|podman` to override).
 - A GitHub personal access token (PAT) with read access to this repository
   (fine-grained with read-only Contents permission, or classic with `repo`
-  scope).
-- AWS credentials with permission to create EKS clusters, VPCs, and IAM roles.
+  scope) for the AWS profile. The Flux Operator chart is pulled anonymously.
+- AWS credentials with permission to create EKS clusters, VPCs, and IAM roles
+  for the AWS profile.
   For the ACK controllers the same principal additionally needs
   `iam:CreateRole`/`PutRolePolicy`/`GetRole`/`TagRole`,
   `iam:CreateUser`/`PutUserPolicy`/`GetUser`/`GetUserPolicy`/`TagUser`
@@ -57,6 +58,9 @@ cp .env.example .env
 $EDITOR .env
 ```
 
+The Flux Operator chart is pulled anonymously for both profiles. The GitHub PAT,
+AWS credentials, and `AWS_REGION` are only needed with the AWS profile.
+
 ## Bootstrap
 
 ```sh
@@ -77,6 +81,11 @@ This is the only imperative step. It:
 Everything downstream — providers, EKS clusters, workload Flux instances, the
 ACK operator, IAM role, pod identity bindings, and S3 buckets — reconciles
 from Git with no further manual steps.
+
+The Mac profile performs steps 1 and 2 only: it installs the Flux Operator in
+the `capi-mgmt` management cluster, but does not create GitHub or SOPS secrets,
+install a `FluxInstance`, or start GitOps reconciliation. The AWS profile
+performs the complete handoff described above.
 
 Watch reconciliation:
 


### PR DESCRIPTION
## Summary

- Pull the Flux Operator chart anonymously from GHCR.
- Require `GITHUB_TOKEN` only for the AWS profile’s Flux Git sync.
- Keep the Mac profile free of GitHub and AWS credential requirements.
- Document profile-specific dotenv requirements.
- Use an empty Helm registry configuration to prevent cached credentials from being used.

## Profile behavior

- `mac`: creates `capi-mgmt`, installs the Flux Operator anonymously, and stops before GitOps sync or AWS provisioning.
- `aws`: creates `capi-mgmt`, installs the Flux Operator anonymously, configures GitHub and SOPS secrets, and starts GitOps reconciliation.