### PR TITLE
feat: install FluxInstance for mac profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ mise run teardown           # full teardown (EKS, AWS resources, kind)
 The shared toolchain is defined in `mise.toml`. AWS-specific tools are layered
 through `mise.aws.toml`; use the `aws` profile when those tools are needed.
 The `mac` profile is still work in progress. It creates the management kind
-cluster and installs the Flux Operator, but does not configure GitOps sync or
-provision AWS resources:
+cluster, installs the Flux Operator and FluxInstance, but does not configure
+GitOps sync or provision AWS resources:
 
 ```sh
 mise -E mac install
@@ -80,7 +80,7 @@ mise -E mac run bootstrap
 mise -E mac run teardown
 ```
 
-The Flux Operator chart is pulled anonymously. The AWS profile requires a
+The Flux charts are pulled anonymously. The AWS profile requires a
 GitHub PAT so Flux can clone this repository; the Mac profile does not require
 GitHub or AWS credentials.
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -122,20 +122,14 @@ helm install flux-operator oci://ghcr.io/controlplaneio-fluxcd/charts/flux-opera
   --wait \
   --registry-config "$ANONYMOUS_REGISTRY_CONFIG"
 
-if [ "$PROFILE" = mac ]; then
-  echo ""
-  echo ">>> Mac profile complete: management kind cluster and Flux Operator are ready"
-  echo ">>> No GitOps sync or AWS resources were provisioned"
-  exit 0
-fi
-
 # ── Step 3: Create GitHub PAT credentials secret ─────────────────────────────
 # Basic-auth secret consumed by Flux's source-controller to clone the repo.
-echo ">>> Creating GitHub PAT credentials secret in flux-system..."
-kubectl create secret generic flux-github-pat \
-  --namespace flux-system \
-  --from-literal=username="${GITHUB_USER}" \
-  --from-literal=password="${GITHUB_TOKEN}"
+if [ "$PROFILE" = aws ]; then
+  echo ">>> Creating GitHub PAT credentials secret in flux-system..."
+  kubectl create secret generic flux-github-pat \
+    --namespace flux-system \
+    --from-literal=username="${GITHUB_USER}" \
+    --from-literal=password="${GITHUB_TOKEN}"
 
 # ── Step 3b: Create SOPS age decryption key secret ────────────────────────────
 # Flux's kustomize-controller uses this key to decrypt *.sops.yaml manifests
@@ -168,25 +162,33 @@ kubectl create secret generic sops-age \
   --namespace flux-system \
   --from-file="keys.${AGE_PUBKEY}.agekey=${AGE_KEY_FILE}" \
   --dry-run=client -o yaml | kubectl apply -f -
+fi
 
-# ── Step 4: Install the FluxInstance via Helm to start GitOps reconciliation ──
+# ── Step 4: Install the FluxInstance via Helm ────────────────────────────────
 echo ">>> Installing FluxInstance via Helm..."
+FLUX_INSTANCE_ARGS=(
+  --set instance.cluster.type=kubernetes
+  --set instance.cluster.size=small
+  --set instance.cluster.multitenant=false
+  --set instance.cluster.networkPolicy=true
+  --set instance.cluster.domain=cluster.local
+  --registry-config "$ANONYMOUS_REGISTRY_CONFIG"
+)
+if [ "$PROFILE" = aws ]; then
+  FLUX_INSTANCE_ARGS+=(
+    --set instance.sync.kind=GitRepository
+    --set instance.sync.url="${GIT_REPO_URL}"
+    --set instance.sync.ref=refs/heads/main
+    --set instance.sync.path=capi-mgmt
+    --set instance.sync.pullSecret=flux-github-pat
+  )
+fi
 helm upgrade --install flux \
   oci://ghcr.io/controlplaneio-fluxcd/charts/flux-instance \
   --namespace flux-system \
   --wait \
   --timeout 10m \
-  --set instance.cluster.type=kubernetes \
-  --set instance.cluster.size=small \
-  --set instance.cluster.multitenant=false \
-  --set instance.cluster.networkPolicy=true \
-  --set instance.cluster.domain=cluster.local \
-  --set instance.sync.kind=GitRepository \
-  --set instance.sync.url="${GIT_REPO_URL}" \
-  --set instance.sync.ref=refs/heads/main \
-  --set instance.sync.path=capi-mgmt \
-  --set instance.sync.pullSecret=flux-github-pat \
-  --registry-config "$ANONYMOUS_REGISTRY_CONFIG"
+  "${FLUX_INSTANCE_ARGS[@]}"
 
 # ── Post-bootstrap health check ───────────────────────────────────────────────
 # Verify the Flux controllers are running before declaring success.
@@ -201,5 +203,10 @@ kubectl wait --namespace flux-system --for=condition=ready pod \
 # infrastructure, capi-providers, addons, and clusters Kustomizations with
 # the correct dependsOn ordering. No further imperative steps are required.
 echo ""
-echo ">>> Bootstrap complete! Flux is now reconciling from ${GIT_REPO_URL}"
-echo ">>> Watch progress with: flux get kustomizations --watch"
+if [ "$PROFILE" = aws ]; then
+  echo ">>> Bootstrap complete! Flux is now reconciling from ${GIT_REPO_URL}"
+  echo ">>> Watch progress with: flux get kustomizations --watch"
+else
+  echo ">>> Mac profile complete: management kind cluster, Flux Operator, and FluxInstance are ready"
+  echo ">>> No GitOps sync or AWS resources were provisioned"
+fi

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -82,10 +82,10 @@ Everything downstream — providers, EKS clusters, workload Flux instances, the
 ACK operator, IAM role, pod identity bindings, and S3 buckets — reconciles
 from Git with no further manual steps.
 
-The Mac profile performs steps 1 and 2 only: it installs the Flux Operator in
+The Mac profile performs the cluster, Flux Operator, and FluxInstance steps in
 the `capi-mgmt` management cluster, but does not create GitHub or SOPS secrets,
-install a `FluxInstance`, or start GitOps reconciliation. The AWS profile
-performs the complete handoff described above.
+configure Git sync, or start GitOps reconciliation. The AWS profile adds the
+GitHub/SOPS secrets and configures the FluxInstance to sync `capi-mgmt/`.
 
 Watch reconciliation:
 


### PR DESCRIPTION
## Summary
- install FluxInstance in the management kind cluster for both profiles
- keep GitHub/SOPS secrets and Git synchronization AWS-only
- retain anonymous OCI chart pulls for both Flux charts
- document the updated Mac profile behavior

## Validation
- bash -n bootstrap.sh
- git diff --check
- mocked Mac bootstrap with Flux Operator and FluxInstance