### PR TITLE
refactor: rename mac profile to local-host

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,21 +70,21 @@ mise run teardown           # full teardown (EKS, AWS resources, kind)
 
 The shared toolchain is defined in `mise.toml`. AWS-specific tools are layered
 through `mise.aws.toml`; use the `aws` profile when those tools are needed.
-The `local` profile is still work in progress. It creates the management kind
+The `local-host` profile is still work in progress. It creates the management kind
 cluster, installs the Flux Operator and FluxInstance, but does not configure
 GitOps sync or provision AWS resources:
 
 ```sh
-mise -E local install
-mise -E local run bootstrap
-mise -E local run teardown
+mise -E local-host install
+mise -E local-host run bootstrap
+mise -E local-host run teardown
 ```
 
 The Flux charts are pulled anonymously. The AWS profile requires a
-GitHub PAT so Flux can clone this repository; the local profile does not require
+GitHub PAT so Flux can clone this repository; the local-host profile does not require
 GitHub or AWS credentials.
 
-The local teardown deletes only the `capi-mgmt` kind cluster. The default
+The local-host teardown deletes only the `capi-mgmt` kind cluster. The default
 teardown path suspends Flux and removes the AWS-managed infrastructure.
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -70,21 +70,21 @@ mise run teardown           # full teardown (EKS, AWS resources, kind)
 
 The shared toolchain is defined in `mise.toml`. AWS-specific tools are layered
 through `mise.aws.toml`; use the `aws` profile when those tools are needed.
-The `mac` profile is still work in progress. It creates the management kind
+The `local` profile is still work in progress. It creates the management kind
 cluster, installs the Flux Operator and FluxInstance, but does not configure
 GitOps sync or provision AWS resources:
 
 ```sh
-mise -E mac install
-mise -E mac run bootstrap
-mise -E mac run teardown
+mise -E local install
+mise -E local run bootstrap
+mise -E local run teardown
 ```
 
 The Flux charts are pulled anonymously. The AWS profile requires a
-GitHub PAT so Flux can clone this repository; the Mac profile does not require
+GitHub PAT so Flux can clone this repository; the local profile does not require
 GitHub or AWS credentials.
 
-The Mac teardown deletes only the `capi-mgmt` kind cluster. The default
+The local teardown deletes only the `capi-mgmt` kind cluster. The default
 teardown path suspends Flux and removes the AWS-managed infrastructure.
 
 ## Documentation

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -5,9 +5,9 @@ set -euo pipefail
 
 PROFILE="${KNR_OPS_PROFILE:-${1:-aws}}"
 case "$PROFILE" in
-  mac|aws) ;;
+  local|aws) ;;
   *)
-    echo "ERROR: unsupported profile '$PROFILE' (expected 'mac' or 'aws')" >&2
+    echo "ERROR: unsupported profile '$PROFILE' (expected 'local' or 'aws')" >&2
     exit 1
     ;;
 esac
@@ -207,6 +207,6 @@ if [ "$PROFILE" = aws ]; then
   echo ">>> Bootstrap complete! Flux is now reconciling from ${GIT_REPO_URL}"
   echo ">>> Watch progress with: flux get kustomizations --watch"
 else
-  echo ">>> Mac profile complete: management kind cluster, Flux Operator, and FluxInstance are ready"
+  echo ">>> Local profile complete: management kind cluster, Flux Operator, and FluxInstance are ready"
   echo ">>> No GitOps sync or AWS resources were provisioned"
 fi

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -5,9 +5,9 @@ set -euo pipefail
 
 PROFILE="${KNR_OPS_PROFILE:-${1:-aws}}"
 case "$PROFILE" in
-  local|aws) ;;
+  local-host|aws) ;;
   *)
-    echo "ERROR: unsupported profile '$PROFILE' (expected 'local' or 'aws')" >&2
+    echo "ERROR: unsupported profile '$PROFILE' (expected 'local-host' or 'aws')" >&2
     exit 1
     ;;
 esac
@@ -207,6 +207,6 @@ if [ "$PROFILE" = aws ]; then
   echo ">>> Bootstrap complete! Flux is now reconciling from ${GIT_REPO_URL}"
   echo ">>> Watch progress with: flux get kustomizations --watch"
 else
-  echo ">>> Local profile complete: management kind cluster, Flux Operator, and FluxInstance are ready"
+  echo ">>> Local-host profile complete: management kind cluster, Flux Operator, and FluxInstance are ready"
   echo ">>> No GitOps sync or AWS resources were provisioned"
 fi

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -82,7 +82,7 @@ Everything downstream — providers, EKS clusters, workload Flux instances, the
 ACK operator, IAM role, pod identity bindings, and S3 buckets — reconciles
 from Git with no further manual steps.
 
-The local profile performs the cluster, Flux Operator, and FluxInstance steps in
+The local-host profile performs the cluster, Flux Operator, and FluxInstance steps in
 the `capi-mgmt` management cluster, but does not create GitHub or SOPS secrets,
 configure Git sync, or start GitOps reconciliation. The AWS profile adds the
 GitHub/SOPS secrets and configures the FluxInstance to sync `capi-mgmt/`.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -82,7 +82,7 @@ Everything downstream — providers, EKS clusters, workload Flux instances, the
 ACK operator, IAM role, pod identity bindings, and S3 buckets — reconciles
 from Git with no further manual steps.
 
-The Mac profile performs the cluster, Flux Operator, and FluxInstance steps in
+The local profile performs the cluster, Flux Operator, and FluxInstance steps in
 the `capi-mgmt` management cluster, but does not create GitHub or SOPS secrets,
 configure Git sync, or start GitOps reconciliation. The AWS profile adds the
 GitHub/SOPS secrets and configures the FluxInstance to sync `capi-mgmt/`.

--- a/mise.local-host.toml
+++ b/mise.local-host.toml
@@ -1,0 +1,2 @@
+[env]
+KNR_OPS_PROFILE = "local-host"

--- a/mise.local.toml
+++ b/mise.local.toml
@@ -1,0 +1,2 @@
+[env]
+KNR_OPS_PROFILE = "local"

--- a/mise.local.toml
+++ b/mise.local.toml
@@ -1,2 +1,0 @@
-[env]
-KNR_OPS_PROFILE = "local"

--- a/mise.mac.toml
+++ b/mise.mac.toml
@@ -1,2 +1,0 @@
-[env]
-KNR_OPS_PROFILE = "mac"

--- a/teardown.sh
+++ b/teardown.sh
@@ -20,26 +20,26 @@
 #
 # Usage:
 #   ./teardown.sh              # Full teardown (k8s + AWS)
-#   KNR_OPS_PROFILE=local ./teardown.sh  # Delete the management kind cluster
+#   KNR_OPS_PROFILE=local-host ./teardown.sh  # Delete the management kind cluster
 #   AWS_ONLY=1 ./teardown.sh   # AWS orphan cleanup only (skip k8s steps)
 set -euo pipefail
 
 PROFILE="${KNR_OPS_PROFILE:-${1:-aws}}"
 case "$PROFILE" in
-  local|aws) ;;
+  local-host|aws) ;;
   *)
-    echo "ERROR: unsupported profile '$PROFILE' (expected 'local' or 'aws')" >&2
+    echo "ERROR: unsupported profile '$PROFILE' (expected 'local-host' or 'aws')" >&2
     exit 1
     ;;
 esac
 
-if [ "$PROFILE" = local ] && [ "${AWS_ONLY:-0}" = "1" ]; then
-  echo "ERROR: AWS_ONLY=1 cannot be combined with the local profile" >&2
+if [ "$PROFILE" = local-host ] && [ "${AWS_ONLY:-0}" = "1" ]; then
+  echo "ERROR: AWS_ONLY=1 cannot be combined with the local-host profile" >&2
   echo "       Use the AWS profile for AWS-only orphan cleanup" >&2
   exit 1
 fi
 
-if [ "$PROFILE" = local ]; then
+if [ "$PROFILE" = local-host ]; then
   command -v kind >/dev/null 2>&1 \
     || { echo "ERROR: kind not found in PATH" >&2; exit 1; }
   if kind get clusters 2>/dev/null | grep -q '^capi-mgmt$'; then

--- a/teardown.sh
+++ b/teardown.sh
@@ -20,26 +20,26 @@
 #
 # Usage:
 #   ./teardown.sh              # Full teardown (k8s + AWS)
-#   KNR_OPS_PROFILE=mac ./teardown.sh  # Delete the management kind cluster
+#   KNR_OPS_PROFILE=local ./teardown.sh  # Delete the management kind cluster
 #   AWS_ONLY=1 ./teardown.sh   # AWS orphan cleanup only (skip k8s steps)
 set -euo pipefail
 
 PROFILE="${KNR_OPS_PROFILE:-${1:-aws}}"
 case "$PROFILE" in
-  mac|aws) ;;
+  local|aws) ;;
   *)
-    echo "ERROR: unsupported profile '$PROFILE' (expected 'mac' or 'aws')" >&2
+    echo "ERROR: unsupported profile '$PROFILE' (expected 'local' or 'aws')" >&2
     exit 1
     ;;
 esac
 
-if [ "$PROFILE" = mac ] && [ "${AWS_ONLY:-0}" = "1" ]; then
-  echo "ERROR: AWS_ONLY=1 cannot be combined with the mac profile" >&2
+if [ "$PROFILE" = local ] && [ "${AWS_ONLY:-0}" = "1" ]; then
+  echo "ERROR: AWS_ONLY=1 cannot be combined with the local profile" >&2
   echo "       Use the AWS profile for AWS-only orphan cleanup" >&2
   exit 1
 fi
 
-if [ "$PROFILE" = mac ]; then
+if [ "$PROFILE" = local ]; then
   command -v kind >/dev/null 2>&1 \
     || { echo "ERROR: kind not found in PATH" >&2; exit 1; }
   if kind get clusters 2>/dev/null | grep -q '^capi-mgmt$'; then


### PR DESCRIPTION
## Summary
- rename mise.mac.toml to mise.local.toml
- rename the profile identity from mac to local
- update bootstrap, teardown, README, and operations documentation
- keep macOS host-specific implementation comments unchanged

## Validation
- bash -n bootstrap.sh teardown.sh
- git diff --check
- mise -E local env -s zsh