### PR TITLE
feat: configure local-host GitOps sync

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,15 +3,18 @@
 #
 #   cp .env.example .env
 
-# ── GitOps source (AWS profile) ───────────────────────────────────────────────
-# HTTPS URL of THIS repository. The AWS profile uses it for Flux sync.
-# Flux syncs the mgmt/ path from here.
+# ── GitOps source ─────────────────────────────────────────────────────────────
+# HTTPS URL of the repository Flux should sync. Defaults to the public
+# knr-ops repository when unset.
 GIT_REPO_URL="https://github.com/polarsquad/knr-ops"
+# Branch to sync. Defaults to "main" when unset.
+GIT_BRANCH="main"
 
-# ── GitHub PAT for Flux (AWS profile) ─────────────────────────────────────────
+# ── GitHub PAT for Flux (private repositories only) ────────────────────────────
 # Create a fine-grained token with read-only Contents access, or a classic token
-# with the `repo` scope. The AWS profile uses it for Flux to clone this
-# repository; the Flux Operator chart is pulled anonymously.
+# with the `repo` scope. Bootstrap detects repository visibility via the GitHub
+# API and requires this token only when the repository is private. The Flux
+# Operator chart is pulled anonymously.
 GITHUB_TOKEN=""
 # Basic-auth username paired with the token. Any non-empty value works for
 # GitHub PATs; "git" is a safe default.

--- a/README.md
+++ b/README.md
@@ -80,10 +80,10 @@ mise -E local-host run bootstrap
 mise -E local-host run teardown
 ```
 
-The Flux charts are pulled anonymously. Bootstrap checks the GitHub repository's
-visibility and configured branch before creating the cluster, and requires a
-GitHub PAT only for a private repository. Neither profile requires AWS
-credentials for the Git source.
+The Flux charts are pulled anonymously. Bootstrap checks the GitHub repository
+and configured branch together before creating the cluster. A supplied GitHub
+PAT is used for that check and by Flux; it is required for private repositories.
+Neither profile requires AWS credentials for the Git source.
 
 The local-host teardown deletes only the `mgmt` kind cluster. The default
 teardown path suspends Flux and removes the AWS-managed infrastructure.

--- a/README.md
+++ b/README.md
@@ -81,8 +81,9 @@ mise -E local-host run teardown
 ```
 
 The Flux charts are pulled anonymously. Bootstrap checks the GitHub repository's
-visibility before creating the cluster and requires a GitHub PAT only for a
-private repository. Neither profile requires AWS credentials for the Git source.
+visibility and configured branch before creating the cluster, and requires a
+GitHub PAT only for a private repository. Neither profile requires AWS
+credentials for the Git source.
 
 The local-host teardown deletes only the `mgmt` kind cluster. The default
 teardown path suspends Flux and removes the AWS-managed infrastructure.

--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ mise run teardown           # full teardown (EKS, AWS resources, kind)
 
 The shared toolchain is defined in `mise.toml`. AWS-specific tools are layered
 through `mise.aws.toml`; use the `aws` profile when those tools are needed.
-The `local-host` profile is still work in progress. It creates the management kind
-cluster, installs the Flux Operator and FluxInstance, but does not configure
-GitOps sync or provision AWS resources:
+The `local-host` profile creates the management kind cluster, installs the Flux
+Operator and FluxInstance, and syncs the public repository's `mgmt/docker/`
+path. It does not provision AWS resources:
 
 ```sh
 mise -E local-host install
@@ -80,9 +80,9 @@ mise -E local-host run bootstrap
 mise -E local-host run teardown
 ```
 
-The Flux charts are pulled anonymously. The AWS profile requires a
-GitHub PAT so Flux can clone this repository; the local-host profile does not require
-GitHub or AWS credentials.
+The Flux charts are pulled anonymously. Bootstrap checks the GitHub repository's
+visibility before creating the cluster and requires a GitHub PAT only for a
+private repository. Neither profile requires AWS credentials for the Git source.
 
 The local-host teardown deletes only the `mgmt` kind cluster. The default
 teardown path suspends Flux and removes the AWS-managed infrastructure.

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -16,6 +16,11 @@ preflight_checks() {
       ;;
   esac
 
+  if [ -z "$GIT_BRANCH" ]; then
+    echo "ERROR: GIT_BRANCH must not be empty" >&2
+    exit 1
+  fi
+
   for cmd in curl kind helm kubectl; do
     command -v "$cmd" >/dev/null 2>&1 || { echo "ERROR: $cmd not found in PATH"; exit 1; }
   done
@@ -73,7 +78,7 @@ preflight_checks() {
   # A public repository is visible without credentials. GitHub returns 404 for
   # a private repository when unauthenticated, so verify the PAT against the
   # repo before creating the management cluster when authentication is needed.
-  local github_api_response github_api_status github_api_body github_auth_status
+  local github_api_response github_api_status github_api_body github_auth_status github_branch_status github_branch_path
   github_api_response="$(curl -sS -H 'Accept: application/vnd.github+json' \
     -w $'\n%{http_code}' "https://api.github.com/repos/${GITHUB_REPO}" || true)"
   github_api_status="${github_api_response##*$'\n'}"
@@ -108,6 +113,22 @@ preflight_checks() {
 
     # Basic-auth secret consumed by Flux's source-controller.
     GITHUB_USER="${GITHUB_USER:-git}"
+  fi
+
+  github_branch_path="${GIT_BRANCH//\//%2F}"
+  if [ "$GIT_REPO_PRIVATE" = true ]; then
+    github_branch_status="$(curl -sS -o /dev/null -w '%{http_code}' \
+      -H 'Accept: application/vnd.github+json' \
+      -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+      "https://api.github.com/repos/${GITHUB_REPO}/branches/${github_branch_path}" || true)"
+  else
+    github_branch_status="$(curl -sS -o /dev/null -w '%{http_code}' \
+      -H 'Accept: application/vnd.github+json' \
+      "https://api.github.com/repos/${GITHUB_REPO}/branches/${github_branch_path}" || true)"
+  fi
+  if [ "$github_branch_status" != 200 ]; then
+    echo "ERROR: GitHub branch '${GIT_BRANCH}' was not found in repository '${GIT_REPO_URL}' (HTTP ${github_branch_status})" >&2
+    exit 1
   fi
 
   if [ "$PROFILE" = aws ]; then

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -75,11 +75,17 @@ preflight_checks() {
   GITHUB_REPO="${GITHUB_REPO%/}"
   GITHUB_REPO="${GITHUB_REPO%.git}"
 
+  # Use the same optional authentication header for every GitHub API request.
+  local github_api_response github_api_status github_api_body github_branch_status github_branch_path
+  local -a GITHUB_AUTH=()
+  if [ -n "${GITHUB_TOKEN:-}" ]; then
+    GITHUB_AUTH=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
+  fi
+
   # A public repository is visible without credentials. GitHub returns 404 for
-  # a private repository when unauthenticated, so verify the PAT against the
-  # repo before creating the management cluster when authentication is needed.
-  local github_api_response github_api_status github_api_body github_auth_status github_branch_status github_branch_path
+  # a private repository when the token is missing or cannot access it.
   github_api_response="$(curl -sS -H 'Accept: application/vnd.github+json' \
+    "${GITHUB_AUTH[@]}" \
     -w $'\n%{http_code}' "https://api.github.com/repos/${GITHUB_REPO}" || true)"
   github_api_status="${github_api_response##*$'\n'}"
   github_api_body="${github_api_response%$'\n'*}"
@@ -92,7 +98,11 @@ preflight_checks() {
       fi
       ;;
     404)
-      GIT_REPO_PRIVATE=true
+      if [ -z "${GITHUB_TOKEN:-}" ]; then
+        : "${GITHUB_TOKEN:?GITHUB_TOKEN must be set for the private GitHub repository (a PAT with read access)}"
+      fi
+      echo "ERROR: GITHUB_TOKEN cannot access GitHub repository '${GIT_REPO_URL}' (HTTP 404)" >&2
+      exit 1
       ;;
     *)
       echo "ERROR: could not inspect GitHub repository '${GIT_REPO_URL}' (HTTP ${github_api_status})" >&2
@@ -101,31 +111,15 @@ preflight_checks() {
   esac
 
   if [ "$GIT_REPO_PRIVATE" = true ]; then
-    : "${GITHUB_TOKEN:?GITHUB_TOKEN must be set for the private GitHub repository (a PAT with read access)}"
-    github_auth_status="$(curl -sS -o /dev/null -w '%{http_code}' \
-      -H 'Accept: application/vnd.github+json' \
-      -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-      "https://api.github.com/repos/${GITHUB_REPO}" || true)"
-    if [ "$github_auth_status" != 200 ]; then
-      echo "ERROR: GITHUB_TOKEN cannot access GitHub repository '${GIT_REPO_URL}' (HTTP ${github_auth_status})" >&2
-      exit 1
-    fi
-
     # Basic-auth secret consumed by Flux's source-controller.
     GITHUB_USER="${GITHUB_USER:-git}"
   fi
 
   github_branch_path="${GIT_BRANCH//\//%2F}"
-  if [ "$GIT_REPO_PRIVATE" = true ]; then
-    github_branch_status="$(curl -sS -o /dev/null -w '%{http_code}' \
-      -H 'Accept: application/vnd.github+json' \
-      -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-      "https://api.github.com/repos/${GITHUB_REPO}/branches/${github_branch_path}" || true)"
-  else
-    github_branch_status="$(curl -sS -o /dev/null -w '%{http_code}' \
-      -H 'Accept: application/vnd.github+json' \
-      "https://api.github.com/repos/${GITHUB_REPO}/branches/${github_branch_path}" || true)"
-  fi
+  github_branch_status="$(curl -sS -o /dev/null -w '%{http_code}' \
+    -H 'Accept: application/vnd.github+json' \
+    "${GITHUB_AUTH[@]}" \
+    "https://api.github.com/repos/${GITHUB_REPO}/branches/${github_branch_path}" || true)"
   if [ "$github_branch_status" != 200 ]; then
     echo "ERROR: GitHub branch '${GIT_BRANCH}' was not found in repository '${GIT_REPO_URL}' (HTTP ${github_branch_status})" >&2
     exit 1

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -4,83 +4,141 @@
 set -euo pipefail
 
 PROFILE="${KNR_OPS_PROFILE:-${1:-aws}}"
-case "$PROFILE" in
-  local-host|aws) ;;
-  *)
-    echo "ERROR: unsupported profile '$PROFILE' (expected 'local-host' or 'aws')" >&2
-    exit 1
-    ;;
-esac
+GIT_REPO_URL="${GIT_REPO_URL:-https://github.com/polarsquad/knr-ops}"
+GIT_BRANCH="${GIT_BRANCH:-main}"
 
-# ── Prerequisites check ───────────────────────────────────────────────────────
-for cmd in kind helm kubectl; do
-  command -v "$cmd" >/dev/null 2>&1 || { echo "ERROR: $cmd not found in PATH"; exit 1; }
-done
+preflight_checks() {
+  case "$PROFILE" in
+    local-host|aws) ;;
+    *)
+      echo "ERROR: unsupported profile '$PROFILE' (expected 'local-host' or 'aws')" >&2
+      exit 1
+      ;;
+  esac
 
-if [ "$PROFILE" = aws ]; then
-  : "${GITHUB_TOKEN:?GITHUB_TOKEN must be set (a PAT with read access to the repo)}"
-  : "${GIT_REPO_URL:?GIT_REPO_URL must be set}"
+  for cmd in curl kind helm kubectl; do
+    command -v "$cmd" >/dev/null 2>&1 || { echo "ERROR: $cmd not found in PATH"; exit 1; }
+  done
 
-  # GITHUB_USER is only used as the basic-auth username; any non-empty value
-  # works with a GitHub PAT, so default to "git".
-  GITHUB_USER="${GITHUB_USER:-git}"
-
-  # ── SOPS age key ────────────────────────────────────────────────────────────
-  # Flux decrypts SOPS-encrypted secrets in Git (e.g. the CAPA AWS credentials)
-  # using an age private key loaded into the cluster as the `sops-age` secret.
-  # AGE_KEY_FILE defaults to ./age.agekey (gitignored).
-  AGE_KEY_FILE="${AGE_KEY_FILE:-age.agekey}"
-  if [ ! -f "$AGE_KEY_FILE" ]; then
-    echo "ERROR: age key file not found at '$AGE_KEY_FILE'." >&2
-    echo "       Generate one with:  mise run sops-keygen" >&2
-    echo "       and add its PUBLIC key to .sops.yaml. See docs/secrets.md." >&2
-    exit 1
-  fi
-fi
-
-# ── Prerequisite: container engine (Docker or Podman) ────────────────────────
-# CONTAINER_ENGINE may be set to "docker" or "podman" to skip auto-detection.
-if [ -z "${CONTAINER_ENGINE:-}" ]; then
-  if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
-    # The podman-docker shim makes `docker` an alias for podman — detect that.
-    if docker --version 2>/dev/null | grep -qi podman; then
+  # CONTAINER_ENGINE may be set to "docker" or "podman" to skip auto-detection.
+  if [ -z "${CONTAINER_ENGINE:-}" ]; then
+    if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
+      # The podman-docker shim makes `docker` an alias for podman — detect that.
+      if docker --version 2>/dev/null | grep -qi podman; then
+        CONTAINER_ENGINE=podman
+      else
+        CONTAINER_ENGINE=docker
+      fi
+    elif command -v podman >/dev/null 2>&1 && podman info >/dev/null 2>&1; then
       CONTAINER_ENGINE=podman
     else
-      CONTAINER_ENGINE=docker
+      echo "ERROR: No running container engine found (tried docker and podman)" >&2
+      exit 1
     fi
-  elif command -v podman >/dev/null 2>&1 && podman info >/dev/null 2>&1; then
-    CONTAINER_ENGINE=podman
-  else
-    echo "ERROR: No running container engine found (tried docker and podman)" >&2
-    exit 1
   fi
-fi
 
-case "$CONTAINER_ENGINE" in
-  docker)
-    docker info >/dev/null 2>&1 || { echo "ERROR: Docker daemon not running" >&2; exit 1; }
-    # Mounted into the kind node so in-cluster tooling (e.g. CAPD) can drive
-    # the host container engine through the Docker API.
-    ENGINE_SOCK="/var/run/docker.sock"
-    ;;
-  podman)
-    podman info >/dev/null 2>&1 || { echo "ERROR: Podman is not running (is 'podman machine' started?)" >&2; exit 1; }
-    # kind's podman support is behind an explicit opt-in flag.
-    export KIND_EXPERIMENTAL_PROVIDER=podman
-    # Ask podman where its API socket lives (on macOS this is the path inside
-    # the podman machine VM, which is what kind's extraMounts resolve against).
-    ENGINE_SOCK="$(podman info --format '{{.Host.RemoteSocket.Path}}' 2>/dev/null || true)"
-    ENGINE_SOCK="${ENGINE_SOCK#unix://}"
-    if [ -z "$ENGINE_SOCK" ]; then
-      ENGINE_SOCK="/run/podman/podman.sock"
-      echo ">>> WARNING: Could not detect the podman API socket path; assuming ${ENGINE_SOCK}" >&2
+  case "$CONTAINER_ENGINE" in
+    docker)
+      docker info >/dev/null 2>&1 || { echo "ERROR: Docker daemon not running" >&2; exit 1; }
+      ENGINE_SOCK="/var/run/docker.sock"
+      ;;
+    podman)
+      podman info >/dev/null 2>&1 || { echo "ERROR: Podman is not running (is 'podman machine' started?)" >&2; exit 1; }
+      export KIND_EXPERIMENTAL_PROVIDER=podman
+      ENGINE_SOCK="$(podman info --format '{{.Host.RemoteSocket.Path}}' 2>/dev/null || true)"
+      ENGINE_SOCK="${ENGINE_SOCK#unix://}"
+      if [ -z "$ENGINE_SOCK" ]; then
+        ENGINE_SOCK="/run/podman/podman.sock"
+        echo ">>> WARNING: Could not detect the podman API socket path; assuming ${ENGINE_SOCK}" >&2
+      fi
+      ;;
+    *)
+      echo "ERROR: Unsupported CONTAINER_ENGINE '${CONTAINER_ENGINE}' (expected 'docker' or 'podman')" >&2
+      exit 1
+      ;;
+  esac
+
+  case "$GIT_REPO_URL" in
+    https://github.com/*/*) ;;
+    *)
+      echo "ERROR: GIT_REPO_URL must be an HTTPS GitHub repository URL" >&2
+      exit 1
+      ;;
+  esac
+
+  GITHUB_REPO="${GIT_REPO_URL#https://github.com/}"
+  GITHUB_REPO="${GITHUB_REPO%/}"
+  GITHUB_REPO="${GITHUB_REPO%.git}"
+
+  # A public repository is visible without credentials. GitHub returns 404 for
+  # a private repository when unauthenticated, so verify the PAT against the
+  # repo before creating the management cluster when authentication is needed.
+  local github_api_response github_api_status github_api_body github_auth_status
+  github_api_response="$(curl -sS -H 'Accept: application/vnd.github+json' \
+    -w $'\n%{http_code}' "https://api.github.com/repos/${GITHUB_REPO}" || true)"
+  github_api_status="${github_api_response##*$'\n'}"
+  github_api_body="${github_api_response%$'\n'*}"
+  case "$github_api_status" in
+    200)
+      if printf '%s' "$github_api_body" | grep -q '"private"[[:space:]]*:[[:space:]]*true'; then
+        GIT_REPO_PRIVATE=true
+      else
+        GIT_REPO_PRIVATE=false
+      fi
+      ;;
+    404)
+      GIT_REPO_PRIVATE=true
+      ;;
+    *)
+      echo "ERROR: could not inspect GitHub repository '${GIT_REPO_URL}' (HTTP ${github_api_status})" >&2
+      exit 1
+      ;;
+  esac
+
+  if [ "$GIT_REPO_PRIVATE" = true ]; then
+    : "${GITHUB_TOKEN:?GITHUB_TOKEN must be set for the private GitHub repository (a PAT with read access)}"
+    github_auth_status="$(curl -sS -o /dev/null -w '%{http_code}' \
+      -H 'Accept: application/vnd.github+json' \
+      -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+      "https://api.github.com/repos/${GITHUB_REPO}" || true)"
+    if [ "$github_auth_status" != 200 ]; then
+      echo "ERROR: GITHUB_TOKEN cannot access GitHub repository '${GIT_REPO_URL}' (HTTP ${github_auth_status})" >&2
+      exit 1
     fi
-    ;;
-  *)
-    echo "ERROR: Unsupported CONTAINER_ENGINE '${CONTAINER_ENGINE}' (expected 'docker' or 'podman')" >&2
-    exit 1
-    ;;
-esac
+
+    # Basic-auth secret consumed by Flux's source-controller.
+    GITHUB_USER="${GITHUB_USER:-git}"
+  fi
+
+  if [ "$PROFILE" = aws ]; then
+    AGE_KEY_FILE="${AGE_KEY_FILE:-age.agekey}"
+    if [ ! -f "$AGE_KEY_FILE" ]; then
+      echo "ERROR: age key file not found at '$AGE_KEY_FILE'." >&2
+      echo "       Generate one with:  mise run sops-keygen" >&2
+      echo "       and add its PUBLIC key to .sops.yaml. See docs/secrets.md." >&2
+      exit 1
+    fi
+    AGE_PUBKEY="${AGE_PUBLIC_KEY:-$(grep '^# public key:' "${AGE_KEY_FILE}" 2>/dev/null | sed 's/^# public key: //')}"
+    if [ -z "$AGE_PUBKEY" ]; then
+      echo "ERROR: Cannot determine age public key from '${AGE_KEY_FILE}' or from AGE_PUBLIC_KEY env var." >&2
+      echo "       Set AGE_PUBLIC_KEY in .env, or regenerate the key with: mise run sops-keygen" >&2
+      exit 1
+    fi
+    AGE_CONTENT=$(cat "${AGE_KEY_FILE}")
+    if ! echo "$AGE_CONTENT" | grep -q '^# created:' 2>/dev/null; then
+      echo "ERROR: '${AGE_KEY_FILE}' does not appear to be a valid age key file."
+      echo "       Expected a file with '# created:' comment header" >&2
+      exit 1
+    fi
+    if ! echo "$AGE_CONTENT" | grep -q '^AGE-SECRET-KEY-' 2>/dev/null; then
+      echo "ERROR: '${AGE_KEY_FILE}' does not appear to contain an age private key."
+      echo "       Expected a line starting with 'AGE-SECRET-KEY-'" >&2
+      exit 1
+    fi
+  fi
+}
+
+preflight_checks
 echo ">>> Using container engine: ${CONTAINER_ENGINE} (socket: ${ENGINE_SOCK})"
 
 # ── Step 1: Create the kind management cluster ────────────────────────────────
@@ -123,13 +181,14 @@ helm install flux-operator oci://ghcr.io/controlplaneio-fluxcd/charts/flux-opera
   --registry-config "$ANONYMOUS_REGISTRY_CONFIG"
 
 # ── Step 3: Create GitHub PAT credentials secret ─────────────────────────────
-# Basic-auth secret consumed by Flux's source-controller to clone the repo.
-if [ "$PROFILE" = aws ]; then
+# Basic-auth secret consumed by Flux's source-controller to clone a private repo.
+if [ "$GIT_REPO_PRIVATE" = true ]; then
   echo ">>> Creating GitHub PAT credentials secret in flux-system..."
   kubectl create secret generic flux-github-pat \
     --namespace flux-system \
     --from-literal=username="${GITHUB_USER}" \
     --from-literal=password="${GITHUB_TOKEN}"
+fi
 
 # ── Step 3b: Create SOPS age decryption key secret ────────────────────────────
 # Flux's kustomize-controller uses this key to decrypt *.sops.yaml manifests
@@ -137,31 +196,14 @@ if [ "$PROFILE" = aws ]; then
 # Secret for keys matching the pattern `keys.<public-key>.agekey` — each
 # matching key is passed to the age library for decryption.
 # AGE_PUBLIC_KEY can be overridden via .env to match a specific .sops.yaml.
-echo ">>> Creating sops-age decryption secret in flux-system..."
-# Remove any existing sops-age secret to avoid stale keys from previous bootstrap runs
-kubectl delete secret sops-age -n flux-system --ignore-not-found
-AGE_PUBKEY="${AGE_PUBLIC_KEY:-$(grep '^# public key:' "${AGE_KEY_FILE}" 2>/dev/null | sed 's/^# public key: //')}"
-if [ -z "$AGE_PUBKEY" ]; then
-  echo "ERROR: Cannot determine age public key from '${AGE_KEY_FILE}' or from AGE_PUBLIC_KEY env var." >&2
-  echo "       Set AGE_PUBLIC_KEY in .env, or regenerate the key with: mise run sops-keygen" >&2
-  exit 1
-fi
-# Validate that the file contains an age private key (must have comment header + key data)
-AGE_CONTENT=$(cat "${AGE_KEY_FILE}")
-if ! echo "$AGE_CONTENT" | grep -q '^# created:' 2>/dev/null; then
-  echo "ERROR: '${AGE_KEY_FILE}' does not appear to be a valid age key file."
-  echo "       Expected a file with '# created:' comment header" >&2
-  exit 1
-fi
-if ! echo "$AGE_CONTENT" | grep -q '^AGE-SECRET-KEY-' 2>/dev/null; then
-  echo "ERROR: '${AGE_KEY_FILE}' does not appear to contain an age private key."
-  echo "       Expected a line starting with 'AGE-SECRET-KEY-'" >&2
-  exit 1
-fi
-kubectl create secret generic sops-age \
-  --namespace flux-system \
-  --from-file="keys.${AGE_PUBKEY}.agekey=${AGE_KEY_FILE}" \
-  --dry-run=client -o yaml | kubectl apply -f -
+if [ "$PROFILE" = aws ]; then
+  echo ">>> Creating sops-age decryption secret in flux-system..."
+  # Remove any existing sops-age secret to avoid stale keys from previous bootstrap runs
+  kubectl delete secret sops-age -n flux-system --ignore-not-found
+  kubectl create secret generic sops-age \
+    --namespace flux-system \
+    --from-file="keys.${AGE_PUBKEY}.agekey=${AGE_KEY_FILE}" \
+    --dry-run=client -o yaml | kubectl apply -f -
 fi
 
 # ── Step 4: Install the FluxInstance via Helm ────────────────────────────────
@@ -178,10 +220,22 @@ if [ "$PROFILE" = aws ]; then
   FLUX_INSTANCE_ARGS+=(
     --set instance.sync.kind=GitRepository
     --set instance.sync.url="${GIT_REPO_URL}"
-    --set instance.sync.ref=refs/heads/main
+    --set instance.sync.ref="refs/heads/${GIT_BRANCH}"
     --set instance.sync.path=mgmt/aws
-    --set instance.sync.pullSecret=flux-github-pat
   )
+  if [ "$GIT_REPO_PRIVATE" = true ]; then
+    FLUX_INSTANCE_ARGS+=(--set instance.sync.pullSecret=flux-github-pat)
+  fi
+elif [ "$PROFILE" = local-host ]; then
+  FLUX_INSTANCE_ARGS+=(
+    --set instance.sync.kind=GitRepository
+    --set instance.sync.url="${GIT_REPO_URL}"
+    --set instance.sync.ref="refs/heads/${GIT_BRANCH}"
+    --set instance.sync.path=mgmt/docker
+  )
+  if [ "$GIT_REPO_PRIVATE" = true ]; then
+    FLUX_INSTANCE_ARGS+=(--set instance.sync.pullSecret=flux-github-pat)
+  fi
 fi
 helm upgrade --install flux \
   oci://ghcr.io/controlplaneio-fluxcd/charts/flux-instance \
@@ -199,14 +253,12 @@ kubectl wait --namespace flux-system --for=condition=ready pod \
 
 # ── Done ──────────────────────────────────────────────────────────────────────
 # Everything else is driven by GitOps. The FluxInstance above syncs the
-# mgmt/aws/ directory, whose top-level kustomization.yaml wires in the
-# infrastructure, capi-providers, addons, and clusters Kustomizations with
-# the correct dependsOn ordering. No further imperative steps are required.
+# profile-specific directory, whose top-level kustomization.yaml wires in the
+# provider and cluster resources. No further imperative steps are required.
 echo ""
 if [ "$PROFILE" = aws ]; then
   echo ">>> Bootstrap complete! Flux is now reconciling from ${GIT_REPO_URL}"
   echo ">>> Watch progress with: flux get kustomizations --watch"
 else
-  echo ">>> Local-host profile complete: management kind cluster, Flux Operator, and FluxInstance are ready"
-  echo ">>> No GitOps sync or AWS resources were provisioned"
+  echo ">>> Local-host profile complete: Flux is reconciling ${GIT_REPO_URL}@${GIT_BRANCH}/mgmt/docker"
 fi

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -75,32 +75,15 @@ preflight_checks() {
   GITHUB_REPO="${GITHUB_REPO%/}"
   GITHUB_REPO="${GITHUB_REPO%.git}"
 
-  local github_api_response github_api_status github_api_body github_branch_status github_branch_path
-
-  # A public repository is visible without credentials. GitHub returns 404 for
-  # a private repository without credentials.
-  github_api_response="$(curl -sS -H 'Accept: application/vnd.github+json' \
-    -w $'\n%{http_code}' "https://api.github.com/repos/${GITHUB_REPO}" || true)"
-  github_api_status="${github_api_response##*$'\n'}"
-  github_api_body="${github_api_response%$'\n'*}"
-  case "$github_api_status" in
-    200)
-      if printf '%s' "$github_api_body" | grep -q '"private"[[:space:]]*:[[:space:]]*true'; then
-        GIT_REPO_PRIVATE=true
-      else
-        GIT_REPO_PRIVATE=false
-      fi
-      ;;
-    404)
-      : "${GITHUB_TOKEN:?GITHUB_TOKEN must be set for the private GitHub repository (a PAT with read access)}"
-      GITHUB_AUTH="Authorization: Bearer ${GITHUB_TOKEN}"
-      GIT_REPO_PRIVATE=true
-      ;;
-    *)
-      echo "ERROR: could not inspect GitHub repository '${GIT_REPO_URL}' (HTTP ${github_api_status})" >&2
-      exit 1
-      ;;
-  esac
+  local github_branch_status github_branch_path
+  local -a github_auth_args=()
+  if [ -n "${GITHUB_TOKEN:-}" ]; then
+    github_auth_args=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
+    GITHUB_AUTH="Authorization: Bearer ${GITHUB_TOKEN}"
+    GIT_REPO_PRIVATE=true
+  else
+    GIT_REPO_PRIVATE=false
+  fi
 
   if [ "$GIT_REPO_PRIVATE" = true ]; then
     # Basic-auth secret consumed by Flux's source-controller.
@@ -108,21 +91,15 @@ preflight_checks() {
   fi
 
   github_branch_path="${GIT_BRANCH//\//%2F}"
-  if [ "$GIT_REPO_PRIVATE" = true ]; then
-    github_branch_status="$(curl -sS -o /dev/null -w '%{http_code}' \
-      -H 'Accept: application/vnd.github+json' \
-      -H "${GITHUB_AUTH}" \
-      "https://api.github.com/repos/${GITHUB_REPO}/branches/${github_branch_path}" || true)"
-  else
-    github_branch_status="$(curl -sS -o /dev/null -w '%{http_code}' \
-      -H 'Accept: application/vnd.github+json' \
-      "https://api.github.com/repos/${GITHUB_REPO}/branches/${github_branch_path}" || true)"
-  fi
+  github_branch_status="$(curl -sS -o /dev/null -w '%{http_code}' \
+    -H 'Accept: application/vnd.github+json' \
+    "${github_auth_args[@]}" \
+    "https://api.github.com/repos/${GITHUB_REPO}/branches/${github_branch_path}" || true)"
   if [ "$github_branch_status" != 200 ]; then
-    if [ "$GIT_REPO_PRIVATE" = true ]; then
-      echo "ERROR: GITHUB_TOKEN cannot access branch '${GIT_BRANCH}' in repository '${GIT_REPO_URL}' (HTTP ${github_branch_status})" >&2
+    if [ -z "${GITHUB_TOKEN:-}" ] && [ "$github_branch_status" = 404 ]; then
+      echo "ERROR: repository or branch '${GIT_BRANCH}' is unavailable at '${GIT_REPO_URL}'; set GITHUB_TOKEN if the repository is private" >&2
     else
-      echo "ERROR: GitHub branch '${GIT_BRANCH}' was not found in repository '${GIT_REPO_URL}' (HTTP ${github_branch_status})" >&2
+      echo "ERROR: GitHub repository or branch '${GIT_BRANCH}' is unavailable at '${GIT_REPO_URL}' (HTTP ${github_branch_status})" >&2
     fi
     exit 1
   fi

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -75,17 +75,11 @@ preflight_checks() {
   GITHUB_REPO="${GITHUB_REPO%/}"
   GITHUB_REPO="${GITHUB_REPO%.git}"
 
-  # Use the same optional authentication header for every GitHub API request.
   local github_api_response github_api_status github_api_body github_branch_status github_branch_path
-  local -a GITHUB_AUTH=()
-  if [ -n "${GITHUB_TOKEN:-}" ]; then
-    GITHUB_AUTH=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
-  fi
 
   # A public repository is visible without credentials. GitHub returns 404 for
-  # a private repository when the token is missing or cannot access it.
+  # a private repository without credentials.
   github_api_response="$(curl -sS -H 'Accept: application/vnd.github+json' \
-    "${GITHUB_AUTH[@]}" \
     -w $'\n%{http_code}' "https://api.github.com/repos/${GITHUB_REPO}" || true)"
   github_api_status="${github_api_response##*$'\n'}"
   github_api_body="${github_api_response%$'\n'*}"
@@ -98,11 +92,9 @@ preflight_checks() {
       fi
       ;;
     404)
-      if [ -z "${GITHUB_TOKEN:-}" ]; then
-        : "${GITHUB_TOKEN:?GITHUB_TOKEN must be set for the private GitHub repository (a PAT with read access)}"
-      fi
-      echo "ERROR: GITHUB_TOKEN cannot access GitHub repository '${GIT_REPO_URL}' (HTTP 404)" >&2
-      exit 1
+      : "${GITHUB_TOKEN:?GITHUB_TOKEN must be set for the private GitHub repository (a PAT with read access)}"
+      GITHUB_AUTH="Authorization: Bearer ${GITHUB_TOKEN}"
+      GIT_REPO_PRIVATE=true
       ;;
     *)
       echo "ERROR: could not inspect GitHub repository '${GIT_REPO_URL}' (HTTP ${github_api_status})" >&2
@@ -116,12 +108,22 @@ preflight_checks() {
   fi
 
   github_branch_path="${GIT_BRANCH//\//%2F}"
-  github_branch_status="$(curl -sS -o /dev/null -w '%{http_code}' \
-    -H 'Accept: application/vnd.github+json' \
-    "${GITHUB_AUTH[@]}" \
-    "https://api.github.com/repos/${GITHUB_REPO}/branches/${github_branch_path}" || true)"
+  if [ "$GIT_REPO_PRIVATE" = true ]; then
+    github_branch_status="$(curl -sS -o /dev/null -w '%{http_code}' \
+      -H 'Accept: application/vnd.github+json' \
+      -H "${GITHUB_AUTH}" \
+      "https://api.github.com/repos/${GITHUB_REPO}/branches/${github_branch_path}" || true)"
+  else
+    github_branch_status="$(curl -sS -o /dev/null -w '%{http_code}' \
+      -H 'Accept: application/vnd.github+json' \
+      "https://api.github.com/repos/${GITHUB_REPO}/branches/${github_branch_path}" || true)"
+  fi
   if [ "$github_branch_status" != 200 ]; then
-    echo "ERROR: GitHub branch '${GIT_BRANCH}' was not found in repository '${GIT_REPO_URL}' (HTTP ${github_branch_status})" >&2
+    if [ "$GIT_REPO_PRIVATE" = true ]; then
+      echo "ERROR: GITHUB_TOKEN cannot access branch '${GIT_BRANCH}' in repository '${GIT_REPO_URL}' (HTTP ${github_branch_status})" >&2
+    else
+      echo "ERROR: GitHub branch '${GIT_BRANCH}' was not found in repository '${GIT_REPO_URL}' (HTTP ${github_branch_status})" >&2
+    fi
     exit 1
   fi
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -86,11 +86,12 @@ from Git with no further manual steps.
 
 Both profiles read `GIT_REPO_URL` and `GIT_BRANCH` from `.env` when run through
 mise. They default to `https://github.com/polarsquad/knr-ops` and `main` when
-those values are not overridden. Bootstrap checks the repository visibility via
-the GitHub API before creating the management cluster. For a private repository
-it requires `GITHUB_TOKEN`, verifies that the token can access the repository,
-and creates the `flux-github-pat` secret used by Flux. Public repositories do
-not need GitHub credentials. AWS additionally requires the SOPS credentials.
+those values are not overridden. Bootstrap checks the repository visibility and
+configured branch via the GitHub API before creating the management cluster.
+For a private repository it requires `GITHUB_TOKEN`, verifies that the token
+can access the repository and branch, and creates the `flux-github-pat` secret
+used by Flux. Public repositories do not need GitHub credentials. AWS
+additionally requires the SOPS credentials.
 
 Watch reconciliation:
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -76,16 +76,21 @@ This is the only imperative step. It:
 2. Installs the Flux Operator (Helm).
 3. Creates the `flux-github-pat` secret (for Git access) and the `sops-age`
    secret (the age private key Flux uses to decrypt SOPS-encrypted secrets).
-4. Installs a `FluxInstance` that syncs `mgmt/aws/` and hands off to GitOps.
+4. Installs a `FluxInstance` that syncs the selected profile path and hands off
+    to GitOps. The AWS profile syncs `mgmt/aws/`; the local-host profile syncs
+    the public repository's `mgmt/docker/` path.
 
 Everything downstream — providers, EKS clusters, workload Flux instances, the
 ACK operator, IAM role, pod identity bindings, and S3 buckets — reconciles
 from Git with no further manual steps.
 
-The local-host profile performs the cluster, Flux Operator, and FluxInstance steps in
-the `mgmt` management cluster, but does not create GitHub or SOPS secrets,
-configure Git sync, or start GitOps reconciliation. The AWS profile adds the
-GitHub/SOPS secrets and configures the FluxInstance to sync `mgmt/aws/`.
+Both profiles read `GIT_REPO_URL` and `GIT_BRANCH` from `.env` when run through
+mise. They default to `https://github.com/polarsquad/knr-ops` and `main` when
+those values are not overridden. Bootstrap checks the repository visibility via
+the GitHub API before creating the management cluster. For a private repository
+it requires `GITHUB_TOKEN`, verifies that the token can access the repository,
+and creates the `flux-github-pat` secret used by Flux. Public repositories do
+not need GitHub credentials. AWS additionally requires the SOPS credentials.
 
 Watch reconciliation:
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -86,11 +86,11 @@ from Git with no further manual steps.
 
 Both profiles read `GIT_REPO_URL` and `GIT_BRANCH` from `.env` when run through
 mise. They default to `https://github.com/polarsquad/knr-ops` and `main` when
-those values are not overridden. Bootstrap checks the repository visibility and
-configured branch via the GitHub API before creating the management cluster.
-For a private repository it requires `GITHUB_TOKEN`, verifies that the token
-can access the repository and branch, and creates the `flux-github-pat` secret
-used by Flux. Public repositories do not need GitHub credentials. AWS
+those values are not overridden. Bootstrap checks the repository and configured
+branch together via the GitHub API before creating the management cluster. If
+`GITHUB_TOKEN` is supplied, it is used for this request and the Flux pull
+secret; it is required when the repository is private. Without a token, a
+protected or unavailable repository/branch stops bootstrap with an error. AWS
 additionally requires the SOPS credentials.
 
 Watch reconciliation:

--- a/mgmt/docker/kustomization.yaml
+++ b/mgmt/docker/kustomization.yaml
@@ -1,0 +1,3 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources: []


### PR DESCRIPTION
## Summary
- configure both profiles to sync a configurable GitHub repository and branch
- detect repository visibility and validate credentials before cluster creation
- add the Docker management kustomize root for local-host reconciliation
- document public and private repository behavior

## Validation
- bash -n bootstrap.sh
- kubectl kustomize mgmt/docker
- git diff --check