### PR TITLE
ci: authenticate curl request with GitHub token to avoid rate limiting

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Install kustomize
         run: |
-          curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
+          curl -s -H "Authorization: token ${{ github.token }}" "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
           sudo mv kustomize /usr/local/bin/
           kustomize version
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,6 +14,8 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Install kustomize
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           curl -s -H "Authorization: token ${{ github.token }}" "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
           sudo mv kustomize /usr/local/bin/


### PR DESCRIPTION
Fixes the rate limiting issue in the validate workflow when downloading kustomize.

The kustomize installation script download was being rate-limited by GitHub's API. Adding the default `github.token` to the curl request avoids unauthenticated rate limits and ensures the workflow completes reliably.