### PR TITLE
feat: bootstrap local container registry for local-host profile

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -140,6 +140,39 @@ echo ">>> Waiting for cluster node to be ready..."
 kubectl config use-context kind-mgmt
 kubectl wait --for=condition=Ready node --all --timeout=120s
 
+# ── Step 1.5: Bootstrap local container registry (local-host profile only) ────
+if [ "$PROFILE" = local-host ]; then
+  echo ">>> Bootstrapping local container registry..."
+  REGISTRY_NAME="knr-registry"
+  REGISTRY_PORT="${REGISTRY_PORT:-5000}"
+  
+  # Check if registry already exists
+  if ! $CONTAINER_ENGINE ps -a --filter "name=^${REGISTRY_NAME}$" | grep -q "${REGISTRY_NAME}"; then
+    # Create registry container
+    $CONTAINER_ENGINE run -d \
+      --name "$REGISTRY_NAME" \
+      --network kind \
+      -p "127.0.0.1:${REGISTRY_PORT}:5000" \
+      registry:2
+    echo "    Registry started: localhost:${REGISTRY_PORT}"
+  else
+    # Check if registry is running, restart if needed
+    if ! $CONTAINER_ENGINE ps --filter "name=^${REGISTRY_NAME}$" | grep -q "${REGISTRY_NAME}"; then
+      echo "    Restarting stopped registry..."
+      $CONTAINER_ENGINE start "$REGISTRY_NAME"
+    else
+      echo "    Registry already running: localhost:${REGISTRY_PORT}"
+    fi
+  fi
+  
+  # Configure kind nodes to access the registry via the hostname
+  # Add a configmap to tell the cluster about the local registry
+  kubectl create configmap local-registry-config \
+    --from-literal=registry-url="${REGISTRY_NAME}:5000" \
+    --namespace kube-system \
+    --dry-run=client -o yaml | kubectl apply -f -
+fi
+
 # ── Step 2: Install the Flux Operator ────────────────────────────────────────
 echo ">>> Installing Flux Operator..."
 ANONYMOUS_REGISTRY_CONFIG="$(mktemp)"

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -16,11 +16,14 @@ You also need:
 
 - A running container engine for kind: Docker, or Podman 5.5+ (auto-detected
   by `bootstrap.sh`; set `CONTAINER_ENGINE=docker|podman` to override).
+  For local-host profile: the same engine is used to host the local container
+  registry for OCI artifacts.
+
+**AWS profile only:**
 - A GitHub personal access token (PAT) with read access to this repository
   (fine-grained with read-only Contents permission, or classic with `repo`
-  scope) for the AWS profile. The Flux Operator chart is pulled anonymously.
-- AWS credentials with permission to create EKS clusters, VPCs, and IAM roles
-  for the AWS profile.
+  scope). The Flux Operator chart is pulled anonymously.
+- AWS credentials with permission to create EKS clusters, VPCs, and IAM roles.
   For the ACK controllers the same principal additionally needs
   `iam:CreateRole`/`PutRolePolicy`/`GetRole`/`TagRole`,
   `iam:CreateUser`/`PutUserPolicy`/`GetUser`/`GetUserPolicy`/`TagUser`
@@ -84,8 +87,30 @@ from Git with no further manual steps.
 
 The local-host profile performs the cluster, Flux Operator, and FluxInstance steps in
 the `mgmt` management cluster, but does not create GitHub or SOPS secrets,
-configure Git sync, or start GitOps reconciliation. The AWS profile adds the
-GitHub/SOPS secrets and configures the FluxInstance to sync `mgmt/aws/`.
+configure Git sync, or start GitOps reconciliation. Instead, it bootstraps a
+local Docker Registry container (`registry:2`) running on the host machine
+(accessible at `localhost:5000`) for managing OCI artifacts.
+
+**OCI Registry (local-host profile only):**
+- Provides a local container registry for development workflows
+- Enables developers to build and push OCI artifacts from git checkouts
+- Flux can sync and deploy OCI artifacts from the registry without external dependencies
+- Configurable via `REGISTRY_PORT` env var (defaults to 5000)
+- Idempotent: restarts if stopped, no action needed if already running
+
+**Workflow:**
+```bash
+# 1. Build OCI artifact from local checkout
+docker build -t localhost:5000/myapp:v1.0 .
+
+# 2. Push to local registry
+docker push localhost:5000/myapp:v1.0
+
+# 3. Configure Flux to pull from registry via mgmt/docker kustomization
+# Flux syncs and deploys from the local registry into the cluster
+```
+
+The AWS profile adds the GitHub/SOPS secrets and configures the FluxInstance to sync `mgmt/aws/`.
 
 Watch reconciliation:
 

--- a/mgmt/docker/kustomization.yaml
+++ b/mgmt/docker/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Empty placeholder for local-host profile GitOps sync.
+# This directory will be used by the Flux sync when running on docker/podman
+# without provisioning any resources.
+resources: []


### PR DESCRIPTION
When running with PROFILE=local-host, bootstrap a Docker Registry container (registry:2)
to track OCI artifacts for local development.

## Features
- Runs in the kind network for in-cluster access
- Exposes on localhost:5000 (configurable via REGISTRY_PORT env var)
- Idempotent: checks if already running, restarts if stopped
- Creates a configmap with registry URL for cluster discovery

This enables local OCI artifact management for development and testing without
requiring external registries.