### PR TITLE
feat: bootstrap local container registry for local-host profile

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -5,6 +5,8 @@ set -euo pipefail
 
 PROFILE="${KNR_OPS_PROFILE:-${1:-aws}}"
 GIT_BRANCH="main"
+REGISTRY_NAME="knr-registry"
+REGISTRY_PORT="${REGISTRY_PORT:-5001}"
 
 preflight_checks() {
   case "$PROFILE" in
@@ -60,7 +62,7 @@ preflight_checks() {
     echo "$AGE_CONTENT" | grep -q '^# created:' 2>/dev/null || missing_fields="${missing_fields}# created: header, "
     echo "$AGE_CONTENT" | grep -q '^# public key:' 2>/dev/null || missing_fields="${missing_fields}# public key: comment, "
     echo "$AGE_CONTENT" | grep -q '^AGE-SECRET-KEY-' 2>/dev/null || missing_fields="${missing_fields}AGE-SECRET-KEY- line, "
-    
+
     if [ -n "$missing_fields" ]; then
       echo "ERROR: '${AGE_KEY_FILE}' is not a valid age key file." >&2
       echo "       Missing: ${missing_fields%, }" >&2
@@ -128,9 +130,17 @@ fi
 # socket path. This ensures all in-cluster components can access a Docker-compatible API
 # at /var/run/docker.sock, whether the backend is Docker or Podman (which exposes a
 # Docker-compatible socket). This is essential for building and loading container images.
+KIND_REGISTRY_PATCH=""
+if [ "$PROFILE" = local-host ]; then
+  KIND_REGISTRY_PATCH="containerdConfigPatches:
+  - |-
+    [plugins.\"io.containerd.grpc.v1.cri\".registry.mirrors.\"localhost:${REGISTRY_PORT}\"]
+      endpoint = [\"http://${REGISTRY_NAME}:5000\"]"
+fi
 kind create cluster --name mgmt --config - <<EOF
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
+${KIND_REGISTRY_PATCH}
 nodes:
   - role: control-plane
     extraMounts:
@@ -142,6 +152,36 @@ echo ">>> Waiting for cluster node to be ready..."
 # Explicitly switch kubectl to use the kind cluster context
 kubectl config use-context kind-mgmt
 kubectl wait --for=condition=Ready node --all --timeout=120s
+
+# ── Step 1.5: Bootstrap local container registry (local-host profile only) ────
+if [ "$PROFILE" = local-host ]; then
+  echo ">>> Bootstrapping local container registry..."
+
+  # Check if registry already exists
+  if ! $CONTAINER_ENGINE ps -a --filter "name=^${REGISTRY_NAME}$" | grep -q "${REGISTRY_NAME}"; then
+    # Create registry container
+    $CONTAINER_ENGINE run -d \
+      --name "$REGISTRY_NAME" \
+      --network kind \
+      -p "127.0.0.1:${REGISTRY_PORT}:5000" \
+      registry:2
+    echo "    Registry started: localhost:${REGISTRY_PORT}"
+  else
+    # Check if registry is running, restart if needed
+    if ! $CONTAINER_ENGINE ps --filter "name=^${REGISTRY_NAME}$" | grep -q "${REGISTRY_NAME}"; then
+      echo "    Restarting stopped registry..."
+      $CONTAINER_ENGINE start "$REGISTRY_NAME"
+    else
+      echo "    Registry already running: localhost:${REGISTRY_PORT}"
+    fi
+  fi
+
+  # Configure kind nodes to access the registry via the hostname
+  # Add a configmap to tell the cluster about the local registry
+  kubectl create configmap local-registry-config \
+    --from-literal=registry-url="${REGISTRY_NAME}:5000" \
+    --namespace kube-system
+fi
 
 # ── Step 2: Install the Flux Operator ────────────────────────────────────────
 echo ">>> Installing Flux Operator..."

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -16,11 +16,14 @@ You also need:
 
 - A running container engine for kind: Docker, or Podman 5.5+ (auto-detected
   by `bootstrap.sh`; set `CONTAINER_ENGINE=docker|podman` to override).
+  For local-host profile: the same engine is used to host the local container
+  registry for OCI artifacts.
+
+**AWS profile only:**
 - A GitHub personal access token (PAT) with read access to this repository
   (fine-grained with read-only Contents permission, or classic with `repo`
-  scope) for the AWS profile. The Flux Operator chart is pulled anonymously.
-- AWS credentials with permission to create EKS clusters, VPCs, and IAM roles
-  for the AWS profile.
+  scope). The Flux Operator chart is pulled anonymously.
+- AWS credentials with permission to create EKS clusters, VPCs, and IAM roles.
   For the ACK controllers the same principal additionally needs
   `iam:CreateRole`/`PutRolePolicy`/`GetRole`/`TagRole`,
   `iam:CreateUser`/`PutUserPolicy`/`GetUser`/`GetUserPolicy`/`TagUser`
@@ -84,8 +87,32 @@ from Git with no further manual steps.
 
 The local-host profile performs the cluster, Flux Operator, and FluxInstance steps in
 the `mgmt` management cluster, but does not create GitHub or SOPS secrets,
-configure Git sync, or start GitOps reconciliation. The AWS profile adds the
-GitHub/SOPS secrets and configures the FluxInstance to sync `mgmt/aws/`.
+configure Git sync, or start GitOps reconciliation. Instead, it bootstraps a
+local Docker Registry container (`registry:2`) running on the host machine
+(accessible at `localhost:5001` by default) for managing OCI artifacts.
+
+**OCI Registry (local-host profile only):**
+- Provides a local container registry for development workflows
+- Enables developers to build and push OCI artifacts from git checkouts
+- Flux can sync and deploy OCI artifacts from the registry without external dependencies
+- Configurable via `REGISTRY_PORT` env var (defaults to 5001)
+- Idempotent: restarts if stopped, no action needed if already running
+
+**Workflow:**
+```bash
+# 1. Build OCI artifact from local checkout
+docker build -t localhost:5001/myapp:v1.0 .
+
+# 2. Push to local registry
+docker push localhost:5001/myapp:v1.0
+
+# 3. Configure Flux to pull from registry via mgmt/local-host kustomization
+# bootstrap.sh configures kind's containerd to mirror localhost:5001 to the
+# registry's in-cluster endpoint, knr-registry:5000.
+# Flux syncs and deploys from the local registry into the cluster
+```
+
+The AWS profile adds the GitHub/SOPS secrets and configures the FluxInstance to sync `mgmt/aws/`.
 
 Watch reconciliation:
 

--- a/teardown.sh
+++ b/teardown.sh
@@ -25,23 +25,81 @@
 set -euo pipefail
 
 PROFILE="${KNR_OPS_PROFILE:-${1:-aws}}"
-case "$PROFILE" in
-  local-host|aws) ;;
-  *)
-    echo "ERROR: unsupported profile '$PROFILE' (expected 'local-host' or 'aws')" >&2
-    exit 1
-    ;;
-esac
 
-if [ "$PROFILE" = local-host ] && [ "${AWS_ONLY:-0}" = "1" ]; then
-  echo "ERROR: AWS_ONLY=1 cannot be combined with the local-host profile" >&2
-  echo "       Use the AWS profile for AWS-only orphan cleanup" >&2
-  exit 1
-fi
+preflight_checks() {
+  case "$PROFILE" in
+    local-host|aws) ;;
+    *)
+      echo "ERROR: unsupported profile '$PROFILE' (expected 'local-host' or 'aws')" >&2
+      exit 1
+      ;;
+  esac
+
+  if [ "$PROFILE" = local-host ]; then
+    if [ "${AWS_ONLY:-0}" = "1" ]; then
+      echo "ERROR: AWS_ONLY=1 cannot be combined with the local-host profile" >&2
+      echo "       Use the AWS profile for AWS-only orphan cleanup" >&2
+      exit 1
+    fi
+
+    command -v kind >/dev/null 2>&1 \
+      || { echo "ERROR: kind not found in PATH" >&2; exit 1; }
+
+    # Select the same running container engine used by bootstrap.sh. Registry
+    # cleanup is best-effort so an unavailable engine does not block teardown.
+    if [ -n "${CONTAINER_ENGINE:-}" ]; then
+      case "$CONTAINER_ENGINE" in
+        docker|podman) ;;
+        *)
+          echo "ERROR: Unsupported CONTAINER_ENGINE '${CONTAINER_ENGINE}' (expected 'docker' or 'podman')" >&2
+          exit 1
+          ;;
+      esac
+      if ! command -v "$CONTAINER_ENGINE" >/dev/null 2>&1 \
+        || ! "$CONTAINER_ENGINE" info >/dev/null 2>&1; then
+        echo ">>> WARNING: ${CONTAINER_ENGINE} is unavailable; registry cleanup will be skipped" >&2
+        CONTAINER_ENGINE=""
+      fi
+    elif command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
+      if docker --version 2>/dev/null | grep -qi podman; then
+        CONTAINER_ENGINE=podman
+      else
+        CONTAINER_ENGINE=docker
+      fi
+    elif command -v podman >/dev/null 2>&1 && podman info >/dev/null 2>&1; then
+      CONTAINER_ENGINE=podman
+    else
+      echo ">>> WARNING: No running container engine found; registry cleanup will be skipped" >&2
+      CONTAINER_ENGINE=""
+    fi
+    return
+  fi
+
+  if [ "${AWS_ONLY:-0}" = "1" ]; then
+    command -v aws >/dev/null 2>&1 \
+      || { echo "ERROR: aws CLI not found in PATH (required for AWS_ONLY mode)" >&2; exit 1; }
+    AWS_AVAILABLE=true
+    echo ">>> AWS_ONLY mode – k8s tools not required"
+    return
+  fi
+
+  for cmd in kind helm kubectl xargs; do
+    command -v "$cmd" >/dev/null 2>&1 \
+      || { echo "ERROR: $cmd not found in PATH" >&2; exit 1; }
+  done
+
+  AWS_AVAILABLE=false
+  if command -v aws >/dev/null 2>&1; then
+    AWS_AVAILABLE=true
+    echo ">>> aws CLI available"
+  else
+    echo "!   aws CLI not found – AWS orphan cleanup (step 4) will be skipped" >&2
+  fi
+}
+
+preflight_checks
 
 if [ "$PROFILE" = local-host ]; then
-  command -v kind >/dev/null 2>&1 \
-    || { echo "ERROR: kind not found in PATH" >&2; exit 1; }
   if kind get clusters 2>/dev/null | grep -q '^mgmt$'; then
     echo ">>> Deleting kind management cluster 'mgmt'..."
     kind delete cluster --name mgmt
@@ -49,6 +107,14 @@ if [ "$PROFILE" = local-host ]; then
   else
     echo ">>> kind management cluster 'mgmt' is not present"
   fi
+
+  # Clean up the local container registry used by local-host profile
+  if [ -n "${CONTAINER_ENGINE:-}" ] && $CONTAINER_ENGINE ps -a --filter "name=^knr-registry$" | grep -q "knr-registry"; then
+    echo ">>> Removing local registry container 'knr-registry'..."
+    $CONTAINER_ENGINE rm -f knr-registry
+    echo "✓   registry container 'knr-registry' removed"
+  fi
+
   exit 0
 fi
 
@@ -166,28 +232,6 @@ _get_rds_instance() {
     *)          return 1 ;;
   esac
 }
-
-# ── Prerequisites check ───────────────────────────────────────────────────────
-# Check for required tools (aws is optional – needed only for AWS cleanup step)
-if [ "${AWS_ONLY:-0}" = "1" ]; then
-  # AWS_ONLY mode: only aws CLI is needed
-  command -v aws >/dev/null 2>&1 \
-    || { echo "ERROR: aws CLI not found in PATH (required for AWS_ONLY mode)"; exit 1; }
-  AWS_AVAILABLE=true
-  info "AWS_ONLY mode – k8s tools not required"
-else
-  for cmd in kind helm kubectl; do
-    command -v "$cmd" >/dev/null 2>&1 \
-      || { echo "ERROR: $cmd not found in PATH"; exit 1; }
-  done
-  AWS_AVAILABLE=false
-  if command -v aws >/dev/null 2>&1; then
-    AWS_AVAILABLE=true
-    info "aws CLI available"
-  else
-    warn "aws CLI not found – AWS orphan cleanup (step 4) will be skipped"
-  fi
-fi
 
 # ── AWS orphan cleanup helpers ────────────────────────────────────────────────
 # All helpers gracefully skip if the resource is already gone and never abort


### PR DESCRIPTION
## Summary

- bootstrap an idempotent local OCI registry for the `local-host` profile
- publish registry connection details in the management cluster
- remove the registry container during local-host teardown
- document the local OCI artifact workflow and prerequisites

## Testing

- Not run (not recorded on the branch)