### PR TITLE
feat: publish local-host configuration as OCI artifact

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,13 +70,15 @@ mise run teardown           # full teardown (EKS, AWS resources, kind)
 
 The shared toolchain is defined in `mise.toml`. AWS-specific tools are layered
 through `mise.aws.toml`; use the `aws` profile when those tools are needed.
-The `local-host` profile is still work in progress. It creates the management kind
-cluster, installs the Flux Operator and FluxInstance, but does not configure
-GitOps sync or provision AWS resources:
+The `local-host` profile is still work in progress. It creates the management
+kind cluster, a local OCI registry, and the Flux Operator and FluxInstance. It
+also publishes the `mgmt/local-host/` folder as the `knr-ops:latest` OCI artifact,
+but does not configure GitOps sync or provision AWS resources:
 
 ```sh
 mise -E local-host install
 mise -E local-host run bootstrap
+mise -E local-host run oci-push  # republish mgmt/local-host after local changes
 mise -E local-host run teardown
 ```
 
@@ -84,8 +86,9 @@ The Flux charts are pulled anonymously. The AWS profile requires a
 GitHub PAT so Flux can clone this repository; the local-host profile does not require
 GitHub or AWS credentials.
 
-The local-host teardown deletes only the `mgmt` kind cluster. The default
-teardown path suspends Flux and removes the AWS-managed infrastructure.
+The local-host teardown deletes the `mgmt` kind cluster and local registry
+container. The default teardown path suspends Flux and removes the AWS-managed
+infrastructure.
 
 ## Documentation
 
@@ -115,6 +118,7 @@ teardown path suspends Flux and removes the AWS-managed infrastructure.
 │   │                              (HelmChartProxy + ClusterResourceSets)
 │   └── clusters/                  EKS cluster defs (eu-north-1, eu-west-1;
 │                                  ARM + GPU MachinePools)
+├── mgmt/local-host/               Source published in the local-host OCI artifact
 └── workload/                          Synced by each WORKLOAD cluster's Flux
     ├── base/                      ACK S3/RDS/IAM controllers, Bucket CRs,
     │                              DBInstance CRs, reader Role CRs

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -21,6 +21,11 @@ preflight_checks() {
     command -v "$cmd" >/dev/null 2>&1 || { echo "ERROR: $cmd not found in PATH"; exit 1; }
   done
 
+  if [ "$PROFILE" = local-host ]; then
+    command -v mise >/dev/null 2>&1 \
+      || { echo "ERROR: mise not found in PATH (required to publish the initial OCI artifact)"; exit 1; }
+  fi
+
   if [ "$PROFILE" = aws ]; then
     : "${GITHUB_TOKEN:?GITHUB_TOKEN must be set (a PAT with read access to the repo)}"
     : "${GIT_REPO_URL:?GIT_REPO_URL must be set}"
@@ -160,20 +165,32 @@ if [ "$PROFILE" = local-host ]; then
   # Check if registry already exists
   if ! $CONTAINER_ENGINE ps -a --filter "name=^${REGISTRY_NAME}$" | grep -q "${REGISTRY_NAME}"; then
     # Create registry container
+    echo "    Creating registry container '${REGISTRY_NAME}'..."
     $CONTAINER_ENGINE run -d \
       --name "$REGISTRY_NAME" \
       --network kind \
       -p "127.0.0.1:${REGISTRY_PORT}:5000" \
-      registry:2
-    echo "    Registry started: localhost:${REGISTRY_PORT}"
+      registry:2 >/dev/null
+    echo "    Registry created and running: localhost:${REGISTRY_PORT}"
   else
     # Check if registry is running, restart if needed
     if ! $CONTAINER_ENGINE ps --filter "name=^${REGISTRY_NAME}$" | grep -q "${REGISTRY_NAME}"; then
       echo "    Restarting stopped registry..."
-      $CONTAINER_ENGINE start "$REGISTRY_NAME"
+      $CONTAINER_ENGINE start "$REGISTRY_NAME" >/dev/null
+      echo "    Registry restarted: localhost:${REGISTRY_PORT}"
     else
       echo "    Registry already running: localhost:${REGISTRY_PORT}"
     fi
+  fi
+
+  echo ">>> Waiting for local registry API at localhost:${REGISTRY_PORT}..."
+  if ! curl --fail --silent --show-error \
+    --retry 30 \
+    --retry-connrefused \
+    --retry-delay 1 \
+    "http://localhost:${REGISTRY_PORT}/v2/" >/dev/null; then
+    echo "ERROR: local registry did not become ready at localhost:${REGISTRY_PORT}" >&2
+    exit 1
   fi
 
   # Configure kind nodes to access the registry via the hostname
@@ -181,6 +198,10 @@ if [ "$PROFILE" = local-host ]; then
   kubectl create configmap local-registry-config \
     --from-literal=registry-url="${REGISTRY_NAME}:5000" \
     --namespace kube-system
+
+  echo ">>> Publishing initial OCI artifact from the local Git checkout..."
+  mise -E local-host run oci-push
+  echo ">>> Initial OCI artifact is available at oci://localhost:${REGISTRY_PORT}/${OCI_REPOSITORY:-knr-ops}:${OCI_TAG:-latest}"
 fi
 
 # ── Step 2: Install the Flux Operator ────────────────────────────────────────
@@ -265,5 +286,6 @@ if [ "$PROFILE" = aws ]; then
   echo ">>> Watch progress with: flux get kustomizations --watch"
 else
   echo ">>> Local-host profile complete: management kind cluster, Flux Operator, and FluxInstance are ready"
+  echo ">>> Local registry: localhost:${REGISTRY_PORT} (cluster endpoint: ${REGISTRY_NAME}:5000)"
   echo ">>> No GitOps sync or AWS resources were provisioned"
 fi

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -67,7 +67,8 @@ AWS credentials, and `AWS_REGION` are only needed with the AWS profile.
 ## Bootstrap
 
 ```sh
-mise run bootstrap   # or: ./bootstrap.sh
+mise run bootstrap                 # AWS profile
+mise -E local-host run bootstrap   # local-host profile
 ```
 
 > Before the first bootstrap, generate an age key for SOPS (see
@@ -89,7 +90,8 @@ The local-host profile performs the cluster, Flux Operator, and FluxInstance ste
 the `mgmt` management cluster, but does not create GitHub or SOPS secrets,
 configure Git sync, or start GitOps reconciliation. Instead, it bootstraps a
 local Docker Registry container (`registry:2`) running on the host machine
-(accessible at `localhost:5001` by default) for managing OCI artifacts.
+(accessible at `localhost:5001` by default) and publishes the `mgmt/local-host/`
+folder as the initial `knr-ops:latest` OCI artifact.
 
 **OCI Registry (local-host profile only):**
 - Provides a local container registry for development workflows
@@ -100,17 +102,23 @@ local Docker Registry container (`registry:2`) running on the host machine
 
 **Workflow:**
 ```bash
-# 1. Build OCI artifact from local checkout
-docker build -t localhost:5001/myapp:v1.0 .
+# Republish the mgmt/local-host/ folder after making local changes
+mise -E local-host run oci-push
 
-# 2. Push to local registry
-docker push localhost:5001/myapp:v1.0
+# Optional overrides
+OCI_REPOSITORY=my-config OCI_TAG=v1 \
+  mise -E local-host run oci-push
 
-# 3. Configure Flux to pull from registry via mgmt/local-host kustomization
+# Configure Flux to pull from the artifact's mgmt/local-host kustomization.
 # bootstrap.sh configures kind's containerd to mirror localhost:5001 to the
 # registry's in-cluster endpoint, knr-registry:5000.
 # Flux syncs and deploys from the local registry into the cluster
 ```
+
+The artifact contains only the `mgmt/local-host/` folder, preserving that
+directory path when the artifact is pulled. Keeping the source scope this
+narrow also prevents local credentials and age private keys elsewhere in the
+repository from being packaged.
 
 The AWS profile adds the GitHub/SOPS secrets and configures the FluxInstance to sync `mgmt/aws/`.
 

--- a/mgmt/local-host/kustomization.yaml
+++ b/mgmt/local-host/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-# Empty placeholder for local-host profile GitOps sync.
-# This directory will be used by the Flux sync when running on docker/podman
-# without provisioning any resources.
+# Root of the local-host OCI artifact. Add local management resources here so
+# they are published by `mise -E local-host run oci-push`.
 resources: []

--- a/mise.local-host.toml
+++ b/mise.local-host.toml
@@ -1,2 +1,50 @@
 [env]
 KNR_OPS_PROFILE = "local-host"
+
+[tasks.oci-push]
+description = "Package the local Git checkout as an OCI artifact and push it to the local registry"
+run = '''
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) \
+  || { echo "ERROR: not inside a Git repository" >&2; exit 1; }
+cd "$REPO_ROOT"
+
+REGISTRY_PORT="${REGISTRY_PORT:-5001}"
+OCI_REPOSITORY="${OCI_REPOSITORY:-knr-ops}"
+OCI_TAG="${OCI_TAG:-latest}"
+OCI_URL="oci://localhost:${REGISTRY_PORT}/${OCI_REPOSITORY}:${OCI_TAG}"
+OCI_SOURCE_PATH="mgmt/local-host"
+
+if [ ! -d "$OCI_SOURCE_PATH" ]; then
+  echo "ERROR: OCI source directory does not exist: $OCI_SOURCE_PATH" >&2
+  exit 1
+fi
+
+if ! curl --fail --silent --show-error "http://localhost:${REGISTRY_PORT}/v2/" >/dev/null; then
+  echo "ERROR: local registry is unavailable at localhost:${REGISTRY_PORT}" >&2
+  echo "       Start it with: mise -E local-host run bootstrap" >&2
+  exit 1
+fi
+
+GIT_SHA=$(git rev-parse HEAD)
+GIT_REF=$(git branch --show-current)
+GIT_REF="${GIT_REF:-detached}"
+SOURCE_URL=$(git config --get remote.origin.url || true)
+SOURCE_URL="${SOURCE_URL:-file://${REPO_ROOT}}"
+
+ARTIFACT_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/knr-ops-oci.XXXXXX")
+cleanup_artifact_root() {
+  rm -rf "$ARTIFACT_ROOT"
+}
+trap cleanup_artifact_root EXIT
+mkdir -p "$ARTIFACT_ROOT/mgmt"
+cp -R "$OCI_SOURCE_PATH" "$ARTIFACT_ROOT/mgmt/local-host"
+
+echo "==> Packaging ${OCI_SOURCE_PATH} as mgmt/local-host"
+echo "==> Pushing ${OCI_URL}"
+flux push artifact "$OCI_URL" \
+  --path="$ARTIFACT_ROOT" \
+  --source="$SOURCE_URL" \
+  --revision="${GIT_REF}@sha1:${GIT_SHA}" \
+  --insecure-registry \
+  --reproducible
+'''


### PR DESCRIPTION
## Summary

- add a local-host-only `oci-push` mise task that publishes `mgmt/docker` to the local registry
- preserve the `mgmt/docker/` directory structure in the pulled artifact
- publish an initial `knr-ops:latest` artifact during local-host bootstrap
- wait for the registry V2 API with curl retries and report registry and artifact endpoints
- document bootstrap, republish, and teardown behavior

## Validation

- `git diff --check`
- `bash -n bootstrap.sh teardown.sh`
- `mise -E local-host tasks info oci-push`
- `mise run validate`
- verified the generated archive contains `mgmt/docker/kustomization.yaml`

## Not run

- end-to-end registry push (the local registry was not running)