### PR TITLE
feat: sync local-host from OCI registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ through `mise.aws.toml`; use the `aws` profile when those tools are needed.
 The `local-host` profile is still work in progress. It creates the management
 kind cluster, a local OCI registry, and the Flux Operator and FluxInstance. It
 also publishes the `mgmt/local-host/` folder as the `knr-ops:latest` OCI artifact,
-but does not configure GitOps sync or provision AWS resources:
+then configures Flux to reconcile from that artifact. It does not provision AWS
+resources:
 
 ```sh
 mise -E local-host install

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -260,6 +260,14 @@ if [ "$PROFILE" = aws ]; then
     --set instance.sync.path=mgmt/aws
     --set instance.sync.pullSecret=flux-github-pat
   )
+else
+  FLUX_INSTANCE_ARGS+=(
+    --set instance.sync.kind=OCIRepository
+    --set instance.sync.url="oci://${REGISTRY_NAME}:5000/${OCI_REPOSITORY:-knr-ops}"
+    --set instance.sync.ref="${OCI_TAG:-latest}"
+    --set instance.sync.path=mgmt/local-host
+    --set-json 'instance.kustomize.patches=[{"patch":"- op: add\n  path: /spec/insecure\n  value: true","target":{"kind":"OCIRepository"}}]'
+  )
 fi
 helm upgrade --install flux \
   oci://ghcr.io/controlplaneio-fluxcd/charts/flux-instance \
@@ -285,7 +293,9 @@ if [ "$PROFILE" = aws ]; then
   echo ">>> Bootstrap complete! Flux is now reconciling from ${GIT_REPO_URL}"
   echo ">>> Watch progress with: flux get kustomizations --watch"
 else
-  echo ">>> Local-host profile complete: management kind cluster, Flux Operator, and FluxInstance are ready"
+  echo ">>> Local-host profile complete: Flux is reconciling from the local OCI artifact"
   echo ">>> Local registry: localhost:${REGISTRY_PORT} (cluster endpoint: ${REGISTRY_NAME}:5000)"
-  echo ">>> No GitOps sync or AWS resources were provisioned"
+  echo ">>> OCI source: oci://${REGISTRY_NAME}:5000/${OCI_REPOSITORY:-knr-ops}:${OCI_TAG:-latest} (path: mgmt/local-host)"
+  echo ">>> Watch progress with: flux get sources oci --watch"
+  echo ">>> No AWS resources were provisioned"
 fi

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -86,17 +86,17 @@ Everything downstream — providers, EKS clusters, workload Flux instances, the
 ACK operator, IAM role, pod identity bindings, and S3 buckets — reconciles
 from Git with no further manual steps.
 
-The local-host profile performs the cluster, Flux Operator, and FluxInstance steps in
-the `mgmt` management cluster, but does not create GitHub or SOPS secrets,
-configure Git sync, or start GitOps reconciliation. Instead, it bootstraps a
-local Docker Registry container (`registry:2`) running on the host machine
-(accessible at `localhost:5001` by default) and publishes the `mgmt/local-host/`
-folder as the initial `knr-ops:latest` OCI artifact.
+The local-host profile performs the cluster, Flux Operator, and FluxInstance
+steps in the `mgmt` management cluster, but does not create GitHub or SOPS
+secrets. Instead, it bootstraps a local Docker Registry container (`registry:2`)
+running on the host machine (accessible at `localhost:5001` by default),
+publishes the `mgmt/local-host/` folder as the initial `knr-ops:latest` OCI
+artifact, and configures Flux to reconcile that path from the artifact.
 
 **OCI Registry (local-host profile only):**
 - Provides a local container registry for development workflows
 - Enables developers to build and push OCI artifacts from git checkouts
-- Flux can sync and deploy OCI artifacts from the registry without external dependencies
+- Flux syncs and deploys the OCI artifact without external dependencies
 - Configurable via `REGISTRY_PORT` env var (defaults to 5001)
 - Idempotent: restarts if stopped, no action needed if already running
 
@@ -109,10 +109,9 @@ mise -E local-host run oci-push
 OCI_REPOSITORY=my-config OCI_TAG=v1 \
   mise -E local-host run oci-push
 
-# Configure Flux to pull from the artifact's mgmt/local-host kustomization.
+# FluxInstance pulls and reconciles the artifact's mgmt/local-host kustomization.
 # bootstrap.sh configures kind's containerd to mirror localhost:5001 to the
 # registry's in-cluster endpoint, knr-registry:5000.
-# Flux syncs and deploys from the local registry into the cluster
 ```
 
 The artifact contains only the `mgmt/local-host/` folder, preserving that


### PR DESCRIPTION
## Summary

- configure the local-host FluxInstance to sync from an OCIRepository
- consume `knr-registry:5000/knr-ops:latest` at `mgmt/local-host`
- mark the generated OCIRepository as insecure for the local HTTP registry
- update bootstrap completion output and documentation for active OCI reconciliation

## Validation

- `git diff --check`
- `bash -n bootstrap.sh teardown.sh`
- `mise run validate`
- rendered the official FluxInstance Helm chart and verified the generated sync URL, tag, path, and `spec.insecure: true` patch

## Not run

- end-to-end bootstrap against a running local registry