### PR TITLE
feat: provision local workload cluster with CAPD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@
 # SOPS age PRIVATE key — the public key in .sops.yaml is safe to commit
 *.agekey
 age.agekey
+
+# Generated local Cluster API workload kubeconfig
+local-workload.kubeconfig

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ Each component pairs a plain kustomize root with a Flux `Kustomization`:
 mise install            # install pinned tools (kubectl, kind, flux, sops, age, ...)
 mise run validate       # build every kustomize overlay; mirrors CI
 mise run bootstrap      # one-time kind cluster + Flux handoff
-mise run kubeconfigs    # export workload-cluster kubeconfigs
+mise -E aws run kubeconfigs  # export AWS workload-cluster kubeconfigs
 mise run teardown       # full teardown (EKS, AWS resources, kind)
 ```
 

--- a/README.md
+++ b/README.md
@@ -72,16 +72,18 @@ mise run teardown           # full teardown (EKS, AWS resources, kind)
 
 The shared toolchain is defined in `mise.toml`. AWS-specific tools are layered
 through `mise.aws.toml`; use the `aws` profile when those tools are needed.
-The `local-host` profile is still work in progress. It creates the management
-kind cluster, a local OCI registry, and the Flux Operator and FluxInstance. It
-also publishes the `mgmt/local-host/` folder as the `knr-ops:latest` OCI artifact,
-then configures Flux to reconcile from that artifact. It does not provision AWS
+The `local-host` profile creates the management kind cluster, a local OCI
+registry, and the Flux Operator and FluxInstance. It publishes the
+`mgmt/local-host/` folder as the `knr-ops:latest` OCI artifact, then Flux installs
+CAPI with its Docker infrastructure provider (CAPD) and provisions a local
+one-control-plane/one-worker workload cluster. It does not provision AWS
 resources:
 
 ```sh
 mise -E local-host install
 mise -E local-host run bootstrap
 mise -E local-host run oci-push  # republish mgmt/local-host after local changes
+mise -E local-host run kubeconfigs
 mise -E local-host run teardown
 ```
 
@@ -89,9 +91,9 @@ The Flux charts are pulled anonymously. The AWS profile requires a
 GitHub PAT so Flux can clone this repository; the local-host profile does not require
 GitHub or AWS credentials.
 
-The local-host teardown deletes the `mgmt` kind cluster and local registry
-container. The default teardown path suspends Flux and removes the AWS-managed
-infrastructure.
+The local-host teardown deletes the CAPD workload cluster before deleting the
+`mgmt` kind cluster and local registry container. The default teardown path
+suspends Flux and removes the AWS-managed infrastructure.
 
 ## Documentation
 
@@ -121,7 +123,7 @@ infrastructure.
 │   │                              (HelmChartProxy + ClusterResourceSets)
 │   └── clusters/                  EKS cluster defs (eu-north-1, eu-west-1;
 │                                  ARM + GPU MachinePools)
-├── mgmt/local-host/               Source published in the local-host OCI artifact
+├── mgmt/local-host/               OCI-synced CAPI/CAPD local workload cluster
 └── workload/                          Synced by each WORKLOAD cluster's Flux
     ├── base/                      ACK S3/RDS/IAM controllers, Bucket CRs,
     │                              DBInstance CRs, reader Role CRs

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -7,6 +7,8 @@ PROFILE="${KNR_OPS_PROFILE:-${1:-aws}}"
 GIT_BRANCH="main"
 REGISTRY_NAME="knr-registry"
 REGISTRY_PORT="${REGISTRY_PORT:-5001}"
+REGISTRY_READY_RETRIES="${REGISTRY_READY_RETRIES:-120}"
+LOCAL_RECONCILE_TIMEOUT="${LOCAL_RECONCILE_TIMEOUT:-15m}"
 
 preflight_checks() {
   case "$PROFILE" in
@@ -185,7 +187,7 @@ if [ "$PROFILE" = local-host ]; then
 
   echo ">>> Waiting for local registry API at localhost:${REGISTRY_PORT}..."
   if ! curl --fail --silent --show-error \
-    --retry 30 \
+    --retry "$REGISTRY_READY_RETRIES" \
     --retry-connrefused \
     --retry-delay 1 \
     "http://localhost:${REGISTRY_PORT}/v2/" >/dev/null; then
@@ -282,6 +284,46 @@ echo ">>> Waiting for Flux controllers to be ready..."
 kubectl wait --namespace flux-system --for=condition=ready pod \
   --selector='app.kubernetes.io/part-of=flux' \
   --timeout=90s || true
+
+# ── Step 5: Watch local-host reconciliation ──────────────────────────────────
+# Stream the GitOps handoff in the bootstrap terminal for the local profile.
+# The final Kustomization is created by the OCI root, so wait for it to appear
+# before asking kubectl to wait for its Ready condition.
+if [ "$PROFILE" = local-host ]; then
+  echo ""
+  echo ">>> Step 5: Flux reconciliation progress"
+  echo ">>> Watching until the local workload cluster is ready..."
+  flux get kustomizations --watch &
+  flux_watch_pid=$!
+  cleanup_flux_watch() {
+    kill "$flux_watch_pid" >/dev/null 2>&1 || true
+    wait "$flux_watch_pid" >/dev/null 2>&1 || true
+  }
+  trap 'cleanup_flux_watch; cleanup_registry_config' EXIT
+
+  reconcile_discovery_attempts=0
+  until kubectl get kustomization docker-workload-cluster \
+      --namespace flux-system >/dev/null 2>&1; do
+    reconcile_discovery_attempts=$((reconcile_discovery_attempts + 1))
+    if [ "$reconcile_discovery_attempts" -ge 60 ]; then
+      echo "ERROR: docker-workload-cluster Kustomization was not created within 2 minutes" >&2
+      flux get kustomizations
+      exit 1
+    fi
+    sleep 2
+  done
+
+  if ! kubectl wait kustomization/docker-workload-cluster \
+      --namespace flux-system \
+      --for=condition=Ready \
+      --timeout="$LOCAL_RECONCILE_TIMEOUT"; then
+    echo "ERROR: local-host reconciliation did not complete within ${LOCAL_RECONCILE_TIMEOUT}" >&2
+    flux get kustomizations
+    exit 1
+  fi
+  cleanup_flux_watch
+  trap cleanup_registry_config EXIT
+fi
 
 # ── Done ──────────────────────────────────────────────────────────────────────
 # Everything else is driven by GitOps. The FluxInstance above syncs the

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -159,7 +159,7 @@ kubectl get roles.iam.services.k8s.aws -n ack-system
 kubectl get podidentityassociations.eks.services.k8s.aws -n ack-system
 
 # Workload clusters — export kubeconfigs first:
-#   mise run kubeconfigs && export KUBECONFIG=~/.kube/knr-ops-workloads.yaml
+#   mise -E aws run kubeconfigs && export KUBECONFIG=~/.kube/knr-ops-workloads.yaml
 #   kubectl config use-context eu-north-1-workload   (or eu-west-1-workload)
 kubectl get kustomizations -n flux-system            # aws-operators, s3-buckets, rds-instances, iam-roles
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -91,7 +91,10 @@ steps in the `mgmt` management cluster, but does not create GitHub or SOPS
 secrets. Instead, it bootstraps a local Docker Registry container (`registry:2`)
 running on the host machine (accessible at `localhost:5001` by default),
 publishes the `mgmt/local-host/` folder as the initial `knr-ops:latest` OCI
-artifact, and configures Flux to reconcile that path from the artifact.
+artifact, and configures Flux to reconcile that path from the artifact. Flux
+then installs the CAPI core, kubeadm, and Docker infrastructure providers and
+creates `local-workload`, a one-control-plane/one-worker Kubernetes cluster in
+containers. CAPD is intended for local development and testing, not production.
 
 **OCI Registry (local-host profile only):**
 - Provides a local container registry for development workflows
@@ -127,6 +130,22 @@ Watch reconciliation:
 flux get kustomizations --watch
 ```
 
+For the local-host profile, export and verify the CAPD workload kubeconfig after
+`docker-workload-cluster` reports Ready:
+
+```sh
+mise -E local-host run kubeconfigs
+KUBECONFIG=local-workload.kubeconfig kubectl get nodes
+```
+
+The workload uses Kubernetes v1.35.0 and bootstraps Calico v3.32.1 as its CNI.
+The management cluster needs access to the container-engine socket, which
+`bootstrap.sh` mounts automatically.
+
+Local-host bootstrap streams the Flux Kustomization status in the same terminal
+and returns after `docker-workload-cluster` becomes Ready. The readiness wait
+defaults to 15 minutes and can be changed with `LOCAL_RECONCILE_TIMEOUT`.
+
 EKS clusters typically take 15–25 minutes to come up; node groups and the
 downstream app chain follow a few minutes after.
 
@@ -156,9 +175,10 @@ mise run teardown    # or: ./teardown.sh
 ```
 
 Tears down in reverse order: suspends Flux, deletes CAPI workload clusters (so
-CAPA deprovisions all AWS resources), removes providers, uninstalls Flux, and
-deletes the kind cluster. The `clusterawsadm` IAM stack is intentionally left
-in place.
+CAPA or CAPD deprovisions their infrastructure), removes providers, uninstalls
+Flux, and deletes the kind cluster. The local-host profile waits for CAPD to
+remove the workload containers before deleting `mgmt`. The `clusterawsadm` IAM
+stack is intentionally left in place.
 
 > Note: S3 buckets, RDS instances, and IAM reader roles created by ACK on the
 > workload clusters are deleted when their `Bucket`/`DBInstance`/`Role` CRs

--- a/mgmt/local-host/capi-providers/capd-system/kustomization.yaml
+++ b/mgmt/local-host/capi-providers/capd-system/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - provider.yaml

--- a/mgmt/local-host/capi-providers/capd-system/namespace.yaml
+++ b/mgmt/local-host/capi-providers/capd-system/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: capd-system

--- a/mgmt/local-host/capi-providers/capd-system/provider.yaml
+++ b/mgmt/local-host/capi-providers/capd-system/provider.yaml
@@ -1,0 +1,13 @@
+# CAPD is a development/test provider. Its v1.14 APIs use the Dev* names.
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
+kind: InfrastructureProvider
+metadata:
+  name: docker
+  namespace: capd-system
+spec:
+  version: "v1.14.0"
+  deployment:
+    containers:
+      - name: manager
+        args:
+          "--feature-gates": "ClusterTopology=true"

--- a/mgmt/local-host/capi-providers/capi-system/kustomization.yaml
+++ b/mgmt/local-host/capi-providers/capi-system/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - providers.yaml

--- a/mgmt/local-host/capi-providers/capi-system/namespace.yaml
+++ b/mgmt/local-host/capi-providers/capi-system/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: capi-system

--- a/mgmt/local-host/capi-providers/capi-system/providers.yaml
+++ b/mgmt/local-host/capi-providers/capi-system/providers.yaml
@@ -1,0 +1,38 @@
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
+kind: CoreProvider
+metadata:
+  name: cluster-api
+  namespace: capi-system
+spec:
+  version: "v1.14.0"
+  deployment:
+    containers:
+      - name: manager
+        args:
+          "--feature-gates": "ClusterTopology=true"
+---
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
+kind: BootstrapProvider
+metadata:
+  name: kubeadm
+  namespace: capi-system
+spec:
+  version: "v1.14.0"
+  deployment:
+    containers:
+      - name: manager
+        args:
+          "--feature-gates": "ClusterTopology=true"
+---
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
+kind: ControlPlaneProvider
+metadata:
+  name: kubeadm
+  namespace: capi-system
+spec:
+  version: "v1.14.0"
+  deployment:
+    containers:
+      - name: manager
+        args:
+          "--feature-gates": "ClusterTopology=true"

--- a/mgmt/local-host/capi-providers/flux-ks.yaml
+++ b/mgmt/local-host/capi-providers/flux-ks.yaml
@@ -1,0 +1,42 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: capi-system
+  namespace: flux-system
+spec:
+  interval: 5m
+  retryInterval: 2m
+  timeout: 5m
+  prune: true
+  wait: true
+  sourceRef:
+    kind: OCIRepository
+    name: flux-system
+  path: ./mgmt/local-host/capi-providers/capi-system
+  dependsOn:
+    - name: capi-operator
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: capd-system
+  namespace: flux-system
+spec:
+  interval: 5m
+  retryInterval: 2m
+  timeout: 5m
+  prune: true
+  wait: false
+  sourceRef:
+    kind: OCIRepository
+    name: flux-system
+  path: ./mgmt/local-host/capi-providers/capd-system
+  dependsOn:
+    - name: capi-system
+  healthChecks:
+    - apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      name: devclusters.infrastructure.cluster.x-k8s.io
+    - apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      name: devmachines.infrastructure.cluster.x-k8s.io

--- a/mgmt/local-host/clusters/docker/cluster-class.yaml
+++ b/mgmt/local-host/clusters/docker/cluster-class.yaml
@@ -1,0 +1,120 @@
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: ClusterClass
+metadata:
+  name: docker-workload
+  namespace: default
+spec:
+  infrastructure:
+    templateRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: DevClusterTemplate
+      name: docker-workload
+  controlPlane:
+    templateRef:
+      apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+      kind: KubeadmControlPlaneTemplate
+      name: docker-workload-control-plane
+    machineInfrastructure:
+      templateRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: DevMachineTemplate
+        name: docker-workload-control-plane
+  workers:
+    machineDeployments:
+      - class: default-worker
+        bootstrap:
+          templateRef:
+            apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
+            kind: KubeadmConfigTemplate
+            name: docker-workload-worker
+        infrastructure:
+          templateRef:
+            apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+            kind: DevMachineTemplate
+            name: docker-workload-worker
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: DevClusterTemplate
+metadata:
+  name: docker-workload
+  namespace: default
+spec:
+  template:
+    spec:
+      backend:
+        docker: {}
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+kind: KubeadmControlPlaneTemplate
+metadata:
+  name: docker-workload-control-plane
+  namespace: default
+spec:
+  template:
+    spec:
+      kubeadmConfigSpec:
+        # Bootstrap networking from a version-pinned upstream manifest. This
+        # runs once, after kubeadm creates the workload API server.
+        postKubeadmCommands:
+          - kubectl --kubeconfig=/etc/kubernetes/admin.conf apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.32.1/manifests/calico.yaml
+        clusterConfiguration:
+          apiServer:
+            certSANs:
+              - localhost
+              - 127.0.0.1
+              - 0.0.0.0
+              - host.docker.internal
+        initConfiguration:
+          nodeRegistration:
+            kubeletExtraArgs:
+              - name: eviction-hard
+                value: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+        joinConfiguration:
+          nodeRegistration:
+            kubeletExtraArgs:
+              - name: eviction-hard
+                value: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: DevMachineTemplate
+metadata:
+  name: docker-workload-control-plane
+  namespace: default
+spec:
+  template:
+    spec:
+      backend:
+        docker:
+          customImage: kindest/node:v1.35.0
+          extraMounts:
+            - hostPath: /var/run/docker.sock
+              containerPath: /var/run/docker.sock
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: DevMachineTemplate
+metadata:
+  name: docker-workload-worker
+  namespace: default
+spec:
+  template:
+    spec:
+      backend:
+        docker:
+          customImage: kindest/node:v1.35.0
+          extraMounts:
+            - hostPath: /var/run/docker.sock
+              containerPath: /var/run/docker.sock
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
+kind: KubeadmConfigTemplate
+metadata:
+  name: docker-workload-worker
+  namespace: default
+spec:
+  template:
+    spec:
+      joinConfiguration:
+        nodeRegistration:
+          kubeletExtraArgs:
+            - name: eviction-hard
+              value: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%

--- a/mgmt/local-host/clusters/docker/cluster.yaml
+++ b/mgmt/local-host/clusters/docker/cluster.yaml
@@ -1,0 +1,27 @@
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: Cluster
+metadata:
+  name: local-workload
+  namespace: default
+  labels:
+    profile: local-host
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+        - 192.168.0.0/16
+    serviceDomain: cluster.local
+    services:
+      cidrBlocks:
+        - 10.128.0.0/12
+  topology:
+    classRef:
+      name: docker-workload
+    version: v1.35.0
+    controlPlane:
+      replicas: 1
+    workers:
+      machineDeployments:
+        - class: default-worker
+          name: md-0
+          replicas: 1

--- a/mgmt/local-host/clusters/docker/kustomization.yaml
+++ b/mgmt/local-host/clusters/docker/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cluster-class.yaml
+  - cluster.yaml

--- a/mgmt/local-host/clusters/flux-ks.yaml
+++ b/mgmt/local-host/clusters/flux-ks.yaml
@@ -1,0 +1,22 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: docker-workload-cluster
+  namespace: flux-system
+spec:
+  interval: 5m
+  retryInterval: 2m
+  timeout: 5m
+  prune: true
+  wait: false
+  sourceRef:
+    kind: OCIRepository
+    name: flux-system
+  path: ./mgmt/local-host/clusters/docker
+  dependsOn:
+    - name: capd-system
+  healthChecks:
+    - apiVersion: cluster.x-k8s.io/v1beta2
+      kind: Cluster
+      name: local-workload
+      namespace: default

--- a/mgmt/local-host/infrastructure/capi-operator/helmrelease.yaml
+++ b/mgmt/local-host/infrastructure/capi-operator/helmrelease.yaml
@@ -1,0 +1,27 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: capi-operator
+  namespace: flux-system
+spec:
+  interval: 1h
+  releaseName: capi-operator
+  targetNamespace: capi-operator-system
+  install:
+    createNamespace: true
+    crds: CreateReplace
+  upgrade:
+    crds: CreateReplace
+  dependsOn:
+    - name: cert-manager
+  chart:
+    spec:
+      chart: cluster-api-operator
+      version: "0.28.0"
+      sourceRef:
+        kind: HelmRepository
+        name: capi-operator
+        namespace: flux-system
+  values:
+    cert-manager:
+      enabled: false

--- a/mgmt/local-host/infrastructure/capi-operator/helmrepo.yaml
+++ b/mgmt/local-host/infrastructure/capi-operator/helmrepo.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: capi-operator
+  namespace: flux-system
+spec:
+  interval: 12h
+  url: https://kubernetes-sigs.github.io/cluster-api-operator

--- a/mgmt/local-host/infrastructure/capi-operator/kustomization.yaml
+++ b/mgmt/local-host/infrastructure/capi-operator/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrepo.yaml
+  - helmrelease.yaml

--- a/mgmt/local-host/infrastructure/cert-manager/helmrelease.yaml
+++ b/mgmt/local-host/infrastructure/cert-manager/helmrelease.yaml
@@ -1,0 +1,25 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: cert-manager
+  namespace: flux-system
+spec:
+  interval: 1h
+  releaseName: cert-manager
+  targetNamespace: cert-manager
+  install:
+    createNamespace: true
+    crds: CreateReplace
+  upgrade:
+    crds: CreateReplace
+  chart:
+    spec:
+      chart: cert-manager
+      version: "1.21.1"
+      sourceRef:
+        kind: HelmRepository
+        name: cert-manager
+        namespace: flux-system
+  values:
+    crds:
+      enabled: true

--- a/mgmt/local-host/infrastructure/cert-manager/helmrepo.yaml
+++ b/mgmt/local-host/infrastructure/cert-manager/helmrepo.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: cert-manager
+  namespace: flux-system
+spec:
+  interval: 12h
+  url: https://charts.jetstack.io

--- a/mgmt/local-host/infrastructure/cert-manager/kustomization.yaml
+++ b/mgmt/local-host/infrastructure/cert-manager/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrepo.yaml
+  - helmrelease.yaml

--- a/mgmt/local-host/infrastructure/flux-ks.yaml
+++ b/mgmt/local-host/infrastructure/flux-ks.yaml
@@ -1,0 +1,33 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cert-manager
+  namespace: flux-system
+spec:
+  interval: 5m
+  retryInterval: 2m
+  timeout: 5m
+  prune: true
+  wait: true
+  sourceRef:
+    kind: OCIRepository
+    name: flux-system
+  path: ./mgmt/local-host/infrastructure/cert-manager
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: capi-operator
+  namespace: flux-system
+spec:
+  interval: 5m
+  retryInterval: 2m
+  timeout: 5m
+  prune: true
+  wait: true
+  sourceRef:
+    kind: OCIRepository
+    name: flux-system
+  path: ./mgmt/local-host/infrastructure/capi-operator
+  dependsOn:
+    - name: cert-manager

--- a/mgmt/local-host/kustomization.yaml
+++ b/mgmt/local-host/kustomization.yaml
@@ -1,5 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-# Root of the local-host OCI artifact. Add local management resources here so
-# they are published by `mise -E local-host run oci-push`.
-resources: []
+# Root of the local-host OCI artifact. Each entry creates Flux Kustomizations
+# which reconcile the corresponding component from this OCI source.
+resources:
+  - infrastructure/flux-ks.yaml
+  - capi-providers/flux-ks.yaml
+  - clusters/flux-ks.yaml

--- a/mise.aws.toml
+++ b/mise.aws.toml
@@ -8,3 +8,31 @@ clusterawsadm = { version = "2.13.0", binary = "clusterawsadm" }
 [tasks.aws-bootstrap]
 description = "Provision the clusterawsadm IAM CloudFormation stack for CAPA"
 run = "clusterawsadm bootstrap iam create-cloudformation-stack --region ${AWS_REGION:-eu-north-1}"
+
+[tasks.kubeconfigs]
+description = "Export workload-cluster kubeconfigs to ~/.kube/knr-ops-workloads.yaml (use: export KUBECONFIG=~/.kube/knr-ops-workloads.yaml)"
+run = '''
+KUBECONFIG_FILE="${KUBECONFIG_FILE:-$HOME/.kube/knr-ops-workloads.yaml}"
+fail=0
+# Regions are discovered from the cluster definitions in Git.
+for region in $(find mgmt/aws/clusters -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | sort); do
+  cluster="default_${region}-workload-control-plane"
+  alias="${region}-workload"
+  echo "==> ${region}: ${cluster} -> context '${alias}'"
+  if ! aws eks update-kubeconfig \
+      --name "$cluster" \
+      --region "$region" \
+      --kubeconfig "$KUBECONFIG_FILE" \
+      --alias "$alias"; then
+    echo "    FAILED: ${cluster} (${region}) — cluster not provisioned yet?" >&2
+    fail=1
+  fi
+done
+chmod 600 "$KUBECONFIG_FILE" 2>/dev/null || true
+echo
+KUBECONFIG="$KUBECONFIG_FILE" kubectl config get-contexts
+echo
+echo "Use with:  export KUBECONFIG=$KUBECONFIG_FILE"
+echo "Or merged: export KUBECONFIG=$HOME/.kube/config:$KUBECONFIG_FILE"
+exit $fail
+'''

--- a/mise.local-host.toml
+++ b/mise.local-host.toml
@@ -48,3 +48,37 @@ flux push artifact "$OCI_URL" \
   --insecure-registry \
   --reproducible
 '''
+
+[tasks.kubeconfigs]
+description = "Export the local CAPD workload-cluster kubeconfig"
+run = '''
+KUBECONFIG_FILE="${KUBECONFIG_FILE:-local-workload.kubeconfig}"
+clusterctl get kubeconfig local-workload > "$KUBECONFIG_FILE"
+
+# CAPD records the load balancer's container-network IP, which is not routable
+# from macOS. Point the kubeconfig at the port published on localhost instead.
+if [ -n "${CONTAINER_ENGINE:-}" ]; then
+  engine="$CONTAINER_ENGINE"
+elif command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
+  engine=docker
+elif command -v podman >/dev/null 2>&1 && podman info >/dev/null 2>&1; then
+  engine=podman
+else
+  echo "ERROR: no running container engine found" >&2
+  exit 1
+fi
+endpoint=$($engine port local-workload-lb 6443/tcp | head -1)
+port="${endpoint##*:}"
+case "$port" in
+  ''|*[!0-9]*)
+    echo "ERROR: cannot determine the local-workload API server port" >&2
+    exit 1
+    ;;
+esac
+kubectl config set-cluster local-workload \
+  --server="https://127.0.0.1:${port}" \
+  --kubeconfig="$KUBECONFIG_FILE" >/dev/null
+chmod 600 "$KUBECONFIG_FILE"
+echo "Wrote ${KUBECONFIG_FILE}"
+echo "Use with: KUBECONFIG=${KUBECONFIG_FILE} kubectl get nodes"
+'''

--- a/mise.toml
+++ b/mise.toml
@@ -67,31 +67,3 @@ run = "clusterawsadm bootstrap credentials encode-as-profile"
 [tasks.teardown]
 description = "Tear down all infrastructure created by bootstrap"
 run = "./teardown.sh"
-
-[tasks.kubeconfigs]
-description = "Export workload-cluster kubeconfigs to ~/.kube/knr-ops-workloads.yaml (use: export KUBECONFIG=~/.kube/knr-ops-workloads.yaml)"
-run = '''
-KUBECONFIG_FILE="${KUBECONFIG_FILE:-$HOME/.kube/knr-ops-workloads.yaml}"
-fail=0
-# Regions are discovered from the cluster definitions in Git.
-for region in $(find mgmt/aws/clusters -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | sort); do
-  cluster="default_${region}-workload-control-plane"
-  alias="${region}-workload"
-  echo "==> ${region}: ${cluster} -> context '${alias}'"
-  if ! aws eks update-kubeconfig \
-      --name "$cluster" \
-      --region "$region" \
-      --kubeconfig "$KUBECONFIG_FILE" \
-      --alias "$alias"; then
-    echo "    FAILED: ${cluster} (${region}) — cluster not provisioned yet?" >&2
-    fail=1
-  fi
-done
-chmod 600 "$KUBECONFIG_FILE" 2>/dev/null || true
-echo
-KUBECONFIG="$KUBECONFIG_FILE" kubectl config get-contexts
-echo
-echo "Use with:  export KUBECONFIG=$KUBECONFIG_FILE"
-echo "Or merged: export KUBECONFIG=$HOME/.kube/config:$KUBECONFIG_FILE"
-exit $fail
-'''

--- a/teardown.sh
+++ b/teardown.sh
@@ -20,7 +20,7 @@
 #
 # Usage:
 #   ./teardown.sh              # Full teardown (k8s + AWS)
-#   KNR_OPS_PROFILE=local-host ./teardown.sh  # Delete the management kind cluster
+#   KNR_OPS_PROFILE=local-host ./teardown.sh  # Delete CAPD workload + management cluster
 #   AWS_ONLY=1 ./teardown.sh   # AWS orphan cleanup only (skip k8s steps)
 set -euo pipefail
 
@@ -42,8 +42,10 @@ preflight_checks() {
       exit 1
     fi
 
-    command -v kind >/dev/null 2>&1 \
-      || { echo "ERROR: kind not found in PATH" >&2; exit 1; }
+    for cmd in kind kubectl; do
+      command -v "$cmd" >/dev/null 2>&1 \
+        || { echo "ERROR: $cmd not found in PATH" >&2; exit 1; }
+    done
 
     # Select the same running container engine used by bootstrap.sh. Registry
     # cleanup is best-effort so an unavailable engine does not block teardown.
@@ -101,6 +103,22 @@ preflight_checks
 
 if [ "$PROFILE" = local-host ]; then
   if kind get clusters 2>/dev/null | grep -q '^mgmt$'; then
+    kubectl config use-context kind-mgmt >/dev/null
+
+    # Prevent Flux from recreating the Cluster while CAPD removes its Docker
+    # machines, then wait before deleting the management cluster/controller.
+    kubectl patch kustomization docker-workload-cluster -n flux-system \
+      --type merge -p '{"spec":{"suspend":true}}' >/dev/null 2>&1 || true
+    if kubectl get cluster local-workload -n default >/dev/null 2>&1; then
+      echo ">>> Deleting CAPD workload cluster 'local-workload'..."
+      kubectl delete cluster local-workload -n default --wait=false
+      if ! kubectl wait --for=delete cluster/local-workload -n default --timeout=5m; then
+        echo "ERROR: CAPD workload cluster did not finish deleting; leaving mgmt intact" >&2
+        exit 1
+      fi
+      echo "✓   CAPD workload cluster 'local-workload' deleted"
+    fi
+
     echo ">>> Deleting kind management cluster 'mgmt'..."
     kind delete cluster --name mgmt
     echo "✓   kind cluster 'mgmt' deleted"


### PR DESCRIPTION
## Summary

- install cert-manager, the CAPI Operator, CAPI core/kubeadm providers, and CAPD through the local-host OCI reconciliation chain
- provision a Kubernetes v1.35 workload cluster with one control-plane and one worker node, with Calico networking
- add profile-specific `kubeconfigs` tasks, live bootstrap reconciliation progress, and safe CAPD teardown
- document the local workload workflow and move the AWS kubeconfig task into the AWS mise profile

## Testing

- `mise run validate`
- `bash -n bootstrap.sh teardown.sh`
- `git diff --check`
- end-to-end local-host bootstrap: all Flux Kustomizations Ready, CAPI Cluster Available, both workload nodes Ready
- end-to-end local-host kubeconfig access and teardown