### PR TITLE
feat: install Flux on local workload cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,15 +74,15 @@ The shared toolchain is defined in `mise.toml`. AWS-specific tools are layered
 through `mise.aws.toml`; use the `aws` profile when those tools are needed.
 The `local-host` profile creates the management kind cluster, a local OCI
 registry, and the Flux Operator and FluxInstance. It publishes the
-`mgmt/local-host/` folder as the `knr-ops:latest` OCI artifact, then Flux installs
-CAPI with its Docker infrastructure provider (CAPD) and provisions a local
-one-control-plane/one-worker workload cluster. It does not provision AWS
-resources:
+`mgmt/local-host/` and `workload/local-host/` folders as the `knr-ops:latest`
+OCI artifact. Flux installs CAPI with its Docker infrastructure provider (CAPD),
+provisions a local one-control-plane/one-worker workload cluster, and installs a
+separate Flux instance there. It does not provision AWS resources:
 
 ```sh
 mise -E local-host install
 mise -E local-host run bootstrap
-mise -E local-host run oci-push  # republish mgmt/local-host after local changes
+mise -E local-host run oci-push  # republish local management and workload paths
 mise -E local-host run kubeconfigs
 mise -E local-host run teardown
 ```

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -302,18 +302,18 @@ if [ "$PROFILE" = local-host ]; then
   trap 'cleanup_flux_watch; cleanup_registry_config' EXIT
 
   reconcile_discovery_attempts=0
-  until kubectl get kustomization docker-workload-cluster \
+  until kubectl get kustomization flux-apps \
       --namespace flux-system >/dev/null 2>&1; do
     reconcile_discovery_attempts=$((reconcile_discovery_attempts + 1))
     if [ "$reconcile_discovery_attempts" -ge 60 ]; then
-      echo "ERROR: docker-workload-cluster Kustomization was not created within 2 minutes" >&2
+      echo "ERROR: flux-apps Kustomization was not created within 2 minutes" >&2
       flux get kustomizations
       exit 1
     fi
     sleep 2
   done
 
-  if ! kubectl wait kustomization/docker-workload-cluster \
+  if ! kubectl wait kustomization/flux-apps \
       --namespace flux-system \
       --for=condition=Ready \
       --timeout="$LOCAL_RECONCILE_TIMEOUT"; then

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -90,11 +90,15 @@ The local-host profile performs the cluster, Flux Operator, and FluxInstance
 steps in the `mgmt` management cluster, but does not create GitHub or SOPS
 secrets. Instead, it bootstraps a local Docker Registry container (`registry:2`)
 running on the host machine (accessible at `localhost:5001` by default),
-publishes the `mgmt/local-host/` folder as the initial `knr-ops:latest` OCI
+publishes the `mgmt/local-host/` and `workload/local-host/` folders as the
+initial `knr-ops:latest` OCI
 artifact, and configures Flux to reconcile that path from the artifact. Flux
 then installs the CAPI core, kubeadm, and Docker infrastructure providers and
 creates `local-workload`, a one-control-plane/one-worker Kubernetes cluster in
-containers. CAPD is intended for local development and testing, not production.
+containers. The management cluster then installs a Flux Operator and
+FluxInstance on `local-workload`; that instance reconciles
+`workload/local-host/` from the same OCI artifact. CAPD is intended for local
+development and testing, not production.
 
 **OCI Registry (local-host profile only):**
 - Provides a local container registry for development workflows
@@ -105,7 +109,7 @@ containers. CAPD is intended for local development and testing, not production.
 
 **Workflow:**
 ```bash
-# Republish the mgmt/local-host/ folder after making local changes
+# Republish the local management and workload folders after making changes
 mise -E local-host run oci-push
 
 # Optional overrides
@@ -117,10 +121,10 @@ OCI_REPOSITORY=my-config OCI_TAG=v1 \
 # registry's in-cluster endpoint, knr-registry:5000.
 ```
 
-The artifact contains only the `mgmt/local-host/` folder, preserving that
-directory path when the artifact is pulled. Keeping the source scope this
-narrow also prevents local credentials and age private keys elsewhere in the
-repository from being packaged.
+The artifact contains only `mgmt/local-host/` and `workload/local-host/`,
+preserving those directory paths when the artifact is pulled. Keeping the
+source scope narrow also prevents local credentials and age private keys
+elsewhere in the repository from being packaged.
 
 The AWS profile adds the GitHub/SOPS secrets and configures the FluxInstance to sync `mgmt/aws/`.
 
@@ -138,12 +142,13 @@ mise -E local-host run kubeconfigs
 KUBECONFIG=local-workload.kubeconfig kubectl get nodes
 ```
 
-The workload uses Kubernetes v1.35.0 and bootstraps Calico v3.32.1 as its CNI.
+The workload uses Kubernetes v1.35.0. A CAPI ClusterResourceSet installs a
+pinned Kindnet daemon as its CNI before the Flux addons are delivered.
 The management cluster needs access to the container-engine socket, which
 `bootstrap.sh` mounts automatically.
 
-Local-host bootstrap streams the Flux Kustomization status in the same terminal
-and returns after `docker-workload-cluster` becomes Ready. The readiness wait
+Local-host bootstrap streams the management Flux Kustomization status in the
+same terminal and returns after `flux-apps` becomes Ready. The readiness wait
 defaults to 15 minutes and can be changed with `LOCAL_RECONCILE_TIMEOUT`.
 
 EKS clusters typically take 15–25 minutes to come up; node groups and the

--- a/mgmt/local-host/addons/cni/flux-ks.yaml
+++ b/mgmt/local-host/addons/cni/flux-ks.yaml
@@ -1,0 +1,26 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: local-workload-cni
+  namespace: flux-system
+spec:
+  interval: 5m
+  retryInterval: 2m
+  timeout: 10m
+  prune: true
+  wait: true
+  sourceRef:
+    kind: OCIRepository
+    name: flux-system
+  path: ./mgmt/local-host/addons/cni
+  dependsOn:
+    - name: docker-workload-cluster
+  healthChecks:
+    - apiVersion: cluster.x-k8s.io/v1beta2
+      kind: Cluster
+      name: local-workload
+      namespace: default
+  healthCheckExprs:
+    - apiVersion: cluster.x-k8s.io/v1beta2
+      kind: Cluster
+      current: status.conditions.exists(e, e.type == 'Available' && e.status == 'True')

--- a/mgmt/local-host/addons/cni/kindnet.yaml
+++ b/mgmt/local-host/addons/cni/kindnet.yaml
@@ -1,0 +1,130 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: local-workload-kindnet
+  namespace: default
+data:
+  kindnet.yaml: |
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: kindnet
+      namespace: kube-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: kindnet
+    rules:
+      - apiGroups: [""]
+        resources: ["nodes", "pods", "namespaces"]
+        verbs: ["list", "watch"]
+      - apiGroups: ["networking.k8s.io"]
+        resources: ["networkpolicies"]
+        verbs: ["list", "watch"]
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: kindnet
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: kindnet
+    subjects:
+      - kind: ServiceAccount
+        name: kindnet
+        namespace: kube-system
+    ---
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      name: kindnet
+      namespace: kube-system
+      labels:
+        app: kindnet
+        k8s-app: kindnet
+        tier: node
+    spec:
+      selector:
+        matchLabels:
+          app: kindnet
+      template:
+        metadata:
+          labels:
+            app: kindnet
+            k8s-app: kindnet
+            tier: node
+        spec:
+          serviceAccountName: kindnet
+          hostNetwork: true
+          nodeSelector:
+            kubernetes.io/os: linux
+          priorityClassName: system-node-critical
+          tolerations:
+            - operator: Exists
+          containers:
+            - name: kindnet-cni
+              image: docker.io/kindest/kindnetd:v20260528-9350166c
+              imagePullPolicy: IfNotPresent
+              env:
+                - name: HOST_IP
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: status.hostIP
+                - name: POD_IP
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: status.podIP
+                - name: POD_SUBNET
+                  value: 192.168.0.0/16
+                - name: CONTROL_PLANE_ENDPOINT
+                  value: host.docker.internal:6443
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 50Mi
+                limits:
+                  cpu: 100m
+                  memory: 50Mi
+              securityContext:
+                capabilities:
+                  add: ["NET_RAW", "NET_ADMIN"]
+              volumeMounts:
+                - name: cni-cfg
+                  mountPath: /etc/cni/net.d
+                - name: xtables-lock
+                  mountPath: /run/xtables.lock
+                - name: lib-modules
+                  mountPath: /lib/modules
+                  readOnly: true
+                - name: nri-plugin
+                  mountPath: /var/run/nri
+          volumes:
+            - name: cni-cfg
+              hostPath:
+                path: /etc/cni/net.d
+            - name: xtables-lock
+              hostPath:
+                path: /run/xtables.lock
+                type: FileOrCreate
+            - name: lib-modules
+              hostPath:
+                path: /lib/modules
+            - name: nri-plugin
+              hostPath:
+                path: /var/run/nri
+---
+apiVersion: addons.cluster.x-k8s.io/v1beta1
+kind: ClusterResourceSet
+metadata:
+  name: local-workload-kindnet
+  namespace: default
+spec:
+  clusterSelector:
+    matchLabels:
+      profile: local-host
+  strategy: ApplyOnce
+  resources:
+    - kind: ConfigMap
+      name: local-workload-kindnet

--- a/mgmt/local-host/addons/cni/kustomization.yaml
+++ b/mgmt/local-host/addons/cni/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - kindnet.yaml

--- a/mgmt/local-host/addons/flux-apps/flux-instance.yaml
+++ b/mgmt/local-host/addons/flux-apps/flux-instance.yaml
@@ -1,0 +1,64 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: local-workload-flux-instance
+  namespace: default
+data:
+  flux-instance.yaml: |
+    apiVersion: v1
+    kind: Namespace
+    metadata:
+      name: flux-system
+    ---
+    apiVersion: fluxcd.controlplane.io/v1
+    kind: FluxInstance
+    metadata:
+      name: flux
+      namespace: flux-system
+      annotations:
+        fluxcd.controlplane.io/reconcileEvery: "1h"
+        fluxcd.controlplane.io/reconcileTimeout: "5m"
+    spec:
+      distribution:
+        version: "2.x"
+        registry: "ghcr.io/fluxcd"
+        artifact: "oci://ghcr.io/controlplaneio-fluxcd/flux-operator-manifests"
+      components:
+        - source-controller
+        - kustomize-controller
+        - helm-controller
+        - notification-controller
+      cluster:
+        type: kubernetes
+        size: small
+        multitenant: false
+        networkPolicy: true
+        domain: cluster.local
+      sync:
+        kind: OCIRepository
+        url: oci://knr-registry:5000/knr-ops
+        ref: latest
+        path: workload/local-host
+      kustomize:
+        patches:
+          - patch: |
+              - op: add
+                path: /spec/insecure
+                value: true
+            target:
+              kind: OCIRepository
+---
+apiVersion: addons.cluster.x-k8s.io/v1beta1
+kind: ClusterResourceSet
+metadata:
+  name: local-workload-flux-instance
+  namespace: default
+spec:
+  clusterSelector:
+    matchLabels:
+      fluxcd: enabled
+      profile: local-host
+  strategy: ApplyOnce
+  resources:
+    - kind: ConfigMap
+      name: local-workload-flux-instance

--- a/mgmt/local-host/addons/flux-apps/flux-ks.yaml
+++ b/mgmt/local-host/addons/flux-apps/flux-ks.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: flux-apps
+  namespace: flux-system
+spec:
+  interval: 5m
+  retryInterval: 2m
+  timeout: 10m
+  prune: true
+  wait: true
+  sourceRef:
+    kind: OCIRepository
+    name: flux-system
+  path: ./mgmt/local-host/addons/flux-apps
+  dependsOn:
+    - name: caaph-system
+    - name: local-workload-cni

--- a/mgmt/local-host/addons/flux-apps/flux-operator.yaml
+++ b/mgmt/local-host/addons/flux-apps/flux-operator.yaml
@@ -1,0 +1,20 @@
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: flux-operator
+  namespace: default
+spec:
+  clusterSelector:
+    matchLabels:
+      fluxcd: enabled
+      profile: local-host
+  repoURL: oci://ghcr.io/controlplaneio-fluxcd/charts
+  chartName: flux-operator
+  version: "0.58.0"
+  namespace: flux-system
+  options:
+    waitForJobs: true
+    wait: true
+    timeout: 5m
+    install:
+      createNamespace: true

--- a/mgmt/local-host/addons/flux-apps/kustomization.yaml
+++ b/mgmt/local-host/addons/flux-apps/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flux-operator.yaml
+  - flux-instance.yaml

--- a/mgmt/local-host/capi-providers/caaph-system/kustomization.yaml
+++ b/mgmt/local-host/capi-providers/caaph-system/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - provider.yaml

--- a/mgmt/local-host/capi-providers/caaph-system/namespace.yaml
+++ b/mgmt/local-host/capi-providers/caaph-system/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: caaph-system

--- a/mgmt/local-host/capi-providers/caaph-system/provider.yaml
+++ b/mgmt/local-host/capi-providers/caaph-system/provider.yaml
@@ -1,0 +1,7 @@
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
+kind: AddonProvider
+metadata:
+  name: helm
+  namespace: caaph-system
+spec:
+  version: "v0.6.4"

--- a/mgmt/local-host/capi-providers/flux-ks.yaml
+++ b/mgmt/local-host/capi-providers/flux-ks.yaml
@@ -40,3 +40,25 @@ spec:
     - apiVersion: apiextensions.k8s.io/v1
       kind: CustomResourceDefinition
       name: devmachines.infrastructure.cluster.x-k8s.io
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: caaph-system
+  namespace: flux-system
+spec:
+  interval: 5m
+  retryInterval: 2m
+  timeout: 5m
+  prune: true
+  wait: false
+  sourceRef:
+    kind: OCIRepository
+    name: flux-system
+  path: ./mgmt/local-host/capi-providers/caaph-system
+  dependsOn:
+    - name: capi-system
+  healthChecks:
+    - apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      name: helmchartproxies.addons.cluster.x-k8s.io

--- a/mgmt/local-host/clusters/docker/cluster-class.yaml
+++ b/mgmt/local-host/clusters/docker/cluster-class.yaml
@@ -53,10 +53,6 @@ spec:
   template:
     spec:
       kubeadmConfigSpec:
-        # Bootstrap networking from a version-pinned upstream manifest. This
-        # runs once, after kubeadm creates the workload API server.
-        postKubeadmCommands:
-          - kubectl --kubeconfig=/etc/kubernetes/admin.conf apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.32.1/manifests/calico.yaml
         clusterConfiguration:
           apiServer:
             certSANs:

--- a/mgmt/local-host/clusters/docker/cluster.yaml
+++ b/mgmt/local-host/clusters/docker/cluster.yaml
@@ -4,6 +4,7 @@ metadata:
   name: local-workload
   namespace: default
   labels:
+    fluxcd: enabled
     profile: local-host
 spec:
   clusterNetwork:

--- a/mgmt/local-host/kustomization.yaml
+++ b/mgmt/local-host/kustomization.yaml
@@ -6,3 +6,5 @@ resources:
   - infrastructure/flux-ks.yaml
   - capi-providers/flux-ks.yaml
   - clusters/flux-ks.yaml
+  - addons/cni/flux-ks.yaml
+  - addons/flux-apps/flux-ks.yaml

--- a/mise.local-host.toml
+++ b/mise.local-host.toml
@@ -12,12 +12,15 @@ REGISTRY_PORT="${REGISTRY_PORT:-5001}"
 OCI_REPOSITORY="${OCI_REPOSITORY:-knr-ops}"
 OCI_TAG="${OCI_TAG:-latest}"
 OCI_URL="oci://localhost:${REGISTRY_PORT}/${OCI_REPOSITORY}:${OCI_TAG}"
-OCI_SOURCE_PATH="mgmt/local-host"
+OCI_MGMT_SOURCE_PATH="mgmt/local-host"
+OCI_WORKLOAD_SOURCE_PATH="workload/local-host"
 
-if [ ! -d "$OCI_SOURCE_PATH" ]; then
-  echo "ERROR: OCI source directory does not exist: $OCI_SOURCE_PATH" >&2
-  exit 1
-fi
+for source_path in "$OCI_MGMT_SOURCE_PATH" "$OCI_WORKLOAD_SOURCE_PATH"; do
+  if [ ! -d "$source_path" ]; then
+    echo "ERROR: OCI source directory does not exist: $source_path" >&2
+    exit 1
+  fi
+done
 
 if ! curl --fail --silent --show-error "http://localhost:${REGISTRY_PORT}/v2/" >/dev/null; then
   echo "ERROR: local registry is unavailable at localhost:${REGISTRY_PORT}" >&2
@@ -36,10 +39,11 @@ cleanup_artifact_root() {
   rm -rf "$ARTIFACT_ROOT"
 }
 trap cleanup_artifact_root EXIT
-mkdir -p "$ARTIFACT_ROOT/mgmt"
-cp -R "$OCI_SOURCE_PATH" "$ARTIFACT_ROOT/mgmt/local-host"
+mkdir -p "$ARTIFACT_ROOT/mgmt" "$ARTIFACT_ROOT/workload"
+cp -R "$OCI_MGMT_SOURCE_PATH" "$ARTIFACT_ROOT/mgmt/local-host"
+cp -R "$OCI_WORKLOAD_SOURCE_PATH" "$ARTIFACT_ROOT/workload/local-host"
 
-echo "==> Packaging ${OCI_SOURCE_PATH} as mgmt/local-host"
+echo "==> Packaging mgmt/local-host and workload/local-host"
 echo "==> Pushing ${OCI_URL}"
 flux push artifact "$OCI_URL" \
   --path="$ARTIFACT_ROOT" \

--- a/workload/local-host/kustomization.yaml
+++ b/workload/local-host/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Root reconciled by the FluxInstance running on the local CAPD workload
+# cluster. Add local workload applications here.
+resources: []


### PR DESCRIPTION
## Summary

- install the CAPI Add-on Helm provider for the local-host profile
- deliver Kindnet, Flux Operator, and a FluxInstance to the CAPD workload cluster
- publish and reconcile the `workload/local-host` path from the local OCI registry
- update bootstrap progress and local-host documentation

## Testing

- `mise run validate`
- `bash -n bootstrap.sh teardown.sh`
- `git diff --check`
- completed a clean `mise -E local-host run bootstrap`
- verified both workload nodes became Ready
- verified workload FluxInstance, OCIRepository, and Kustomization became Ready
- completed `mise -E local-host run teardown`