### PR TITLE
feat: deploy Podinfo to local workload cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,19 +77,27 @@ registry, and the Flux Operator and FluxInstance. It publishes the
 `mgmt/local-host/` and `workload/local-host/` folders as the `knr-ops:latest`
 OCI artifact. Flux installs CAPI with its Docker infrastructure provider (CAPD),
 provisions a local one-control-plane/one-worker workload cluster, and installs a
-separate Flux instance there. It does not provision AWS resources:
+separate Flux instance there. That workload Flux instance reconciles Podinfo,
+providing an end-to-end local path from management-cluster bootstrap through
+workload delivery and application access. This covers the complete GitOps and
+CAPI lifecycle without provisioning AWS resources:
 
 ```sh
 mise -E local-host install
 mise -E local-host run bootstrap
 mise -E local-host run oci-push  # republish local management and workload paths
 mise -E local-host run kubeconfigs
+mise -E local-host run podinfo-port-forward  # http://localhost:9898
 mise -E local-host run teardown
 ```
 
 The Flux charts are pulled anonymously. The AWS profile requires a
 GitHub PAT so Flux can clone this repository; the local-host profile does not require
 GitHub or AWS credentials.
+
+`mise -E local-host run bootstrap` waits for both the management and workload
+Flux reconciliation chains and streams their progress. A successful bootstrap,
+followed by the Podinfo port-forward, verifies the end-to-end local-host flow.
 
 The local-host teardown deletes the CAPD workload cluster before deleting the
 `mgmt` kind cluster and local registry container. The default teardown path

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -288,19 +288,12 @@ kubectl wait --namespace flux-system --for=condition=ready pod \
 # ── Step 5: Watch local-host reconciliation ──────────────────────────────────
 # Stream the GitOps handoff in the bootstrap terminal for the local profile.
 # The final Kustomization is created by the OCI root, so wait for it to appear
-# before asking kubectl to wait for its Ready condition.
+# before starting the progress watcher or asking kubectl to wait for readiness.
+# Matching the watch timeout to the authoritative readiness timeout prevents
+# the progress display from reporting a misleading early timeout.
 if [ "$PROFILE" = local-host ]; then
   echo ""
   echo ">>> Step 5: Flux reconciliation progress"
-  echo ">>> Watching until the local workload cluster is ready..."
-  flux get kustomizations --watch &
-  flux_watch_pid=$!
-  cleanup_flux_watch() {
-    kill "$flux_watch_pid" >/dev/null 2>&1 || true
-    wait "$flux_watch_pid" >/dev/null 2>&1 || true
-  }
-  trap 'cleanup_flux_watch; cleanup_registry_config' EXIT
-
   reconcile_discovery_attempts=0
   until kubectl get kustomization flux-apps \
       --namespace flux-system >/dev/null 2>&1; do
@@ -313,6 +306,15 @@ if [ "$PROFILE" = local-host ]; then
     sleep 2
   done
 
+  echo ">>> Watching until the local workload cluster and Flux addons are ready..."
+  flux get kustomizations --watch --timeout="$LOCAL_RECONCILE_TIMEOUT" &
+  flux_watch_pid=$!
+  cleanup_flux_watch() {
+    kill "$flux_watch_pid" >/dev/null 2>&1 || true
+    wait "$flux_watch_pid" >/dev/null 2>&1 || true
+  }
+  trap 'cleanup_flux_watch; cleanup_registry_config' EXIT
+
   if ! kubectl wait kustomization/flux-apps \
       --namespace flux-system \
       --for=condition=Ready \
@@ -322,6 +324,65 @@ if [ "$PROFILE" = local-host ]; then
     exit 1
   fi
   cleanup_flux_watch
+  trap cleanup_registry_config EXIT
+
+  echo ""
+  echo ">>> Workload cluster Flux reconciliation logs"
+  workload_kubeconfig="$(mktemp)"
+  workload_flux_log_pid=""
+  cleanup_workload_reconciliation() {
+    if [ -n "$workload_flux_log_pid" ]; then
+      kill "$workload_flux_log_pid" >/dev/null 2>&1 || true
+      wait "$workload_flux_log_pid" >/dev/null 2>&1 || true
+    fi
+    rm -f "$workload_kubeconfig"
+  }
+  trap 'cleanup_workload_reconciliation; cleanup_registry_config' EXIT
+
+  clusterctl get kubeconfig local-workload > "$workload_kubeconfig"
+  workload_endpoint="$($CONTAINER_ENGINE port local-workload-lb 6443/tcp | head -1)"
+  workload_port="${workload_endpoint##*:}"
+  case "$workload_port" in
+    ''|*[!0-9]*)
+      echo "ERROR: cannot determine the local-workload API server port" >&2
+      exit 1
+      ;;
+  esac
+  kubectl config set-cluster local-workload \
+    --server="https://127.0.0.1:${workload_port}" \
+    --kubeconfig="$workload_kubeconfig" >/dev/null
+
+  workload_flux_discovery_attempts=0
+  until kubectl --kubeconfig "$workload_kubeconfig" get kustomization flux-system \
+      --namespace flux-system >/dev/null 2>&1; do
+    workload_flux_discovery_attempts=$((workload_flux_discovery_attempts + 1))
+    if [ "$workload_flux_discovery_attempts" -ge 60 ]; then
+      echo "ERROR: workload Flux Kustomization was not created within 2 minutes" >&2
+      kubectl --kubeconfig "$workload_kubeconfig" get pods \
+        --namespace flux-system || true
+      exit 1
+    fi
+    sleep 2
+  done
+
+  flux logs \
+    --kubeconfig "$workload_kubeconfig" \
+    --all-namespaces \
+    --follow \
+    --since=10m &
+  workload_flux_log_pid=$!
+
+  if ! kubectl --kubeconfig "$workload_kubeconfig" wait kustomization/flux-system \
+      --namespace flux-system \
+      --for=condition=Ready \
+      --timeout="$LOCAL_RECONCILE_TIMEOUT"; then
+    echo "ERROR: workload reconciliation did not complete within ${LOCAL_RECONCILE_TIMEOUT}" >&2
+    flux get kustomizations \
+      --kubeconfig "$workload_kubeconfig" \
+      --all-namespaces
+    exit 1
+  fi
+  cleanup_workload_reconciliation
   trap cleanup_registry_config EXIT
 fi
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -100,6 +100,13 @@ FluxInstance on `local-workload`; that instance reconciles
 `workload/local-host/` from the same OCI artifact. CAPD is intended for local
 development and testing, not production.
 
+Together, these stages make `local-host` an end-to-end profile: one command
+bootstraps the management control plane, publishes and reconciles the OCI
+configuration, provisions a workload cluster through CAPI, installs a distinct
+Flux control plane on that cluster, and reconciles a reachable Podinfo workload.
+It exercises the complete cluster-to-workload GitOps lifecycle locally; only
+the AWS-specific infrastructure and ACK resources are outside its scope.
+
 **OCI Registry (local-host profile only):**
 - Provides a local container registry for development workflows
 - Enables developers to build and push OCI artifacts from git checkouts
@@ -142,19 +149,45 @@ mise -E local-host run kubeconfigs
 KUBECONFIG=local-workload.kubeconfig kubectl get nodes
 ```
 
+The local workload Flux instance installs Podinfo from its OCI Helm chart. Open
+it in a host browser by running the port-forward task in a separate terminal:
+
+```sh
+mise -E local-host run podinfo-port-forward
+```
+
+Then browse to <http://localhost:9898>. Press Ctrl-C to stop forwarding.
+
 The workload uses Kubernetes v1.35.0. A CAPI ClusterResourceSet installs a
 pinned Kindnet daemon as its CNI before the Flux addons are delivered.
 The management cluster needs access to the container-engine socket, which
 `bootstrap.sh` mounts automatically.
 
-Local-host bootstrap streams the management Flux Kustomization status in the
-same terminal and returns after `flux-apps` becomes Ready. The readiness wait
-defaults to 15 minutes and can be changed with `LOCAL_RECONCILE_TIMEOUT`.
+Local-host bootstrap first streams the management Flux Kustomization status.
+After `flux-apps` becomes Ready, it connects to `local-workload`, streams the
+workload Flux controller reconciliation logs, and returns after the workload
+root Kustomization becomes Ready. Each readiness wait defaults to 15 minutes
+and can be changed with `LOCAL_RECONCILE_TIMEOUT`.
 
 EKS clusters typically take 15–25 minutes to come up; node groups and the
 downstream app chain follow a few minutes after.
 
 ### Verifying the full chain
+
+For the local-host end-to-end chain:
+
+```sh
+mise -E local-host run bootstrap
+mise -E local-host run kubeconfigs
+KUBECONFIG=local-workload.kubeconfig flux get all --all-namespaces
+mise -E local-host run podinfo-port-forward  # browse to http://localhost:9898
+```
+
+Bootstrap does not return until the management and workload root
+Kustomizations are Ready. The final port-forward verifies that the workload
+Flux instance successfully delivered the application.
+
+For the AWS chain:
 
 ```sh
 # Management cluster

--- a/mise.local-host.toml
+++ b/mise.local-host.toml
@@ -86,3 +86,19 @@ chmod 600 "$KUBECONFIG_FILE"
 echo "Wrote ${KUBECONFIG_FILE}"
 echo "Use with: KUBECONFIG=${KUBECONFIG_FILE} kubectl get nodes"
 '''
+
+[tasks.podinfo-port-forward]
+description = "Expose workload Podinfo at http://localhost:9898"
+run = '''
+KUBECONFIG_FILE="${KUBECONFIG_FILE:-local-workload.kubeconfig}"
+if [ ! -f "$KUBECONFIG_FILE" ]; then
+  echo "ERROR: workload kubeconfig not found: $KUBECONFIG_FILE" >&2
+  echo "       Create it with: mise -E local-host run kubeconfigs" >&2
+  exit 1
+fi
+
+echo "Podinfo will be available at http://localhost:9898"
+echo "Press Ctrl-C to stop forwarding."
+kubectl --kubeconfig "$KUBECONFIG_FILE" \
+  port-forward --namespace podinfo service/podinfo 9898:9898
+'''

--- a/workload/local-host/kustomization.yaml
+++ b/workload/local-host/kustomization.yaml
@@ -1,5 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 # Root reconciled by the FluxInstance running on the local CAPD workload
-# cluster. Add local workload applications here.
-resources: []
+# cluster.
+resources:
+  - podinfo

--- a/workload/local-host/podinfo/helm.yaml
+++ b/workload/local-host/podinfo/helm.yaml
@@ -1,0 +1,28 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: podinfo-chart
+  namespace: podinfo
+spec:
+  interval: 1h
+  url: oci://ghcr.io/stefanprodan/charts/podinfo
+  ref:
+    tag: "6.14.0"
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: podinfo
+  namespace: podinfo
+spec:
+  interval: 10m
+  timeout: 5m
+  chartRef:
+    kind: OCIRepository
+    name: podinfo-chart
+  install:
+    createNamespace: false
+  values:
+    replicaCount: 1
+    service:
+      type: ClusterIP

--- a/workload/local-host/podinfo/kustomization.yaml
+++ b/workload/local-host/podinfo/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - helm.yaml

--- a/workload/local-host/podinfo/namespace.yaml
+++ b/workload/local-host/podinfo/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: podinfo


### PR DESCRIPTION
## Summary

- deploy Podinfo to the local CAPD workload cluster through Flux using its OCI Helm chart
- add a mise task and documentation for forwarding Podinfo to http://localhost:9898
- align the local bootstrap reconciliation watcher with the readiness timeout

## Testing

- mise run validate