### PR TITLE
fix: wait explicitly for FluxInstance readiness

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -271,12 +271,21 @@ else
     --set-json 'instance.kustomize.patches=[{"patch":"- op: add\n  path: /spec/insecure\n  value: true","target":{"kind":"OCIRepository"}}]'
   )
 fi
+# Helm 4's watcher strategy treats the FluxInstance's transient InProgress
+# condition as a terminal failure. Use the legacy chart-resource wait here,
+# then wait explicitly for the operator-owned Ready condition below.
 helm upgrade --install flux \
   oci://ghcr.io/controlplaneio-fluxcd/charts/flux-instance \
   --namespace flux-system \
-  --wait \
+  --wait=legacy \
   --timeout 10m \
   "${FLUX_INSTANCE_ARGS[@]}"
+
+echo ">>> Waiting for FluxInstance reconciliation to complete..."
+kubectl wait fluxinstance/flux \
+  --namespace flux-system \
+  --for=condition=Ready \
+  --timeout=10m
 
 # ── Post-bootstrap health check ───────────────────────────────────────────────
 # Verify the Flux controllers are running before declaring success.

--- a/mise.toml
+++ b/mise.toml
@@ -12,9 +12,16 @@ age = "latest"
 env_file = ".env"
 
 [tasks.validate]
-description = "Build every kustomize overlay to catch structural/reference errors"
+description = "Check shell scripts and build every kustomize overlay"
 run = '''
 fail=0
+for script in bootstrap.sh teardown.sh; do
+  echo "==> bash -n $script"
+  if ! bash -n "$script"; then
+    echo "    FAILED: $script" >&2
+    fail=1
+  fi
+done
 for dir in $(find mgmt workload -name kustomization.yaml -exec dirname {} \; | sort -u); do
   echo "==> kustomize build $dir"
   if ! kubectl kustomize "$dir" >/dev/null; then


### PR DESCRIPTION
## Summary

- use Helm 4 legacy resource waiting to avoid treating the FluxInstance transient InProgress condition as a terminal failure
- wait explicitly for the FluxInstance Ready condition after chart installation

## Context

Follow-up to #36; the fix was added to its source branch after that PR had already merged.

## Testing

- bash -n bootstrap.sh
- git diff --check
- mise run validate