### PR TITLE
fix: clean up bootstrap reconciliation output

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,9 @@ GitHub PAT so Flux can clone this repository; the local-host profile does not re
 GitHub or AWS credentials.
 
 `mise -E local-host run bootstrap` waits for both the management and workload
-Flux reconciliation chains and streams their progress. A successful bootstrap,
-followed by the Podinfo port-forward, verifies the end-to-end local-host flow.
+Flux reconciliation chains, streams management progress, and surfaces workload
+reconciliation errors. A successful bootstrap, followed by the Podinfo
+port-forward, verifies the end-to-end local-host flow.
 
 The local-host teardown deletes the CAPD workload cluster before deleting the
 `mgmt` kind cluster and local registry container. The default teardown path

--- a/README.md
+++ b/README.md
@@ -96,9 +96,9 @@ GitHub PAT so Flux can clone this repository; the local-host profile does not re
 GitHub or AWS credentials.
 
 `mise -E local-host run bootstrap` waits for both the management and workload
-Flux reconciliation chains, streams management progress, and surfaces workload
-reconciliation errors. A successful bootstrap, followed by the Podinfo
-port-forward, verifies the end-to-end local-host flow.
+Flux reconciliation chains and surfaces workload reconciliation errors. A
+successful bootstrap, followed by the Podinfo port-forward, verifies the
+end-to-end local-host flow.
 
 The local-host teardown deletes the CAPD workload cluster before deleting the
 `mgmt` kind cluster and local registry container. The default teardown path

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -336,7 +336,7 @@ if [ "$PROFILE" = local-host ]; then
   trap cleanup_registry_config EXIT
 
   echo ""
-  echo ">>> Workload cluster Flux reconciliation logs"
+  echo ">>> Workload cluster Flux reconciliation errors"
   workload_kubeconfig="$(mktemp)"
   workload_flux_log_pid=""
   cleanup_workload_reconciliation() {
@@ -378,6 +378,7 @@ if [ "$PROFILE" = local-host ]; then
     --kubeconfig "$workload_kubeconfig" \
     --all-namespaces \
     --follow \
+    --level=error \
     --since=10m &
   workload_flux_log_pid=$!
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -210,10 +210,33 @@ fi
 echo ">>> Installing Flux Operator..."
 ANONYMOUS_REGISTRY_CONFIG="$(mktemp)"
 printf '{}\n' > "$ANONYMOUS_REGISTRY_CONFIG"
-cleanup_registry_config() {
+flux_watch_pid=""
+workload_flux_log_pid=""
+workload_kubeconfig=""
+cleanup_flux_watch() {
+  if [ -n "$flux_watch_pid" ]; then
+    kill "$flux_watch_pid" >/dev/null 2>&1 || true
+    wait "$flux_watch_pid" >/dev/null 2>&1 || true
+    flux_watch_pid=""
+  fi
+}
+cleanup_workload_reconciliation() {
+  if [ -n "$workload_flux_log_pid" ]; then
+    kill "$workload_flux_log_pid" >/dev/null 2>&1 || true
+    wait "$workload_flux_log_pid" >/dev/null 2>&1 || true
+    workload_flux_log_pid=""
+  fi
+  if [ -n "$workload_kubeconfig" ]; then
+    rm -f "$workload_kubeconfig"
+    workload_kubeconfig=""
+  fi
+}
+cleanup_bootstrap() {
+  cleanup_flux_watch
+  cleanup_workload_reconciliation
   rm -f "$ANONYMOUS_REGISTRY_CONFIG"
 }
-trap cleanup_registry_config EXIT
+trap cleanup_bootstrap EXIT
 helm install flux-operator oci://ghcr.io/controlplaneio-fluxcd/charts/flux-operator \
   --namespace flux-system \
   --create-namespace \
@@ -318,11 +341,6 @@ if [ "$PROFILE" = local-host ]; then
   echo ">>> Watching until the local workload cluster and Flux addons are ready..."
   flux get kustomizations --watch --timeout="$LOCAL_RECONCILE_TIMEOUT" &
   flux_watch_pid=$!
-  cleanup_flux_watch() {
-    kill "$flux_watch_pid" >/dev/null 2>&1 || true
-    wait "$flux_watch_pid" >/dev/null 2>&1 || true
-  }
-  trap 'cleanup_flux_watch; cleanup_registry_config' EXIT
 
   if ! kubectl wait kustomization/flux-apps \
       --namespace flux-system \
@@ -333,20 +351,10 @@ if [ "$PROFILE" = local-host ]; then
     exit 1
   fi
   cleanup_flux_watch
-  trap cleanup_registry_config EXIT
 
   echo ""
   echo ">>> Workload cluster Flux reconciliation errors"
   workload_kubeconfig="$(mktemp)"
-  workload_flux_log_pid=""
-  cleanup_workload_reconciliation() {
-    if [ -n "$workload_flux_log_pid" ]; then
-      kill "$workload_flux_log_pid" >/dev/null 2>&1 || true
-      wait "$workload_flux_log_pid" >/dev/null 2>&1 || true
-    fi
-    rm -f "$workload_kubeconfig"
-  }
-  trap 'cleanup_workload_reconciliation; cleanup_registry_config' EXIT
 
   clusterctl get kubeconfig local-workload > "$workload_kubeconfig"
   workload_endpoint="$($CONTAINER_ENGINE port local-workload-lb 6443/tcp | head -1)"
@@ -393,7 +401,6 @@ if [ "$PROFILE" = local-host ]; then
     exit 1
   fi
   cleanup_workload_reconciliation
-  trap cleanup_registry_config EXIT
 fi
 
 # ── Done ──────────────────────────────────────────────────────────────────────

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -369,6 +369,13 @@ if [ "$PROFILE" = local-host ]; then
     sleep 2
   done
 
+  echo ">>> Waiting for workload Flux controllers to be ready..."
+  kubectl --kubeconfig "$workload_kubeconfig" wait pod \
+    --namespace flux-system \
+    --selector='app.kubernetes.io/part-of=flux' \
+    --for=condition=Ready \
+    --timeout="$LOCAL_RECONCILE_TIMEOUT"
+
   flux logs \
     --kubeconfig "$workload_kubeconfig" \
     --all-namespaces \

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -210,16 +210,8 @@ fi
 echo ">>> Installing Flux Operator..."
 ANONYMOUS_REGISTRY_CONFIG="$(mktemp)"
 printf '{}\n' > "$ANONYMOUS_REGISTRY_CONFIG"
-flux_watch_pid=""
 workload_flux_log_pid=""
 workload_kubeconfig=""
-cleanup_flux_watch() {
-  if [ -n "$flux_watch_pid" ]; then
-    kill "$flux_watch_pid" >/dev/null 2>&1 || true
-    wait "$flux_watch_pid" >/dev/null 2>&1 || true
-    flux_watch_pid=""
-  fi
-}
 cleanup_workload_reconciliation() {
   if [ -n "$workload_flux_log_pid" ]; then
     kill "$workload_flux_log_pid" >/dev/null 2>&1 || true
@@ -232,7 +224,6 @@ cleanup_workload_reconciliation() {
   fi
 }
 cleanup_bootstrap() {
-  cleanup_flux_watch
   cleanup_workload_reconciliation
   rm -f "$ANONYMOUS_REGISTRY_CONFIG"
 }
@@ -338,9 +329,7 @@ if [ "$PROFILE" = local-host ]; then
     sleep 2
   done
 
-  echo ">>> Watching until the local workload cluster and Flux addons are ready..."
-  flux get kustomizations --watch --timeout="$LOCAL_RECONCILE_TIMEOUT" &
-  flux_watch_pid=$!
+  echo ">>> Waiting until the local workload cluster and Flux addons are ready..."
 
   if ! kubectl wait kustomization/flux-apps \
       --namespace flux-system \
@@ -350,8 +339,6 @@ if [ "$PROFILE" = local-host ]; then
     flux get kustomizations
     exit 1
   fi
-  cleanup_flux_watch
-
   echo ""
   echo ">>> Workload cluster Flux reconciliation errors"
   workload_kubeconfig="$(mktemp)"

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -165,9 +165,11 @@ The management cluster needs access to the container-engine socket, which
 
 Local-host bootstrap first streams the management Flux Kustomization status.
 After `flux-apps` becomes Ready, it connects to `local-workload`, streams the
-workload Flux controller reconciliation logs, and returns after the workload
-root Kustomization becomes Ready. Each readiness wait defaults to 15 minutes
-and can be changed with `LOCAL_RECONCILE_TIMEOUT`.
+workload Flux controller error logs, and returns after the workload root
+Kustomization becomes Ready. Filtering the workload stream to errors avoids
+showing normal startup retries and advisory messages as apparent failures. Each
+readiness wait defaults to 15 minutes and can be changed with
+`LOCAL_RECONCILE_TIMEOUT`.
 
 EKS clusters typically take 15–25 minutes to come up; node groups and the
 downstream app chain follow a few minutes after.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -163,13 +163,13 @@ pinned Kindnet daemon as its CNI before the Flux addons are delivered.
 The management cluster needs access to the container-engine socket, which
 `bootstrap.sh` mounts automatically.
 
-Local-host bootstrap first streams the management Flux Kustomization status.
-After `flux-apps` becomes Ready, it connects to `local-workload`, streams the
-workload Flux controller error logs, and returns after the workload root
-Kustomization becomes Ready. Filtering the workload stream to errors avoids
-showing normal startup retries and advisory messages as apparent failures. Each
-readiness wait defaults to 15 minutes and can be changed with
-`LOCAL_RECONCILE_TIMEOUT`.
+Local-host bootstrap first waits for the management `flux-apps` Kustomization
+without printing transient `Unknown` status rows. After `flux-apps` becomes
+Ready, it connects to `local-workload`, streams the workload Flux controller
+error logs, and returns after the workload root Kustomization becomes Ready.
+Filtering the workload stream to errors avoids showing normal startup retries
+and advisory messages as apparent failures. Each readiness wait defaults to 15
+minutes and can be changed with `LOCAL_RECONCILE_TIMEOUT`.
 
 EKS clusters typically take 15–25 minutes to come up; node groups and the
 downstream app chain follow a few minutes after.


### PR DESCRIPTION
## Summary

- limit workload Flux log streaming to actual errors
- remove transient management Flux status rows while retaining authoritative readiness waits
- replace layered EXIT traps with one stable, idempotent cleanup handler

## Testing

- mise run validate
- git diff --check