### PR TITLE
ci: add air-gapped workflow

### DIFF
--- a/.github/workflows/air-gapped.yml
+++ b/.github/workflows/air-gapped.yml
@@ -1,0 +1,250 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: air-gapped
+
+on:
+  push:
+    branches:
+      - ci/air-gapped-workflow
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build air-gap package
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7.0.1
+
+      - name: Install mise
+        uses: jdx/mise-action@v4.2.3
+        with:
+          version: 2026.8.10
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Start local OCI registry
+        run: |
+          docker run --detach \
+            --name knr-registry \
+            --publish 127.0.0.1:5001:5000 \
+            registry:2
+
+          for attempt in {1..30}; do
+            if curl --fail --silent http://localhost:5001/v2/ >/dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+
+          docker logs knr-registry
+          exit 1
+
+      - name: Build air-gap package
+        run: airgap/scripts/build-package.sh
+        env:
+          AIRGAP_CLUSTER_NAME: airgap-wl
+          OCI_REGISTRY: localhost:5001
+          WORKLOAD_REGISTRY_HOST: knr-registry-airgap
+
+      - name: Store Zarf package
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: knr-ops-airgap-arm64
+          path: |
+            airgap/archives/
+            airgap/config-artifact/
+            airgap/zarf-package-knr-ops-airgap-*.tar.zst
+          if-no-files-found: error
+          retention-days: 1
+
+  offline-deploy:
+    name: Deploy without external egress
+    needs: build
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7.0.1
+
+      - name: Install mise
+        uses: jdx/mise-action@v4.2.3
+        with:
+          version: 2026.8.10
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Download air-gap bundle
+        uses: actions/download-artifact@v8.0.0
+        with:
+          name: knr-ops-airgap-arm64
+          path: airgap
+
+      - name: Run deployment on an internal Docker network
+        env:
+          SKIP_OFFLINE_CHECK: "1"
+        run: |
+          set -uo pipefail
+
+          capture=/tmp/airgap-public-egress.pcap
+          firewall_comment=knr-airgap-egress
+          bridge_interface=
+
+          cleanup() {
+            if [ -n "$bridge_interface" ]; then
+              sudo iptables -D DOCKER-USER \
+                -i "$bridge_interface" ! -o "$bridge_interface" \
+                -m conntrack --ctstate NEW \
+                -m comment --comment "$firewall_comment" -j DROP \
+                2>/dev/null || true
+            fi
+          }
+          trap cleanup EXIT
+
+          if docker network inspect kind >/dev/null 2>&1; then
+            if [ "$(docker network inspect kind --format '{{.Internal}}')" = "true" ]; then
+              docker network rm kind >/dev/null
+            fi
+          fi
+          docker network inspect kind >/dev/null 2>&1 || \
+            docker network create kind >/dev/null
+
+          network_id=$(docker network inspect kind --format '{{.Id}}')
+          bridge_interface="br-${network_id:0:12}"
+          sudo iptables -I DOCKER-USER 1 \
+            -i "$bridge_interface" ! -o "$bridge_interface" \
+            -m conntrack --ctstate NEW \
+            -m comment --comment "$firewall_comment" -j DROP
+          if ! sudo iptables -C DOCKER-USER \
+            -i "$bridge_interface" ! -o "$bridge_interface" \
+            -m conntrack --ctstate NEW \
+            -m comment --comment "$firewall_comment" -j DROP; then
+            echo "::error::Failed to block external egress from the kind network"
+            exit 1
+          fi
+
+          sudo tcpdump \
+            -i "$bridge_interface" \
+            -w "$capture" \
+            '(ip and not dst net 10.0.0.0/8 and not dst net 172.16.0.0/12 and not dst net 192.168.0.0/16 and not dst net 127.0.0.0/8 and not dst net 169.254.0.0/16 and not multicast) or (ip6 and not dst net fc00::/7 and not dst net fe80::/10 and not dst host ::1 and not multicast)' &
+          tcpdump_pid=$!
+
+          sleep 1
+          if ! sudo kill -0 "$tcpdump_pid" 2>/dev/null; then
+            echo "::error::Traffic capture failed to start"
+            wait "$tcpdump_pid"
+            exit 1
+          fi
+
+          if airgap/scripts/offline-run.sh \
+            airgap/zarf-package-knr-ops-airgap-*.tar.zst; then
+            deploy_result=0
+          else
+            deploy_result=$?
+          fi
+
+          sudo kill "$tcpdump_pid" 2>/dev/null || true
+          wait "$tcpdump_pid" 2>/dev/null || true
+          sudo tcpdump -n -r "$capture" \
+            > /tmp/airgap-public-egress.txt 2>/dev/null
+
+          if [ -s /tmp/airgap-public-egress.txt ]; then
+            echo "::error::Public network traffic occurred during the offline deployment"
+            cat /tmp/airgap-public-egress.txt
+            exit 1
+          fi
+
+          exit "$deploy_result"
+
+      - name: Store offline deployment evidence
+        if: always()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: knr-ops-airgap-isolated-results
+          path: |
+            /tmp/airgap-offline-run.log
+            /tmp/airgap-offline-summary.txt
+            /tmp/airgap-public-egress.pcap
+            /tmp/airgap-public-egress.txt
+          if-no-files-found: warn
+          retention-days: 1
+
+  monitored-deploy:
+    name: Deploy while monitoring public traffic
+    needs: build
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7.0.1
+
+      - name: Install mise
+        uses: jdx/mise-action@v4.2.3
+        with:
+          version: 2026.8.10
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Download air-gap bundle
+        uses: actions/download-artifact@v8.0.0
+        with:
+          name: knr-ops-airgap-arm64
+          path: airgap
+
+      - name: Run offline deployment and monitor traffic
+        env:
+          SKIP_OFFLINE_CHECK: "1"
+        run: |
+          set -uo pipefail
+
+          docker network inspect kind >/dev/null 2>&1 || \
+            docker network create kind >/dev/null
+          network_id=$(docker network inspect kind --format '{{.Id}}')
+          bridge_interface="br-${network_id:0:12}"
+          capture=/tmp/airgap-public-egress.pcap
+
+          sudo tcpdump \
+            -i "$bridge_interface" \
+            -w "$capture" \
+            '(ip and not dst net 10.0.0.0/8 and not dst net 172.16.0.0/12 and not dst net 192.168.0.0/16 and not dst net 127.0.0.0/8 and not dst net 169.254.0.0/16 and not multicast) or (ip6 and not dst net fc00::/7 and not dst net fe80::/10 and not dst host ::1 and not multicast)' &
+          tcpdump_pid=$!
+
+          sleep 1
+          if ! sudo kill -0 "$tcpdump_pid" 2>/dev/null; then
+            echo "::error::Traffic capture failed to start"
+            wait "$tcpdump_pid"
+            exit 1
+          fi
+
+          if airgap/scripts/offline-run.sh \
+            airgap/zarf-package-knr-ops-airgap-*.tar.zst; then
+            deploy_result=0
+          else
+            deploy_result=$?
+          fi
+
+          sudo kill "$tcpdump_pid" 2>/dev/null || true
+          wait "$tcpdump_pid" 2>/dev/null || true
+          sudo tcpdump -n -r "$capture" \
+            > /tmp/airgap-public-egress.txt 2>/dev/null
+
+          if [ -s /tmp/airgap-public-egress.txt ]; then
+            echo "::error::Public network traffic occurred during the offline deployment"
+            cat /tmp/airgap-public-egress.txt
+            exit 1
+          fi
+
+          exit "$deploy_result"
+
+      - name: Store monitored deployment evidence
+        if: always()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: knr-ops-airgap-monitored-results
+          path: |
+            /tmp/airgap-offline-run.log
+            /tmp/airgap-offline-summary.txt
+            /tmp/airgap-public-egress.pcap
+            /tmp/airgap-public-egress.txt
+          if-no-files-found: warn
+          retention-days: 1

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ suspends Flux and removes the AWS-managed infrastructure.
 | [docs/secrets.md](docs/secrets.md) | SOPS + age secret management, key setup, credential rotation |
 | [docs/operations.md](docs/operations.md) | Prerequisites, AWS service quotas, configuration, bootstrap, verification, teardown, validation |
 | [docs/extending.md](docs/extending.md) | Adding a workload cluster, adding apps to the workload clusters, adding other providers (Azure, Talos, k0smotron) |
-| [docs/airgap.md](docs/airgap.md) | Zarf air-gap kit: package build, offline deploy, verification checklist, update drill |
+| [docs/airgap.md](docs/airgap.md) | Zarf air-gap bundle: workflow-bootstrapped local OCI registry, package build, offline deploy, verification checklist, update drill |
 
 ## Repository layout
 

--- a/airgap/scripts/build-config-artifact.sh
+++ b/airgap/scripts/build-config-artifact.sh
@@ -20,7 +20,8 @@ cd "$REPO_ROOT"
 REGISTRY_PORT="${REGISTRY_PORT:-5001}"
 OCI_REPOSITORY="${OCI_REPOSITORY:-knr-ops-airgap}"
 OCI_TAG="${OCI_TAG:-latest}"
-OCI_URL="oci://localhost:${REGISTRY_PORT}/${OCI_REPOSITORY}:${OCI_TAG}"
+OCI_REGISTRY="${OCI_REGISTRY:-localhost:${REGISTRY_PORT}}"
+OCI_URL="oci://${OCI_REGISTRY}/${OCI_REPOSITORY}:${OCI_TAG}"
 
 ARTIFACT_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/knr-ops-airgap-oci.XXXXXX")
 cleanup() { rm -rf "$ARTIFACT_ROOT"; }
@@ -226,7 +227,8 @@ PY
 if [ -n "${WORKLOAD_REGISTRY_HOST:-}" ] && [ "$WORKLOAD_REGISTRY_HOST" != "knr-registry" ]; then
   echo "==> Rewriting workload registry references to '${WORKLOAD_REGISTRY_HOST}'"
   grep -rl "knr-registry" "$ARTIFACT_ROOT" | while IFS= read -r f; do
-    sed -i '' "s/knr-registry/${WORKLOAD_REGISTRY_HOST}/g" "$f"
+    sed -i.bak "s|knr-registry|${WORKLOAD_REGISTRY_HOST}|g" "$f"
+    rm -f "${f}.bak"
   done
 fi
 
@@ -301,7 +303,8 @@ EOF
 if [ -n "${AIRGAP_CLUSTER_NAME:-}" ]; then
   echo "==> Renaming workload cluster to '${AIRGAP_CLUSTER_NAME}' in the artifact copy"
   grep -rl "local-workload" "$LH" | while IFS= read -r f; do
-    sed -i '' "s/local-workload/${AIRGAP_CLUSTER_NAME}/g" "$f"
+    sed -i.bak "s|local-workload|${AIRGAP_CLUSTER_NAME}|g" "$f"
+    rm -f "${f}.bak"
   done
 fi
 
@@ -312,18 +315,26 @@ SOURCE_URL=$(git config --get remote.origin.url || true)
 SOURCE_URL="${SOURCE_URL:-file://${REPO_ROOT}}"
 
 echo "==> Pushing airgap config artifact ${OCI_URL}"
-flux push artifact "$OCI_URL" \
-  --path="$ARTIFACT_ROOT" \
-  --source="$SOURCE_URL" \
-  --revision="${GIT_REF}@sha1:${GIT_SHA}" \
-  --insecure-registry \
+PUSH_ARGS=(
+  "$OCI_URL"
+  --path="$ARTIFACT_ROOT"
+  --source="$SOURCE_URL"
+  --revision="${GIT_REF}@sha1:${GIT_SHA}"
   --reproducible
+)
+if [[ "$OCI_REGISTRY" == localhost:* ]]; then
+  PUSH_ARGS+=(--insecure-registry)
+fi
+if [ -n "${OCI_USERNAME:-}" ] && [ -n "${OCI_PASSWORD:-}" ]; then
+  PUSH_ARGS+=(--creds "${OCI_USERNAME}:${OCI_PASSWORD}")
+fi
+flux push artifact "${PUSH_ARGS[@]}"
 
-# Keep a plain-directory copy of the tree in the kit: the gap-side stage
+# Keep a plain-directory copy of the tree in the bundle: the gap-side stage
 # script re-pushes it into knr-registry as knr-ops:latest for the workload
 # cluster's Flux (which does not talk to the Zarf registry).
 rm -rf "$REPO_ROOT/airgap/config-artifact"
 cp -R "$ARTIFACT_ROOT" "$REPO_ROOT/airgap/config-artifact"
-echo "==> Kit copy at airgap/config-artifact/ ($(du -sh "$REPO_ROOT/airgap/config-artifact" | cut -f1))"
+echo "==> Bundle copy at airgap/config-artifact/ ($(du -sh "$REPO_ROOT/airgap/config-artifact" | cut -f1))"
 
-echo "==> Done. zarf.yaml's knr-ops-config component references localhost:${REGISTRY_PORT}/${OCI_REPOSITORY}:${OCI_TAG}"
+echo "==> Done. Config artifact: ${OCI_REGISTRY}/${OCI_REPOSITORY}:${OCI_TAG}"

--- a/airgap/scripts/build-package.sh
+++ b/airgap/scripts/build-package.sh
@@ -2,10 +2,9 @@
 # build-package.sh — connected-side package build.
 #
 #   1. mise run validate (all overlays still build)
-#   2. build-config-artifact.sh (trimmed airgap tree -> localhost:5001 OCI)
-#   3. stage workload-node pod images into archives/ (host-daemon tarball for
-#      CAPD preLoadImages; distinct from the mgmt substrate images the Zarf
-#      package pushes into the internal registry)
+#   2. build-config-artifact.sh (trimmed airgap tree -> configured OCI registry)
+#   3. stage the Zarf init package, host-daemon images, workload-node pod
+#      images, and OCI charts into archives/
 #   4. zarf package create
 #
 # Output: zarf-package-knr-ops-airgap-arm64-0.1.0.tar.zst next to airgap/.
@@ -21,8 +20,50 @@ mise run validate
 echo "==> 2/4 config artifact"
 "$SCRIPT_DIR/build-config-artifact.sh"
 
-echo "==> 3/4 workload-node pod images + OCI charts"
+# The package must pull the same config artifact that the preceding step
+# published. Builds retain zarf.yaml's localhost:5001 default unless an
+# alternate OCI_REGISTRY is explicitly supplied, so rewrite only the working
+# tree for package creation when an override is present.
+if [ -n "${OCI_REGISTRY:-}" ]; then
+  OCI_REPOSITORY="${OCI_REPOSITORY:-knr-ops-airgap}"
+  OCI_TAG="${OCI_TAG:-latest}"
+  python3 - airgap/zarf.yaml "${OCI_REGISTRY}/${OCI_REPOSITORY}:${OCI_TAG}" <<'PY'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+replacement = sys.argv[2]
+text = path.read_text()
+expected = "localhost:5001/knr-ops-airgap:latest"
+if expected not in text:
+    raise SystemExit(f"ERROR: expected config artifact reference {expected!r}")
+path.write_text(text.replace(expected, replacement, 1))
+print(f"    zarf config artifact: {replacement}")
+PY
+fi
+
+echo "==> 3/4 offline host assets, workload-node images, and OCI charts"
 mkdir -p airgap/archives
+
+mise x -- zarf tools download-init \
+  --architecture arm64 \
+  --output-directory airgap/archives
+
+HOST_IMAGES=(
+  kindest/node:v1.36.1
+  kindest/node:v1.35.0
+  kindest/haproxy:v20230606-42a2262b
+  docker.io/library/registry:2
+)
+for img in "${HOST_IMAGES[@]}"; do
+  docker pull --platform linux/arm64 "$img" >/dev/null
+done
+docker save -o airgap/archives/kindest_node_v1.36.1_mgmt.tar kindest/node:v1.36.1
+docker save -o airgap/archives/kindest_node_v1.35.0.tar kindest/node:v1.35.0
+docker save -o airgap/archives/kindest_haproxy_v20230606-42a2262b.tar kindest/haproxy:v20230606-42a2262b
+docker save -o airgap/archives/docker.io_library_registry_2.tar docker.io/library/registry:2
+echo "    saved Zarf init package and host-daemon image archives"
+
 WORKLOAD_IMAGES=(
   registry.k8s.io/pause:3.10.1
   docker.io/kindest/kindnetd:v20260528-9350166c

--- a/airgap/scripts/offline-run.sh
+++ b/airgap/scripts/offline-run.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# offline-run.sh — autonomous Wi-Fi-off validation of the knr-ops airgap kit.
+# offline-run.sh — autonomous Wi-Fi-off validation of the knr-ops airgap bundle.
 #
 # This script is designed to run with NO operator and NO LLM/agent attached:
 # it waits until the internet is unreachable, runs the full deploy, verifies,
@@ -18,14 +18,18 @@ LOG=/tmp/airgap-offline-run.log
 SUMMARY=/tmp/airgap-offline-summary.txt
 AIRGAP_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 ARCHIVES="$AIRGAP_DIR/archives"
+PACKAGE_INPUT="${1:-$ARCHIVES/zarf-package-knr-ops-airgap-arm64-0.1.0.tar.zst}"
+PACKAGE_DIR=$(cd "$(dirname "$PACKAGE_INPUT")" && pwd)
+PACKAGE="$PACKAGE_DIR/$(basename "$PACKAGE_INPUT")"
 
-# Direct binary paths (offline-safe; no mise/network resolution).
-ZARF="$HOME/.local/share/mise/installs/github-zarf-dev-zarf/v0.83.0/zarf"
-FLUX=/opt/homebrew/bin/flux
-HELM=/opt/homebrew/bin/helm
-KIND=/opt/homebrew/bin/kind
-KUBECTL=/usr/local/bin/kubectl
-DOCKER=/usr/local/bin/docker
+# Resolve the already-installed tools before going offline. This supports both
+# the macOS operator workflow and Linux CI without invoking mise in the gap.
+ZARF=$(command -v zarf)
+FLUX=$(command -v flux)
+HELM=$(command -v helm)
+KIND=$(command -v kind)
+KUBECTL=$(command -v kubectl)
+DOCKER=$(command -v docker)
 export KUBECONFIG="$HOME/.kube/config"
 
 export CLUSTER_NAME=airgap-mgmt
@@ -41,20 +45,24 @@ fail() { echo "FAIL: $*" | tee -a "$SUMMARY"; }
 : > "$SUMMARY"
 {
 step "0. waiting for Wi-Fi to go OFF (internet unreachable)..."
-online_deadline=$(( $(date +%s) + ${OFFLINE_WAIT_SECONDS:-900} ))
-while true; do
-  if ! curl -s --max-time 3 https://ghcr.io >/dev/null 2>&1 && \
-     ! curl -s --max-time 3 https://registry.k8s.io >/dev/null 2>&1; then
-    echo "internet unreachable -> OFFLINE confirmed"
-    break
-  fi
-  if [ "$(date +%s)" -ge "$online_deadline" ]; then
-    echo "TIMEOUT waiting for Wi-Fi off; aborting."
-    fail "never went offline within ${OFFLINE_WAIT_SECONDS:-900}s"
-    exit 1
-  fi
-  sleep 5
-done
+if [ "${SKIP_OFFLINE_CHECK:-0}" = "1" ]; then
+  echo "offline connectivity check skipped; external traffic is monitored by the caller"
+else
+  online_deadline=$(( $(date +%s) + ${OFFLINE_WAIT_SECONDS:-900} ))
+  while true; do
+    if ! curl -s --max-time 3 https://ghcr.io >/dev/null 2>&1 && \
+       ! curl -s --max-time 3 https://registry.k8s.io >/dev/null 2>&1; then
+      echo "internet unreachable -> OFFLINE confirmed"
+      break
+    fi
+    if [ "$(date +%s)" -ge "$online_deadline" ]; then
+      echo "TIMEOUT waiting for Wi-Fi off; aborting."
+      fail "never went offline within ${OFFLINE_WAIT_SECONDS:-900}s"
+      exit 1
+    fi
+    sleep 5
+  done
+fi
 
 step "1. stage: docker load + kind create + seed registry"
 if CLUSTER_NAME=$CLUSTER_NAME REGISTRY_NAME=$REGISTRY_NAME REGISTRY_PORT=$REGISTRY_PORT \
@@ -62,6 +70,7 @@ if CLUSTER_NAME=$CLUSTER_NAME REGISTRY_NAME=$REGISTRY_NAME REGISTRY_PORT=$REGIST
   pass "stage (docker load, kind create, registry seed)"
 else
   fail "stage-and-create-cluster.sh"
+  exit 1
 fi
 
 step "2. zarf init"
@@ -70,13 +79,15 @@ if ( cd "$AIRGAP_DIR" && "$ZARF" init "$ARCHIVES/zarf-init-arm64-v0.83.0.tar.zst
   pass "zarf init"
 else
   fail "zarf init"
+  exit 1
 fi
 
 step "3. zarf package deploy"
-if ( cd "$AIRGAP_DIR" && "$ZARF" package deploy "$ARCHIVES/zarf-package-knr-ops-airgap-arm64-0.1.0.tar.zst" --confirm ); then
+if ( cd "$AIRGAP_DIR" && "$ZARF" package deploy "$PACKAGE" --confirm ); then
   pass "zarf package deploy"
 else
   fail "zarf package deploy"
+  exit 1
 fi
 
 step "4. verify mgmt substrate (all non-baked images from 127.0.0.1:31999)"
@@ -133,6 +144,14 @@ if [ -n "$port" ]; then
 
   wlf=$("$KUBECTL" --kubeconfig="$WL_KCFG" -n flux-system get ocirepository flux-system \
     -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null)
+  # The workload API can become reachable before its Flux source has been
+  # created and reconciled. Allow that asynchronous handoff to complete.
+  for i in $(seq 1 20); do
+    [ "$wlf" = "True" ] && break
+    sleep 15
+    wlf=$("$KUBECTL" --kubeconfig="$WL_KCFG" -n flux-system get ocirepository flux-system \
+      -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null)
+  done
   [ "$wlf" = "True" ] && pass "workload Flux sync Ready from knr-registry" || fail "workload Flux sync ready=$wlf"
 
   podinfo=$("$KUBECTL" --kubeconfig="$WL_KCFG" -n podinfo get pods --no-headers 2>/dev/null | grep -c " Running ")
@@ -156,4 +175,4 @@ else
   cat "$SUMMARY"
   exit 0
 fi
-} > "$LOG" 2>&1
+} 2>&1 | tee "$LOG"

--- a/airgap/scripts/stage-and-create-cluster.sh
+++ b/airgap/scripts/stage-and-create-cluster.sh
@@ -24,6 +24,12 @@ ARCHIVES="$AIRGAP_DIR/archives"
 
 CLUSTER_NAME="${CLUSTER_NAME:-mgmt}"
 KIND_NODE_IMAGE="${KIND_NODE_IMAGE:-kindest/node:v1.36.1}"
+DOCKER_SOCKET_PATH="${DOCKER_SOCKET_PATH:-/var/run/docker.sock}"
+
+if [ ! -S "$DOCKER_SOCKET_PATH" ]; then
+  echo "ERROR: Docker socket does not exist: ${DOCKER_SOCKET_PATH}" >&2
+  exit 1
+fi
 
 echo ">>> Loading image archives into the host Docker daemon..."
 for tar in "$ARCHIVES"/*.tar; do
@@ -41,7 +47,7 @@ apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
     extraMounts:
-      - hostPath: /var/run/docker.sock
+      - hostPath: ${DOCKER_SOCKET_PATH}
         containerPath: /var/run/docker.sock
 EOF
 fi
@@ -56,10 +62,17 @@ REGISTRY_PORT="${REGISTRY_PORT:-5001}"
 if ! docker ps --filter "name=^${REGISTRY_NAME}$" --format '{{.Names}}' | grep -q "$REGISTRY_NAME"; then
   echo ">>> Creating registry container '${REGISTRY_NAME}' (localhost:${REGISTRY_PORT})..."
   docker rm -f "$REGISTRY_NAME" >/dev/null 2>&1 || true
-  docker run -d --name "$REGISTRY_NAME" --network kind -p "127.0.0.1:${REGISTRY_PORT}:5000" registry:2 >/dev/null
+  docker run -d --name "$REGISTRY_NAME" --network kind \
+    -p "127.0.0.1:${REGISTRY_PORT}:5000" registry:2 >/dev/null
 fi
-curl --fail --silent --retry 10 --retry-connrefused --retry-delay 1 \
-  "http://localhost:${REGISTRY_PORT}/v2/" >/dev/null
+if ! curl --fail --show-error --silent --max-time 2 \
+  --retry 15 --retry-all-errors --retry-delay 1 \
+  "http://localhost:${REGISTRY_PORT}/v2/" >/dev/null; then
+  echo "ERROR: registry '${REGISTRY_NAME}' did not become ready" >&2
+  docker ps -a --filter "name=^${REGISTRY_NAME}$" >&2
+  docker logs "$REGISTRY_NAME" >&2 || true
+  exit 1
+fi
 
 # Seed knr-registry: the knr-ops config artifact (workload/local-host syncs
 # from it) and the two OCI charts (flux-operator for the HelmChartProxy,
@@ -67,7 +80,7 @@ curl --fail --silent --retry 10 --retry-connrefused --retry-delay 1 \
 echo ">>> Seeding ${REGISTRY_NAME} with the config artifact + charts..."
 flux push artifact "oci://localhost:${REGISTRY_PORT}/knr-ops:latest" \
   --path="$AIRGAP_DIR/config-artifact" \
-  --source="airgap-kit" \
+  --source="airgap-bundle" \
   --revision="airgap@sha1:$(git -C "$AIRGAP_DIR" rev-parse HEAD 2>/dev/null || echo unknown)" \
   --insecure-registry \
   --reproducible

--- a/docs/airgap.md
+++ b/docs/airgap.md
@@ -14,7 +14,7 @@ re-verify.
 
 ## Prerequisites
 
-The kit is single-architecture (arm64), including the pinned Zarf CLI. The
+The bundle is single-architecture (arm64), including the pinned Zarf CLI. The
 mise pin in `mise.toml` selects the matching Linux or macOS arm64 release
 asset. Docker and kind are also required on the deploy host (the prototype
 keeps kind as the management-cluster substrate; see Known limitations).
@@ -59,7 +59,7 @@ Zarf package and is published into Zarf's internal registry at deploy time.
 The verification linchpin is the agent's **image rewrite** plus a Ready
 `OCIRepository` pointing at the internal registry, with the radio off.
 
-## What crosses the gap (the kit)
+## What crosses the gap (the bundle)
 
 | Item | Purpose |
 |---|---|
@@ -81,6 +81,14 @@ Connected (build):
 ```sh
 airgap/scripts/build-package.sh   # validate, artifact, images, charts, zarf package create
 ```
+
+The `air-gapped` GitHub Actions workflow is self-contained: its build job
+starts an ephemeral `registry:2` container on `localhost:5001` before running
+`build-package.sh`. The config artifact is pushed to that local OCI registry
+and then embedded in the bundle by Zarf. The workflow does not publish the
+artifact to GHCR, does not log in to GHCR, and needs no package-write
+permission. A manual connected-side build must provide the equivalent local
+registry before invoking the script.
 
 Gap (deploy) — from `airgap/`:
 


### PR DESCRIPTION
## Summary

- add an ARM64 air-gap package workflow triggered on updates to its fork branch or by manual dispatch
- install pinned build tools with mise and authenticate to GHCR with `docker/login-action`
- publish the Flux configuration as an OCI artifact in GHCR while retaining the local-registry default for local builds
- make the pinned Zarf installation portable across Linux and macOS ARM64
- build the complete Zarf air-gap package on GitHub-hosted Ubuntu ARM64 and store its `.tar.zst` as a workflow artifact

## Testing

- fork workflow passed: https://github.com/lmilbaum/knr-ops/actions/runs/32382702623
- OCI artifact published to `ghcr.io/lmilbaum/knr-ops-airgap:latest`
- Zarf package uploaded as workflow artifact `knr-ops-airgap-arm64`
- PR contains one squashed commit