### PR TITLE
fix: select native Zarf asset in mise

### DIFF
--- a/docs/airgap.md
+++ b/docs/airgap.md
@@ -14,13 +14,10 @@ re-verify.
 
 ## Prerequisites
 
-The kit is single-architecture (arm64), including the pinned Zarf CLI: the
-mise pin in `mise.toml` (`asset_pattern = "zarf_v0.83.0_Darwin_arm64"`)
-resolves only on macOS/arm64, so `mise install` fails on other platforms
-with a confusing asset-not-found error. On Linux, adjust the pin to the
-matching `Linux_*` release asset first. Docker and kind are also required
-on the deploy host (the prototype keeps kind as the management-cluster
-substrate; see Known limitations).
+The kit is single-architecture (arm64), including the pinned Zarf CLI. The
+mise pin in `mise.toml` selects the matching Linux or macOS arm64 release
+asset. Docker and kind are also required on the deploy host (the prototype
+keeps kind as the management-cluster substrate; see Known limitations).
 
 ## Architecture
 

--- a/mise.toml
+++ b/mise.toml
@@ -9,12 +9,11 @@ sops = "latest"
 age = "latest"
 
 # Zarf CLI (airgap prototype). The mise github backend downloads the raw
-# release asset and keeps its original filename, so we pin the exact asset
-# and use `bin` to name the binary `zarf`. asset_pattern is Darwin/arm64
-# (this prototype targets the local arm64 host; adjust for other platforms).
+# release asset and keeps its original filename, so we select the native
+# Linux/macOS arm64 asset and use `bin` to name the binary `zarf`.
 [tools."github:zarf-dev/zarf"]
 version = "v0.83.0"
-asset_pattern = "zarf_v0.83.0_Darwin_arm64"
+asset_pattern = 'zarf_v{{ version }}_{{ os(linux="Linux", macos="Darwin") }}_{{ arch() }}'
 bin = "zarf"
 
 [settings]

--- a/mise.toml
+++ b/mise.toml
@@ -13,7 +13,7 @@ age = "latest"
 # Linux/macOS arm64 asset and use `bin` to name the binary `zarf`.
 [tools."github:zarf-dev/zarf"]
 version = "v0.83.0"
-asset_pattern = 'zarf_v0.83.0_{{ os(linux="Linux", macos="Darwin") }}_{{ arch() }}'
+asset_pattern = 'zarf_v{{ version }}_{{ os(linux="Linux", macos="Darwin") }}_{{ arch() }}'
 bin = "zarf"
 
 [settings]

--- a/mise.toml
+++ b/mise.toml
@@ -13,7 +13,7 @@ age = "latest"
 # Linux/macOS arm64 asset and use `bin` to name the binary `zarf`.
 [tools."github:zarf-dev/zarf"]
 version = "v0.83.0"
-asset_pattern = 'zarf_v{{ version }}_{{ os(linux="Linux", macos="Darwin") }}_{{ arch() }}'
+asset_pattern = 'zarf_v0.83.0_{{ os(linux="Linux", macos="Darwin") }}_{{ arch() }}'
 bin = "zarf"
 
 [settings]


### PR DESCRIPTION
## Summary

- select the native Linux or macOS arm64 Zarf release asset in mise
- update the air-gap prerequisites to match

## Testing

- `mise run validate`