### PR TITLE
chore: require mise 2026.8.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ not a developer self-service portal; you are the consumer.
 
 ## Prerequisites
 
-- Mise
+- Mise 2026.8.10 or newer
 - A running Docker engine, or Podman 5.5+, for kind; the local-host profile
   also uses it for its local OCI registry
 - AWS profile only: GitHub personal access token (PAT) with read access to this

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -2,8 +2,8 @@
 
 ## Prerequisites
 
-Tool versions are pinned in `mise.toml`. With [mise](https://mise.jdx.dev/)
-installed:
+Tool versions are pinned in `mise.toml`, which requires mise 2026.8.10 or
+newer. With [mise](https://mise.jdx.dev/) installed:
 
 ```sh
 mise install

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,5 @@
+min_version = "2026.8.10"
+
 [tools]
 go = "1.26"
 kubectl = "1.35"


### PR DESCRIPTION
## Summary

- require mise 2026.8.10 or newer through the project configuration
- document the minimum supported mise version in the README and operations guide
- leave automated version updates to a later Renovate change

## Testing

- validation commands from `mise run validate` passed when run directly
- `git diff --check` passed
- confirmed the new guard rejects local mise 2026.8.9 with the expected upgrade message