### PR TITLE
fix: make air-gap sed rewrites portable

### DIFF
--- a/airgap/scripts/build-config-artifact.sh
+++ b/airgap/scripts/build-config-artifact.sh
@@ -226,7 +226,8 @@ PY
 if [ -n "${WORKLOAD_REGISTRY_HOST:-}" ] && [ "$WORKLOAD_REGISTRY_HOST" != "knr-registry" ]; then
   echo "==> Rewriting workload registry references to '${WORKLOAD_REGISTRY_HOST}'"
   grep -rl "knr-registry" "$ARTIFACT_ROOT" | while IFS= read -r f; do
-    sed -i '' "s/knr-registry/${WORKLOAD_REGISTRY_HOST}/g" "$f"
+    sed -i.bak "s|knr-registry|${WORKLOAD_REGISTRY_HOST}|g" "$f"
+    rm -f "${f}.bak"
   done
 fi
 
@@ -301,7 +302,8 @@ EOF
 if [ -n "${AIRGAP_CLUSTER_NAME:-}" ]; then
   echo "==> Renaming workload cluster to '${AIRGAP_CLUSTER_NAME}' in the artifact copy"
   grep -rl "local-workload" "$LH" | while IFS= read -r f; do
-    sed -i '' "s/local-workload/${AIRGAP_CLUSTER_NAME}/g" "$f"
+    sed -i.bak "s|local-workload|${AIRGAP_CLUSTER_NAME}|g" "$f"
+    rm -f "${f}.bak"
   done
 fi
 


### PR DESCRIPTION
## Summary

- replace BSD-only `sed -i ''` calls with portable backup-suffix edits
- remove the temporary backup files after each rewrite
- isolate the smallest Linux-runner prerequisite from #42

## Testing

- `bash -n airgap/scripts/build-config-artifact.sh`
- exercised both replacements against a temporary file on macOS
- `git diff --check`