### PR TITLE
docs: fix drift found in accuracy audit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,8 +38,8 @@ resources. There is no app source code here, only declarative infrastructure.
    commit plaintext secrets; `age.agekey` and `.env` are gitignored and must
    stay that way. Encrypt with `mise run sops-encrypt <file>`.
 4. Run `mise run validate` before pushing. PRs are reviewed as rendered Flux
-   diffs by the in-cluster konflate instance, so what you push is what gets
-   reviewed.
+   diffs by the konflate GitHub Actions workflow (backed by an in-cluster
+   instance), so what you push is what gets reviewed.
 
 ## App layout convention
 
@@ -76,7 +76,7 @@ Load these only when the task touches their domain:
 - `docs/architecture.md`: reconciliation order, how workload apps are delivered.
 - `docs/extending.md`: adding a workload cluster, adding apps, adding other providers (Azure, Talos, k0smotron).
 - `docs/secrets.md`: SOPS + age setup, credential rotation.
-- `docs/konflate.md`: rendered PR review, tokens, write-back.
+- `docs/konflate.md`: rendered PR review, CI gate, tokens, write-back.
 - `docs/aws-iam.md`: EKS Pod Identity, ACK controller roles, reader user.
 - `docs/operations.md`: quotas, configuration, bootstrap, verification.
 - `docs/workload-resources.md`: S3/RDS posture, known limitations.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -143,11 +143,14 @@ The management cluster also runs a single
 (`github://polarsquad/knr-ops`, rendering from the repo root). It renders each
 open PR at its merge-base and head and shows the diff of the *rendered* Flux
 output — blast radius, image changes, render failures, and danger lint —
-instead of the raw file diff. Konflate posts the rendered summary as a PR
-comment and a `Konflate` commit status itself (**write-back** — outbound-only,
-so the local kind cluster needs no inbound reachability from GitHub, and no CI
-job is involved). Full details (deployment, tokens, write-back, UI access):
-[PR review: konflate](./konflate.md).
+instead of the raw file diff. Results reach the PR two ways: a GitHub Actions
+workflow (`.github/workflows/konflate.yml`) runs a one-shot konflate service
+container on each PR push and gates the `konflate / Rendered Flux diff` check
+on a clean render, and the in-cluster instance posts the rendered summary
+comment and a `Konflate` commit status itself (write-back, outbound-only, so
+the local kind cluster needs no inbound reachability from GitHub). Both upsert
+the same marker-keyed comment. Full details (deployment, CI gate, tokens,
+write-back, UI access): [PR review: konflate](./konflate.md).
 
 ## Reconciliation order (each workload cluster)
 

--- a/docs/aws-iam.md
+++ b/docs/aws-iam.md
@@ -8,7 +8,7 @@ The ACK S3, RDS, and IAM controllers on the workload clusters carry
 - Each EKS control plane enables the `eks-pod-identity-agent` addon
   (declared in the CAPI cluster spec).
 - The **management** cluster runs ACK IAM + EKS controllers
-  (`infrastructure/ack-controllers/`, authenticated with the same
+  (`mgmt/aws/infrastructure/ack-controllers/`, authenticated with the same
   SOPS-encrypted credential pattern as CAPA) which declaratively create:
   - an IAM `Role` per controller, trusted by `pods.eks.amazonaws.com`:
     - `knr-ops-ack-s3-controller` — scoped to `knr-ops-*` buckets only

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -9,8 +9,10 @@ newer. With [mise](https://mise.jdx.dev/) installed:
 mise install
 ```
 
-This provides `kubectl`, `kind`, `helm`, `flux`, `clusterctl`, `clusterawsadm`,
-`aws-cli`, `go`, `sops`, and `age`.
+This provides `kubectl`, `kind`, `helm`, `flux`, `clusterctl`, `go`, `sops`,
+`age`, and the `zarf` CLI. The `aws` profile layers on `aws-cli` and
+`clusterawsadm` (`mise -E aws install`); the `local-host` profile needs no
+extra tools.
 
 You also need:
 


### PR DESCRIPTION
Audited README.md and all of docs/ against current repo state. The docs were in good shape; four stale spots fixed:

## Fixes

| File | Drift | Fix |
|---|---|---|
| docs/operations.md | Tool list claimed `mise install` provides `aws-cli`/`clusterawsadm` (both live in `mise.aws.toml`) and omitted `zarf` | Correct base tool list; note the aws profile layer |
| docs/architecture.md | Konflate section said "no CI job is involved" | Describes both paths now: the GHA gate (`konflate / Rendered Flux diff` check) + in-cluster write-back, matching docs/konflate.md |
| docs/aws-iam.md | Bare `infrastructure/ack-controllers/` path | Prefixed with `mgmt/aws/` like the rest of the doc |
| AGENTS.md | Golden rule 4 + konflate pointer predated the CI workflow | Mentions the GHA workflow |

## Verified accurate (no changes needed)

- **README.md**: resource counts (2 clusters, 4 node pools, 2 buckets, 2 RDS, 1 reader user, per-cluster reader roles), mise 2026.8.10 min_version, local-host task names, layout tree, docs table (all 8 targets exist incl. airgap.md).
- **docs/operations.md**: bootstrap step order, local-host registry wiring (`registry:2` on 127.0.0.1:5001, containerd mirror to `knr-registry:5000`), `LOCAL_RECONCILE_TIMEOUT` default 15m, `docker-workload-cluster` Kustomization name, workload k8s v1.35.0 + kindnet CNI, teardown sweep (RDS/S3/roles/user patterns all present in teardown.sh).
- **docs/secrets.md**: .sops.yaml path rule (`mgmt/aws/.*\.sops\.yaml`) and all four documented secret files exist at the documented paths.
- **docs/extending.md**: mgmt/aws + workload paths, provider versions (CAPI v1.14.0 core confirmed in providers.yaml), clusterctl registry claims.
- **docs/konflate.md**: in-cluster chart pin 0.5.0 == workflow image 0.5.0, clusterPath "" matches helm.yaml.
- **docs/workload-resources.md**: bucket posture (AES256, BucketOwnerEnforced, versioning, TLS-deny policy) and RDS config (postgres 17, db.t4g.micro, 20GiB gp3, manageMasterUserPassword, no dbSubnetGroupName) all match the CRs.
- **docs/airgap.md**: all six scripts exist; the kit table lists gitignored build outputs as designed (archives/, rendered/, config-artifact/ all ignored).