### PR TITLE
fix: make air-gap Docker socket configurable

### DIFF
--- a/airgap/scripts/stage-and-create-cluster.sh
+++ b/airgap/scripts/stage-and-create-cluster.sh
@@ -24,6 +24,12 @@ ARCHIVES="$AIRGAP_DIR/archives"
 
 CLUSTER_NAME="${CLUSTER_NAME:-mgmt}"
 KIND_NODE_IMAGE="${KIND_NODE_IMAGE:-kindest/node:v1.36.1}"
+DOCKER_SOCKET_PATH="${DOCKER_SOCKET_PATH:-/var/run/docker.sock}"
+
+if [ ! -S "$DOCKER_SOCKET_PATH" ]; then
+  echo "ERROR: Docker socket does not exist: ${DOCKER_SOCKET_PATH}" >&2
+  exit 1
+fi
 
 echo ">>> Loading image archives into the host Docker daemon..."
 for tar in "$ARCHIVES"/*.tar; do
@@ -41,7 +47,7 @@ apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
     extraMounts:
-      - hostPath: /var/run/docker.sock
+      - hostPath: ${DOCKER_SOCKET_PATH}
         containerPath: /var/run/docker.sock
 EOF
 fi


### PR DESCRIPTION
## Summary

- allow the gap-side staging script to use `DOCKER_SOCKET_PATH`
- retain `/var/run/docker.sock` as the default
- fail early with a clear error when the configured socket does not exist
- mount the configured host socket into the kind management node

Extracted as the next small, independent change from #42.

## Testing

- `bash -n airgap/scripts/stage-and-create-cluster.sh`
- verified a nonexistent `DOCKER_SOCKET_PATH` fails with the expected error
- `git diff --check`