### PR TITLE
feat: stream airgap run logs

### DIFF
--- a/airgap/scripts/offline-run.sh
+++ b/airgap/scripts/offline-run.sh
@@ -167,4 +167,4 @@ else
   cat "$SUMMARY"
   exit 0
 fi
-} > "$LOG" 2>&1
+} 2>&1 | tee "$LOG"


### PR DESCRIPTION
## Summary

- stream offline-run progress to stdout while retaining the complete log file
- preserve failures through the `tee` pipeline via the script’s existing `pipefail` setting

Extracted as the next focused slice of #42.

## Testing

- `bash -n airgap/scripts/offline-run.sh`
- `git diff --check`
- verified output reaches stdout and the log file
- verified a simulated exit status 7 remains 7 through the `tee` pipeline
- underlying repository validation commands: shell checks and every kustomize overlay passed

This branch contains one commit.