### PR TITLE
docs: clarify airgap isolation mode logging

### DIFF
--- a/airgap/scripts/offline-run.sh
+++ b/airgap/scripts/offline-run.sh
@@ -51,10 +51,11 @@ fail() { echo "FAIL: $*" | tee -a "$SUMMARY"; }
 
 : > "$SUMMARY"
 {
-step "0. waiting for Wi-Fi to go OFF (internet unreachable)..."
+step "0. establish offline isolation"
 if [ "${SKIP_OFFLINE_CHECK:-0}" = "1" ]; then
-  echo "offline connectivity check skipped; external traffic is monitored by the caller"
+  echo "isolation mode: caller-monitored (offline connectivity check skipped)"
 else
+  echo "isolation mode: self-checked (waiting for internet to become unreachable)"
   online_deadline=$(( $(date +%s) + ${OFFLINE_WAIT_SECONDS:-900} ))
   while true; do
     if ! curl -s --max-time 3 https://ghcr.io >/dev/null 2>&1 && \

--- a/docs/airgap.md
+++ b/docs/airgap.md
@@ -18,6 +18,11 @@ enforces network isolation and monitors external traffic for the full run; in
 that mode, the result log explicitly records that the connectivity check was
 skipped and caller-monitored.
 
+```sh
+# Caller must enforce isolation and monitor external traffic until completion.
+SKIP_OFFLINE_CHECK=1 airgap/scripts/offline-run.sh
+```
+
 ## Prerequisites
 
 The kit is single-architecture (arm64), including the pinned Zarf CLI. The


### PR DESCRIPTION
## Summary

- make the isolation step heading accurate in both self-checked and caller-monitored modes
- log the active isolation mode explicitly at the start of an offline run
- document the caller-monitored invocation with its operator responsibility

## Testing

- `bash -n airgap/scripts/offline-run.sh`
- `git diff --check main...HEAD`