### PR TITLE
docs: note airgap version pin coupling

### DIFF
--- a/airgap/scripts/build-package.sh
+++ b/airgap/scripts/build-package.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # build-package.sh — connected-side package build.
+# Version bumps must update HOST_IMAGES, mise.toml's Zarf pin, stage-and-create-cluster.sh's KIND_NODE_IMAGE, and cluster-class.yaml's customImage together.
 #
 #   1. mise run validate (all overlays still build)
 #   2. build-config-artifact.sh (trimmed airgap tree -> configured OCI registry)


### PR DESCRIPTION
## Summary

- document the coupled airgap version pins in the package builder header
- point future bumps to the host image list, Zarf mise pin, management kind image, and CAPD custom image

## Testing

- `bash -n airgap/scripts/build-package.sh`
- `git diff --check`