### PR TITLE
ci: build airgap transfer bundle

### DIFF
--- a/.github/workflows/air-gapped.yml
+++ b/.github/workflows/air-gapped.yml
@@ -1,0 +1,60 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: air-gapped
+
+on:
+  # Intentionally run for every PR: package inputs span the repository. A path
+  # filter could miss new inputs while still producing a successful but
+  # incomplete bundle.
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: air-gapped-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build air-gap bundle
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 15
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5001:5000
+        options: >-
+          --health-cmd "wget --spider --quiet http://localhost:5000/v2/"
+          --health-interval 2s
+          --health-timeout 5s
+          --health-retries 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7.0.1
+
+      - name: Install mise
+        uses: jdx/mise-action@v4.2.3
+        with:
+          version: 2026.8.10
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Build air-gap bundle
+        run: airgap/scripts/build-package.sh
+        env:
+          AIRGAP_CLUSTER_NAME: airgap-wl
+          OCI_REGISTRY: localhost:5001
+          WORKLOAD_REGISTRY_HOST: knr-registry-airgap
+
+      - name: Store air-gap bundle
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: knr-ops-airgap-arm64
+          path: |
+            airgap/archives/
+            airgap/config-artifact/
+            airgap/zarf-package-knr-ops-airgap-*.tar.zst
+          if-no-files-found: error
+          retention-days: 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,9 @@ resources. There is no app source code here, only declarative infrastructure.
 - `airgap/`: Zarf offline install kit for the local-host profile.
   `zarf.yaml` + `images.txt` define the packages; `scripts/` builds,
   renders, and stages the kit (`build-*`, `render-*`, `stage-*`,
-  `offline-run.sh`); `archives/` and `rendered/` are gitignored outputs.
+  `offline-run.sh`); `archives/` and `rendered/` are gitignored outputs. The
+  `air-gapped` workflow builds the ARM64 transfer bundle for every PR and for
+  manual dispatches.
 - `bootstrap.sh` / `teardown.sh`: the only imperative steps (one-time
   kind + Flux bootstrap, full teardown).
 - `docs/`: detailed documentation (see the table in README.md).

--- a/docs/airgap.md
+++ b/docs/airgap.md
@@ -85,6 +85,9 @@ The verification linchpin is the agent's **image rewrite** plus a Ready
 | `archives/charts/{flux-operator,podinfo}-*.tgz` | OCI charts seeded into knr-registry |
 | `config-artifact/` | trimmed GitOps tree, re-pushed as `knr-ops:latest` |
 
+The CI artifact excludes the `zarf` CLI; fetch it via mise or the Zarf release
+for the deploy host's target OS before crossing the gap.
+
 ## Sequence
 
 Connected (build):
@@ -92,6 +95,10 @@ Connected (build):
 ```sh
 airgap/scripts/build-package.sh   # validate, artifact, images, charts, zarf package create
 ```
+
+The `air-gapped` GitHub Actions workflow runs the same build on ARM64 for
+every pull request and for manual dispatches, then retains the generated
+transfer artifacts as a one-day workflow artifact.
 
 Gap (deploy) — from `airgap/`:
 


### PR DESCRIPTION
## Summary

- add an ARM64 GitHub Actions job for the connected-side airgap bundle build
- start an ephemeral local OCI registry and run the existing package builder
- upload the complete transfer bundle as a one-day workflow artifact
- document the new build workflow in the airgap guide and agent repository map

Deployment and network-isolation verification remain separate follow-up slices.

## Testing

- `bash -n` passed for all repository shell scripts
- all `mgmt/` and `workload/` overlays built successfully with `kubectl kustomize`
- `git diff --check` passed