### PR TITLE
ci: monitor airgap deployment traffic

### DIFF
--- a/.github/workflows/air-gapped.yml
+++ b/.github/workflows/air-gapped.yml
@@ -2,22 +2,21 @@
 name: air-gapped
 
 on:
-  # Intentionally run for every PR: package inputs span the repository. A path
-  # filter could miss new inputs while still producing a successful but
-  # incomplete bundle.
-  pull_request:
+  schedule:
+    - cron: "17 2 * * *"
   workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
-  group: air-gapped-${{ github.event.pull_request.number || github.ref }}
+  group: air-gapped-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   build:
     name: Build air-gap bundle
+    if: github.repository == 'polarsquad/knr-ops' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 15
     services:
@@ -57,4 +56,94 @@ jobs:
             airgap/config-artifact/
             airgap/zarf-package-knr-ops-airgap-*.tar.zst
           if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+
+  monitored-deploy:
+    name: Deploy while monitoring public traffic
+    needs: build
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7.0.1
+
+      - name: Install mise
+        uses: jdx/mise-action@v4.2.3
+        with:
+          version: 2026.8.10
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Download air-gap bundle
+        uses: actions/download-artifact@v8.0.0
+        with:
+          name: knr-ops-airgap-arm64
+          path: airgap
+
+      - name: Deploy and monitor public traffic
+        env:
+          SKIP_OFFLINE_CHECK: "1"
+        run: |
+          set -uo pipefail
+
+          docker network inspect kind >/dev/null 2>&1 || \
+            docker network create kind >/dev/null
+          network_id=$(docker network inspect kind --format '{{.Id}}')
+          bridge_interface="br-${network_id:0:12}"
+          capture=/tmp/airgap-public-egress.pcap
+          tcpdump_pid=
+
+          stop_capture() {
+            if [ -n "$tcpdump_pid" ]; then
+              sudo kill "$tcpdump_pid" 2>/dev/null || true
+              wait "$tcpdump_pid" 2>/dev/null || true
+              tcpdump_pid=
+            fi
+          }
+          trap stop_capture EXIT
+
+          sudo tcpdump \
+            -i "$bridge_interface" \
+            -w "$capture" \
+            '(ip and not dst net 10.0.0.0/8 and not dst net 172.16.0.0/12 and not dst net 192.168.0.0/16 and not dst net 127.0.0.0/8 and not dst net 169.254.0.0/16 and not multicast) or (ip6 and not dst net fc00::/7 and not dst net fe80::/10 and not dst host ::1 and not multicast)' &
+          tcpdump_pid=$!
+
+          sleep 1
+          if ! sudo kill -0 "$tcpdump_pid" 2>/dev/null; then
+            echo "::error::Traffic capture failed to start"
+            wait "$tcpdump_pid"
+            exit 1
+          fi
+
+          if airgap/scripts/offline-run.sh \
+            airgap/zarf-package-knr-ops-airgap-*.tar.zst; then
+            deploy_result=0
+          else
+            deploy_result=$?
+          fi
+
+          stop_capture
+          sudo tcpdump -n -r "$capture" \
+            > /tmp/airgap-public-egress.txt 2>/dev/null
+
+          if [ -s /tmp/airgap-public-egress.txt ]; then
+            echo "::error::Public network traffic occurred during the deployment"
+            cat /tmp/airgap-public-egress.txt
+            exit 1
+          fi
+
+          exit "$deploy_result"
+
+      - name: Store monitored deployment evidence
+        if: always()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: knr-ops-airgap-monitored-results
+          path: |
+            /tmp/airgap-offline-run.log
+            /tmp/airgap-offline-summary.txt
+            /tmp/airgap-public-egress.pcap
+            /tmp/airgap-public-egress.txt
+          if-no-files-found: warn
           retention-days: 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,8 +29,8 @@ resources. There is no app source code here, only declarative infrastructure.
   `zarf.yaml` + `images.txt` define the packages; `scripts/` builds,
   renders, and stages the kit (`build-*`, `render-*`, `stage-*`,
   `offline-run.sh`); `archives/` and `rendered/` are gitignored outputs. The
-  `air-gapped` workflow builds the ARM64 transfer bundle for every PR and for
-  manual dispatches.
+  `air-gapped` workflow builds the ARM64 transfer bundle and exercises a
+  monitored deployment only on upstream `main`, nightly or by manual dispatch.
 - `bootstrap.sh` / `teardown.sh`: the only imperative steps (one-time
   kind + Flux bootstrap, full teardown).
 - `docs/`: detailed documentation (see the table in README.md).

--- a/airgap/scripts/offline-run.sh
+++ b/airgap/scripts/offline-run.sh
@@ -152,6 +152,14 @@ if [ -n "$port" ]; then
 
   wlf=$("$KUBECTL" --kubeconfig="$WL_KCFG" -n flux-system get ocirepository flux-system \
     -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null)
+  # The workload API can become reachable before its Flux source has been
+  # created and reconciled. Allow that asynchronous handoff to complete.
+  for i in $(seq 1 20); do
+    [ "$wlf" = "True" ] && break
+    sleep 15
+    wlf=$("$KUBECTL" --kubeconfig="$WL_KCFG" -n flux-system get ocirepository flux-system \
+      -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null)
+  done
   [ "$wlf" = "True" ] && pass "workload Flux sync Ready from knr-registry" || fail "workload Flux sync ready=$wlf"
 
   podinfo=$("$KUBECTL" --kubeconfig="$WL_KCFG" -n podinfo get pods --no-headers 2>/dev/null | grep -c " Running ")

--- a/docs/airgap.md
+++ b/docs/airgap.md
@@ -96,9 +96,20 @@ Connected (build):
 airgap/scripts/build-package.sh   # validate, artifact, images, charts, zarf package create
 ```
 
-The `air-gapped` GitHub Actions workflow runs the same build on ARM64 for
-every pull request and for manual dispatches, then retains the generated
-transfer artifacts as a one-day workflow artifact.
+The `air-gapped` GitHub Actions workflow runs only on upstream `main`, nightly
+or by manual dispatch. It builds the ARM64 bundle, deploys it while capturing
+public traffic, fails if any public packet is observed, and retains the bundle
+and verification evidence as one-day workflow artifacts.
+
+The nightly schedule starts at 02:17 UTC rather than at the top of the hour to
+reduce GitHub Actions queue contention. Build and deploy remain separate jobs
+so CI verifies that the uploaded transfer bundle can be downloaded and used on
+a clean runner. The bundle upload uses compression level 0 because its largest
+contents are already-compressed container layers and Zstandard archives. CI
+also deliberately avoids caching container images: pulling them during every
+run verifies that the declared air-gap inventory remains available and
+complete. Repository and ref guards prevent forks or non-`main` manual
+dispatches from consuming the ARM64 runners.
 
 Gap (deploy) — from `airgap/`:
 


### PR DESCRIPTION
## Summary

- consume the ARM64 bundle produced by the existing air-gapped build job
- deploy it on a fresh ARM64 runner while capturing public traffic from the kind bridge
- fail when the deployment fails or any public packet is observed
- retain deployment logs, summaries, and packet-capture evidence for one day
- document the monitored deployment stage in the airgap guide and agent repository map

Enforced network blocking remains a separate follow-up slice.

## Testing

- `bash -n` passed for all repository shell scripts
- all `mgmt/` and `workload/` overlays built successfully with `kubectl kustomize`
- `git diff --check` passed