### PR TITLE
ci: detect upstream default branch dynamically

### DIFF
--- a/.github/workflows/air-gapped.yml
+++ b/.github/workflows/air-gapped.yml
@@ -16,7 +16,9 @@ concurrency:
 jobs:
   build:
     name: Build air-gap bundle
-    if: github.repository == 'polarsquad/knr-ops' && github.ref == 'refs/heads/main'
+    if: >-
+      github.event.repository.fork == false &&
+      github.ref_name == github.event.repository.default_branch
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 15
     services:

--- a/docs/airgap.md
+++ b/docs/airgap.md
@@ -108,8 +108,8 @@ a clean runner. The bundle upload uses compression level 0 because its largest
 contents are already-compressed container layers and Zstandard archives. CI
 also deliberately avoids caching container images: pulling them during every
 run verifies that the declared air-gap inventory remains available and
-complete. Repository and ref guards prevent forks or non-`main` manual
-dispatches from consuming the ARM64 runners.
+complete. Fork and default-branch guards prevent fork or non-default-branch
+manual dispatches from consuming the ARM64 runners.
 
 Gap (deploy) — from `airgap/`:
 


### PR DESCRIPTION
## Summary

- replace the hardcoded upstream repository and `main` ref guard with fork/default-branch metadata
- keep ARM64 air-gap jobs restricted to a non-fork repository on its declared default branch
- update the air-gap documentation to describe the portable guard

## Testing

- `git diff --check`
- workflow delta matches the post-merge change previously reviewed on PR #63