### PR TITLE
ci: verify deployment with external egress blocked

### DIFF
--- a/.github/workflows/air-gapped.yml
+++ b/.github/workflows/air-gapped.yml
@@ -61,6 +61,120 @@ jobs:
           retention-days: 1
           compression-level: 0
 
+  isolated-deploy:
+    name: Deploy without external egress
+    needs: build
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7.0.1
+
+      - name: Install mise
+        uses: jdx/mise-action@v4.2.3
+        with:
+          version: 2026.8.10
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Download air-gap bundle
+        uses: actions/download-artifact@v8.0.0
+        with:
+          name: knr-ops-airgap-arm64
+          path: airgap
+
+      - name: Deploy with external egress blocked
+        env:
+          SKIP_OFFLINE_CHECK: "1"
+        run: |
+          set -uo pipefail
+
+          capture=/tmp/airgap-public-egress.pcap
+          firewall_comment=knr-airgap-egress
+          bridge_interface=
+          tcpdump_pid=
+
+          stop_capture() {
+            if [ -n "$tcpdump_pid" ]; then
+              sudo kill "$tcpdump_pid" 2>/dev/null || true
+              wait "$tcpdump_pid" 2>/dev/null || true
+              tcpdump_pid=
+            fi
+          }
+          cleanup() {
+            stop_capture
+            if [ -n "$bridge_interface" ]; then
+              sudo iptables -D DOCKER-USER \
+                -i "$bridge_interface" ! -o "$bridge_interface" \
+                -m conntrack --ctstate NEW \
+                -m comment --comment "$firewall_comment" -j DROP \
+                2>/dev/null || true
+            fi
+          }
+          trap cleanup EXIT
+
+          docker network inspect kind >/dev/null 2>&1 || \
+            docker network create kind >/dev/null
+          network_id=$(docker network inspect kind --format '{{.Id}}')
+          bridge_interface="br-${network_id:0:12}"
+
+          sudo iptables -I DOCKER-USER 1 \
+            -i "$bridge_interface" ! -o "$bridge_interface" \
+            -m conntrack --ctstate NEW \
+            -m comment --comment "$firewall_comment" -j DROP
+          if ! sudo iptables -C DOCKER-USER \
+            -i "$bridge_interface" ! -o "$bridge_interface" \
+            -m conntrack --ctstate NEW \
+            -m comment --comment "$firewall_comment" -j DROP; then
+            echo "::error::Failed to block external egress from the kind network"
+            exit 1
+          fi
+
+          sudo tcpdump \
+            -i "$bridge_interface" \
+            -w "$capture" \
+            '(ip and not dst net 10.0.0.0/8 and not dst net 172.16.0.0/12 and not dst net 192.168.0.0/16 and not dst net 127.0.0.0/8 and not dst net 169.254.0.0/16 and not multicast) or (ip6 and not dst net fc00::/7 and not dst net fe80::/10 and not dst host ::1 and not multicast)' &
+          tcpdump_pid=$!
+
+          sleep 1
+          if ! sudo kill -0 "$tcpdump_pid" 2>/dev/null; then
+            echo "::error::Traffic capture failed to start"
+            wait "$tcpdump_pid"
+            exit 1
+          fi
+
+          if airgap/scripts/offline-run.sh \
+            airgap/zarf-package-knr-ops-airgap-*.tar.zst; then
+            deploy_result=0
+          else
+            deploy_result=$?
+          fi
+
+          stop_capture
+          sudo tcpdump -n -r "$capture" \
+            > /tmp/airgap-public-egress.txt 2>/dev/null
+
+          if [ -s /tmp/airgap-public-egress.txt ]; then
+            echo "::error::Public network traffic was attempted during the isolated deployment"
+            cat /tmp/airgap-public-egress.txt
+            exit 1
+          fi
+
+          exit "$deploy_result"
+
+      - name: Store isolated deployment evidence
+        if: always()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: knr-ops-airgap-isolated-results
+          path: |
+            /tmp/airgap-offline-run.log
+            /tmp/airgap-offline-summary.txt
+            /tmp/airgap-public-egress.pcap
+            /tmp/airgap-public-egress.txt
+          if-no-files-found: warn
+          retention-days: 1
+
   monitored-deploy:
     name: Deploy while monitoring public traffic
     needs: build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,10 @@ resources. There is no app source code here, only declarative infrastructure.
   renders, and stages the kit (`build-*`, `render-*`, `stage-*`,
   `offline-run.sh`); `archives/` and `rendered/` are gitignored outputs. The
   `air-gapped` workflow builds the ARM64 transfer bundle and exercises a
-  monitored deployment only on upstream `main`, nightly or by manual dispatch.
+  monitored deployment and an egress-blocked deployment in parallel only on
+  upstream `main`, nightly or by manual dispatch. Running both is a temporary
+  comparison of validation accuracy and performance; the less effective job
+  will be removed after enough runs are evaluated.
 - `bootstrap.sh` / `teardown.sh`: the only imperative steps (one-time
   kind + Flux bootstrap, full teardown).
 - `docs/`: detailed documentation (see the table in README.md).

--- a/docs/airgap.md
+++ b/docs/airgap.md
@@ -97,19 +97,31 @@ airgap/scripts/build-package.sh   # validate, artifact, images, charts, zarf pac
 ```
 
 The `air-gapped` GitHub Actions workflow runs only on upstream `main`, nightly
-or by manual dispatch. It builds the ARM64 bundle, deploys it while capturing
-public traffic, fails if any public packet is observed, and retains the bundle
-and verification evidence as one-day workflow artifacts.
+or by manual dispatch. It builds the ARM64 bundle, then starts two deployment
+jobs in parallel: one observes public traffic without blocking it, while the
+other blocks new external connections from the kind network. Both capture
+public traffic and fail if any public packet is observed or attempted. The
+workflow retains the bundle and verification evidence as one-day artifacts.
+
+Running both deployment jobs is a temporary evaluation, not the intended
+long-term workflow shape. Their results and timings provide comparable samples
+from the same bundle so maintainers can determine which method detects offline
+violations more accurately and whether either has a meaningful performance
+cost. After enough nightly and manual runs have been assessed, the less
+effective job will be removed.
 
 The nightly schedule starts at 02:17 UTC rather than at the top of the hour to
-reduce GitHub Actions queue contention. Build and deploy remain separate jobs
-so CI verifies that the uploaded transfer bundle can be downloaded and used on
-a clean runner. The bundle upload uses compression level 0 because its largest
-contents are already-compressed container layers and Zstandard archives. CI
-also deliberately avoids caching container images: pulling them during every
-run verifies that the declared air-gap inventory remains available and
-complete. Fork and default-branch guards prevent fork or non-default-branch
-manual dispatches from consuming the ARM64 runners.
+reduce GitHub Actions queue contention. Build and deployment remain separate
+jobs so CI verifies that the uploaded transfer bundle can be downloaded and
+used on clean runners. Both deployment jobs depend only on the build job, so
+they run concurrently to make their timing comparison fair and avoid doubling
+elapsed validation time. The bundle upload uses compression level 0 because its
+largest contents are already-compressed container layers and Zstandard
+archives. CI also
+deliberately avoids caching container images: pulling them during every run
+verifies that the declared air-gap inventory remains available and complete.
+Fork and default-branch guards prevent fork or non-default-branch manual
+dispatches from consuming the ARM64 runners.
 
 Gap (deploy) — from `airgap/`:
 


### PR DESCRIPTION
## Summary

- add a second air-gap deployment job that blocks new external connections from the kind Docker network
- preserve established reply traffic so host-to-container registry access continues to work
- capture attempted public traffic and retain isolated-run evidence
- run monitored and isolated deployments in parallel from the same bundle

## Evaluation intent

Running both jobs is temporary. Parallel runs provide directly comparable evidence for:

- which method identifies offline violations more accurately
- whether either method produces false positives or misses attempted egress
- runtime and performance differences between observation and enforced isolation

After enough nightly and manual runs have been assessed, the less effective job will be removed.

## Testing

- `git diff --check`
- `bash -n airgap/scripts/offline-run.sh airgap/scripts/stage-and-create-cluster.sh`
- workflow YAML parsed locally
- the isolated deployment approach previously passed in https://github.com/lmilbaum/knr-ops/actions/runs/32743099384

## Runtime impact

- adds approximately eight GitHub-hosted ARM64 runner-minutes per nightly/manual run
- does not intentionally extend wall-clock duration because both deployments run concurrently after the build