### PR TITLE
docs: rename airgap kit to bundle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,9 +25,9 @@ resources. There is no app source code here, only declarative infrastructure.
 - `workload/`: synced by each WORKLOAD cluster's Flux.
   - `base/`: ACK controllers and S3/RDS/IAM custom resources.
   - `<region>-01/`: per-cluster overlays pointing at `../base`.
-- `airgap/`: Zarf offline install kit for the local-host profile.
+- `airgap/`: Zarf offline transfer bundle for the local-host profile.
   `zarf.yaml` + `images.txt` define the packages; `scripts/` builds,
-  renders, and stages the kit (`build-*`, `render-*`, `stage-*`,
+  renders, and stages the bundle (`build-*`, `render-*`, `stage-*`,
   `offline-run.sh`); `archives/` and `rendered/` are gitignored outputs. The
   `air-gapped` workflow builds the ARM64 transfer bundle and exercises a
   monitored deployment and an egress-blocked deployment in parallel only on
@@ -104,4 +104,4 @@ Load these only when the task touches their domain:
 - `docs/aws-iam.md`: EKS Pod Identity, ACK controller roles, reader user.
 - `docs/operations.md`: quotas, configuration, bootstrap, verification.
 - `docs/workload-resources.md`: S3/RDS posture, known limitations.
-- `docs/airgap.md`: Zarf offline kit for the local-host profile.
+- `docs/airgap.md`: Zarf offline bundle for the local-host profile.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ After the one-time bootstrap, **everything is declared in Git as YAML**.
 The `aws` profile declares 2 CAPI workload clusters: 4 node pools (ARM and
 GPU) across 2 regions, 2 S3 buckets, 2 RDS instances, 1 reader user, and one
 reader role per workload cluster. The repository also ships a
-[Zarf](https://zarf.dev/) air-gap kit that packages the `local-host`
+[Zarf](https://zarf.dev/) air-gap bundle that packages the `local-host`
 deployment for offline installs. 0 HCL, 0 state files.
 
 ## Who this is for
@@ -132,7 +132,7 @@ suspends Flux and removes the AWS-managed infrastructure.
 | [docs/secrets.md](docs/secrets.md) | SOPS + age secret management, key setup, credential rotation |
 | [docs/operations.md](docs/operations.md) | Prerequisites, AWS service quotas, configuration, bootstrap, verification, teardown, validation |
 | [docs/extending.md](docs/extending.md) | Adding a workload cluster, adding apps to the workload clusters, adding other providers (Azure, Talos, k0smotron) |
-| [docs/airgap.md](docs/airgap.md) | Zarf air-gap kit: package build, offline deploy, verification checklist, update drill |
+| [docs/airgap.md](docs/airgap.md) | Zarf air-gap bundle: package build, offline deploy, verification checklist, update drill |
 
 ## Repository layout
 

--- a/airgap/scripts/build-config-artifact.sh
+++ b/airgap/scripts/build-config-artifact.sh
@@ -330,11 +330,11 @@ if [ -n "${OCI_USERNAME:-}" ] && [ -n "${OCI_PASSWORD:-}" ]; then
 fi
 flux push artifact "${PUSH_ARGS[@]}"
 
-# Keep a plain-directory copy of the tree in the kit: the gap-side stage
+# Keep a plain-directory copy of the tree in the bundle: the gap-side stage
 # script re-pushes it into knr-registry as knr-ops:latest for the workload
 # cluster's Flux (which does not talk to the Zarf registry).
 rm -rf "$REPO_ROOT/airgap/config-artifact"
 cp -R "$ARTIFACT_ROOT" "$REPO_ROOT/airgap/config-artifact"
-echo "==> Kit copy at airgap/config-artifact/ ($(du -sh "$REPO_ROOT/airgap/config-artifact" | cut -f1))"
+echo "==> Bundle copy at airgap/config-artifact/ ($(du -sh "$REPO_ROOT/airgap/config-artifact" | cut -f1))"
 
 echo "==> Done. Config artifact: ${OCI_REGISTRY}/${OCI_REPOSITORY}:${OCI_TAG}"

--- a/airgap/scripts/offline-run.sh
+++ b/airgap/scripts/offline-run.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# offline-run.sh — autonomous Wi-Fi-off validation of the knr-ops airgap kit.
+# offline-run.sh — autonomous Wi-Fi-off validation of the knr-ops airgap bundle.
 #
 # This script is designed to run with NO operator and NO LLM/agent attached:
 # it waits until the internet is unreachable, runs the full deploy, verifies,

--- a/airgap/scripts/stage-and-create-cluster.sh
+++ b/airgap/scripts/stage-and-create-cluster.sh
@@ -106,7 +106,7 @@ fi
 echo ">>> Seeding ${REGISTRY_NAME} with the config artifact + charts..."
 flux push artifact "oci://localhost:${REGISTRY_PORT}/knr-ops:latest" \
   --path="$AIRGAP_DIR/config-artifact" \
-  --source="airgap-kit" \
+  --source="airgap-bundle" \
   --revision="airgap@sha1:$(git -C "$AIRGAP_DIR" rev-parse HEAD 2>/dev/null || echo unknown)" \
   --insecure-registry \
   --reproducible

--- a/docs/air-gap-infra.svg
+++ b/docs/air-gap-infra.svg
@@ -18,7 +18,7 @@
   <rect width="1600" height="1150" fill="#0f0f0f"/>
 
   <!-- ===== title block ===== -->
-  <text x="800" y="60" text-anchor="middle" font-family="DejaVu Sans" font-size="40" font-weight="bold" fill="#ff78c9">knr-ops &#183; Zarf Air-Gap Kit &#183; Radio Off, Chain Intact</text>
+  <text x="800" y="60" text-anchor="middle" font-family="DejaVu Sans" font-size="40" font-weight="bold" fill="#ff78c9">knr-ops &#183; Zarf Air-Gap Bundle &#183; Radio Off, Chain Intact</text>
   <text x="800" y="96" text-anchor="middle" font-family="DejaVu Sans" font-size="19" fill="#8f8f8f">Zarf packages the local-host profile &#183; build connected, deploy with no internet &#183; two registries, one package</text>
 
   <!-- ===== section headers ===== -->
@@ -37,10 +37,10 @@
   <text x="100" y="352" font-family="DejaVu Sans Mono" font-size="16" fill="#85c7bb">&#8226; zarf package create</text>
   <text x="284" y="388" text-anchor="middle" font-family="DejaVu Sans" font-size="14.5" fill="#8f8f8f">git tree is never modified; airgap variant generated at build</text>
 
-  <!-- ===== the kit ===== -->
+  <!-- ===== the bundle ===== -->
   <rect x="620" y="150" width="400" height="256" rx="14" fill="#131320" stroke="#3d3d55" stroke-width="1.5"/>
   <rect x="636" y="158" width="368" height="5" rx="2.5" fill="#ab9fd6"/>
-  <text x="820" y="198" text-anchor="middle" font-family="DejaVu Sans" font-size="25" font-weight="bold" fill="#ab9fd6">The Kit</text>
+  <text x="820" y="198" text-anchor="middle" font-family="DejaVu Sans" font-size="25" font-weight="bold" fill="#ab9fd6">The Bundle</text>
   <text x="820" y="222" text-anchor="middle" font-family="DejaVu Sans" font-size="16" fill="#8f8f8f">(what crosses the gap)</text>
   <text x="656" y="258" font-family="DejaVu Sans Mono" font-size="15" fill="#d6d6d6">zarf-package-knr-ops-airgap-*.tar.zst</text>
   <text x="656" y="286" font-family="DejaVu Sans Mono" font-size="15" fill="#d6d6d6">zarf-init tarball + zarf CLI</text>
@@ -48,7 +48,7 @@
   <text x="656" y="342" font-family="DejaVu Sans Mono" font-size="15" fill="#d6d6d6">charts/*.tgz <tspan font-family="DejaVu Sans" fill="#8f8f8f">(flux-operator, podinfo)</tspan></text>
   <text x="656" y="370" font-family="DejaVu Sans Mono" font-size="15" fill="#d6d6d6">config-artifact/ <tspan font-family="DejaVu Sans" fill="#8f8f8f">&#8594; knr-ops:latest</tspan></text>
 
-  <!-- build -> kit arrow -->
+  <!-- build -> bundle arrow -->
   <line x1="508" y1="278" x2="612" y2="278" stroke="#85c7bb" stroke-width="2.5" marker-end="url(#arrow-teal)"/>
   <text x="561" y="258" text-anchor="middle" font-family="DejaVu Sans" font-size="16" font-weight="bold" fill="#fafafa">1. build</text>
 
@@ -138,7 +138,7 @@
   <!-- step 2 -->
   <circle cx="1140" cy="338" r="15" fill="#ab9fd6"/>
   <text x="1140" y="344" text-anchor="middle" font-family="DejaVu Sans" font-size="15" font-weight="bold" fill="#0f0f0f">2</text>
-  <text x="1168" y="334" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">The kit crosses the gap. Offline:</text>
+  <text x="1168" y="334" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">The bundle crosses the gap. Offline:</text>
   <text x="1168" y="360" font-family="DejaVu Sans Mono" font-size="15.5" fill="#ab9fd6">docker load<tspan font-family="DejaVu Sans" font-size="17" fill="#d6d6d6"> archives, create kind</tspan></text>
   <text x="1168" y="386" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">mgmt cluster, seed knr-registry.</text>
   <line x1="1122" y1="420" x2="1504" y2="420" stroke="#34344a" stroke-width="1.2"/>

--- a/docs/airgap.md
+++ b/docs/airgap.md
@@ -25,7 +25,7 @@ SKIP_OFFLINE_CHECK=1 airgap/scripts/offline-run.sh
 
 ## Prerequisites
 
-The kit is single-architecture (arm64), including the pinned Zarf CLI. The
+The bundle is single-architecture (arm64), including the pinned Zarf CLI. The
 mise pin in `mise.toml` selects the matching Linux or macOS arm64 release
 asset. Docker and kind are also required on the deploy host (the prototype
 keeps kind as the management-cluster substrate; see Known limitations).
@@ -70,7 +70,7 @@ Zarf package and is published into Zarf's internal registry at deploy time.
 The verification linchpin is the agent's **image rewrite** plus a Ready
 `OCIRepository` pointing at the internal registry, with the radio off.
 
-## What crosses the gap (the kit)
+## What crosses the gap (the bundle)
 
 | Item | Purpose |
 |---|---|


### PR DESCRIPTION
## Summary

- use **bundle** consistently for the complete set of assets transferred across the gap
- retain **Zarf package** for the specific `.tar.zst` package contained in that bundle
- update repository guidance, user documentation, script messages/comments, Flux artifact metadata, and the air-gap architecture diagram

## Rationale

The workflow produces and transfers more than a Zarf package: it also includes host image archives, workload image archives, charts, and the config artifact. Calling that complete output a bundle makes the boundary clear and avoids using “kit” and “bundle” interchangeably.

## Testing

- no remaining standalone `kit` or `airgap-kit` references
- `bash -n` for the modified shell scripts
- `git diff --check`
- `xmllint --noout docs/air-gap-infra.svg` when xmllint is available