### PR TITLE
docs: catch README and AGENTS.md up with recent changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,12 +28,14 @@ resources. There is no app source code here, only declarative infrastructure.
 - `airgap/`: Zarf offline transfer bundle for the local-host profile.
   `zarf.yaml` + `images.txt` define the packages; `scripts/` builds,
   renders, and stages the bundle (`build-*`, `render-*`, `stage-*`,
-  `offline-run.sh`); `archives/` and `rendered/` are gitignored outputs. The
-  `air-gapped` workflow builds the ARM64 transfer bundle and exercises a
-  monitored deployment and an egress-blocked deployment in parallel only on
-  upstream `main`, nightly or by manual dispatch. Running both is a temporary
-  comparison of validation accuracy and performance; the less effective job
-  will be removed after enough runs are evaluated.
+  `offline-run.sh`); `archives/` and `rendered/` are gitignored outputs.
+  The `air-gapped` workflow (upstream main only, nightly at 02:17 UTC or
+  manual dispatch) builds the ARM64 bundle on an arm64 runner, then runs
+  two comparison deployments in parallel: one with public traffic monitored
+  and one with external egress blocked (fails if any public traffic was
+  attempted). Both deploy evidence artifacts are uploaded. Running both is
+  a temporary comparison of validation accuracy and performance; the less
+  effective job will be removed after enough runs are evaluated.
 - `bootstrap.sh` / `teardown.sh`: the only imperative steps (one-time
   kind + Flux bootstrap, full teardown).
 - `docs/`: detailed documentation (see the table in README.md).
@@ -42,8 +44,11 @@ resources. There is no app source code here, only declarative infrastructure.
   activated with `MISE_ENV=aws`.
 - `deps/versions.toml`: the single authoritative dependency version
   catalog. Every pinned version in the repo is either generated from it or
-  validated against it by `mise run deps-check`. Bump versions only there;
-  see `docs/dependencies.md`.
+  validated against it by `mise run deps-check` (same check CI runs). A
+  dependency bump changes exactly one value there; see
+  `docs/dependencies.md`. Generated consumers (`zarf.yaml`, `images.txt`,
+  airgap scripts) are rendered from the catalog, so never hand-edit their
+  version literals.
 
 ## The golden rules (read before changing anything)
 

--- a/README.md
+++ b/README.md
@@ -49,9 +49,11 @@ not a developer self-service portal; you are the consumer.
 - **State files**: drift, locking, corruption. Controllers reconcile actual
   state continuously instead of diffing a snapshot.
 - **The plan/apply gap**: PRs are reviewed as **rendered** Flux diffs (blast
-  radius, image changes, render failures) by an in-cluster
-  [konflate](https://github.com/home-operations/konflate) instance: you review
-  byte-for-byte what reconciles. See [docs/konflate.md](docs/konflate.md).
+  radius, image changes, render failures) by
+  [konflate](https://github.com/home-operations/konflate): a GitHub Actions
+  workflow runs it on every PR push as a merge gate, and an in-cluster
+  instance posts the summary to the PR. You review byte-for-byte what
+  reconciles. See [docs/konflate.md](docs/konflate.md).
 - **Two toolchains**: HCL for infra, YAML for workloads. One control plane
   means RBAC, policy, and audit cover both.
 - **Lifecycle split**: Terraform builds the cluster but can't manage what's
@@ -82,8 +84,13 @@ mise run sops-keygen        # first time only: age key for SOPS
 mise run bootstrap          # kind cluster + Flux; everything else is GitOps
 flux get kustomizations --watch
 mise run validate           # build every kustomize overlay (mirrors CI)
+mise run deps-check         # verify version pins against deps/versions.toml (mirrors CI)
 mise run teardown           # full teardown (EKS, AWS resources, kind)
 ```
+
+Version bumps change exactly one value in `deps/versions.toml`; generated
+consumers and CI keep the rest in sync (see
+[docs/dependencies.md](docs/dependencies.md)).
 
 ### Mise profiles
 
@@ -129,7 +136,7 @@ suspends Flux and removes the AWS-managed infrastructure.
 | [docs/architecture.md](docs/architecture.md) | Architecture diagram, reconciliation order, how workload apps are delivered |
 | [docs/aws-iam.md](docs/aws-iam.md) | EKS Pod Identity, ACK controller IAM roles, per-cluster reader roles, the `knr-ops-reader` console user |
 | [docs/workload-resources.md](docs/workload-resources.md) | S3 bucket security posture, RDS instances, known limitations |
-| [docs/konflate.md](docs/konflate.md) | Rendered Flux PR review: in-cluster konflate instance, write-back to PRs, tokens |
+| [docs/konflate.md](docs/konflate.md) | Rendered Flux PR review: GitHub Actions gate, in-cluster instance, write-back to PRs, tokens |
 | [docs/secrets.md](docs/secrets.md) | SOPS + age secret management, key setup, credential rotation |
 | [docs/operations.md](docs/operations.md) | Prerequisites, AWS service quotas, configuration, bootstrap, verification, teardown, validation |
 | [docs/extending.md](docs/extending.md) | Adding a workload cluster, adding apps to the workload clusters, adding other providers (Azure, Talos, k0smotron) |
@@ -138,8 +145,10 @@ suspends Flux and removes the AWS-managed infrastructure.
 ## Repository layout
 
 ```
-├── airgap/                       Zarf air-gap package, image inventory, scripts
+├── airgap/                       Zarf air-gap bundle, image inventory, scripts
 ├── bootstrap.sh / teardown.sh     One-time imperative bootstrap / full teardown
+├── deps/                          Version catalog (versions.toml) + drift-check
+│                                  scripts; single place to bump any dependency
 ├── docs/                          Detailed documentation (see table above)
 ├── mise.toml / mise.*.toml        Pinned toolchain and AWS/local-host tasks
 ├── mgmt/aws/                     Synced by the MANAGEMENT cluster's Flux
@@ -154,7 +163,7 @@ suspends Flux and removes the AWS-managed infrastructure.
 │   └── clusters/                  EKS cluster defs (eu-north-1, eu-west-1;
 │                                  ARM + GPU MachinePools)
 ├── mgmt/local-host/               OCI-synced CAPI/CAPD local workload cluster
-└── workload/                          Synced by each WORKLOAD cluster's Flux
+└── workload/                      Synced by each WORKLOAD cluster's Flux
     ├── base/                      ACK S3/RDS/IAM controllers, Bucket CRs,
     │                              DBInstance CRs, reader Role CRs
     ├── local-host/                OCI-synced Podinfo workload overlay


### PR DESCRIPTION
Both entry documents had drifted behind the last ~30 merged PRs (deps catalog #69, airgap CI #57-67, rename #68). This PR closes the gaps.

## README.md

- Konflate: the problems-solved bullet and docs-table row described only the in-cluster instance; now covers both paths (GHA merge gate + in-cluster write-back).
- Quickstart: adds `mise run deps-check` (CI runs it on every PR now) plus a one-line pointer that version bumps change one value in `deps/versions.toml`.
- Layout tree: gains `deps/` (version catalog + drift-check scripts), fixes the airgap `package` -> `bundle` rename (#68), realigns the mis-indented `workload/` gutter.

## AGENTS.md

- `air-gapped` workflow bullet: adds schedule (nightly 02:17 UTC, manual dispatch, upstream main only), arm64 runner, and the two comparison jobs (public-traffic-monitored vs egress-blocked) with evidence artifacts.
- `deps/versions.toml` bullet: clarifies that generated consumers (`zarf.yaml`, `images.txt`, airgap scripts) are rendered from the catalog and must not be hand-edited; notes deps-check is the same check CI runs.

All claims verified against the workflow YAML, mise.toml tasks, and deps/scripts/check.py.