### PR TITLE
feat: add Renovate dependency update automation

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,46 @@
+name: renovate
+
+on:
+  schedule:
+    - cron: "0 5 * * 1" # Mondays 05:00 UTC = 08:00 EEST
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run (no PRs created)"
+        type: boolean
+        default: true
+
+concurrency:
+  group: renovate
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Renovate dry-run config check
+        if: github.event_name == 'workflow_dispatch'
+        uses: renovatebot/github-action@v42
+        with:
+          configurationFile: renovate.json5
+          token: ${{ secrets.RENOVATE_TOKEN }}
+        env:
+          RENOVATE_DRY_RUN: ${{ inputs.dry_run && 'full' || 'false' }}
+          RENOVATE_REPO: ${{ github.repository }}
+          LOG_LEVEL: debug
+
+      - name: Renovate scheduled run
+        if: github.event_name == 'schedule'
+        uses: renovatebot/github-action@v42
+        with:
+          configurationFile: renovate.json5
+          token: ${{ secrets.RENOVATE_TOKEN }}
+        env:
+          RENOVATE_REPO: ${{ github.repository }}
+          RENOVATE_ONBOARDING: "false"
+          LOG_LEVEL: info

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Renovate dry-run config check
         if: github.event_name == 'workflow_dispatch'
-        uses: renovatebot/github-action@v42
+        uses: renovatebot/github-action@v46.2.4
         with:
           configurationFile: renovate.json5
           token: ${{ secrets.RENOVATE_TOKEN }}
@@ -36,7 +36,7 @@ jobs:
 
       - name: Renovate scheduled run
         if: github.event_name == 'schedule'
-        uses: renovatebot/github-action@v42
+        uses: renovatebot/github-action@v46.2.4
         with:
           configurationFile: renovate.json5
           token: ${{ secrets.RENOVATE_TOKEN }}

--- a/mise.aws.toml
+++ b/mise.aws.toml
@@ -2,7 +2,7 @@
 KNR_OPS_PROFILE = "aws"
 
 [tools]
-aws-cli = "latest"
+aws-cli = "2.36.32"
 clusterawsadm = { version = "2.13.0", binary = "clusterawsadm" }
 
 [tasks.aws-bootstrap]

--- a/mise.toml
+++ b/mise.toml
@@ -7,9 +7,9 @@ kubectl = "1.35"
 kind = "0.32"
 helm = "4.2"
 clusterctl = "1.14.0"
-flux2 = "latest"
-sops = "latest"
-age = "latest"
+flux2 = "2.9.4"
+sops = "3.13.3"
+age = "1.3.1"
 
 # Zarf CLI (airgap prototype). The mise github backend downloads the raw
 # release asset and keeps its original filename, so we select the native

--- a/renovate.json5
+++ b/renovate.json5
@@ -275,9 +275,10 @@
       "separateMajorMinor": true,
       "groupName": null
     },
-    // Floating "latest" pins (flux2, sops, age, aws-cli in mise; the zarf
-    // local-registry image) are intentionally untracked: Renovate skips a
-    // "latest" currentValue as invalid before any rule can pin it, so they
-    // stay floating by decision until pinned by hand once.
+    // flux2, sops, age, and aws-cli were previously floating "latest" pins;
+    // they are now pinned to concrete versions in mise.toml / mise.aws.toml
+    // so Renovate tracks them normally. The zarf local-registry image keeps
+    // its bare "latest" tag: it is built locally per run and has no
+    // comparable version.
   ]
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -51,6 +51,7 @@
       "matchStrings": ["go = \"(?<currentValue>[^\"]+)\""],
       "depNameTemplate": "golang",
       "datasourceTemplate": "golang-version",
+      "versioningTemplate": "loose",
       "autoReplaceStringTemplate": "go = \"{{newValue}}\""
     },
     {
@@ -220,7 +221,7 @@
       "description": "airgap images.txt container refs",
       "managerFilePatterns": ["/(^|/)airgap/images\\.txt$/"],
       "matchStrings": [
-        "(?:^|\n)(?<depName>(?:[a-zA-Z0-9._-]+(?::[0-9]+)?/)?(?:[^\s:@#/]+/)*[^\s:@#/]+):(?<currentValue>[^\s@:]+)(@(?<currentDigest>sha256:[a-f0-9]+))?[ \t]*(?:#.*)?\n"
+        "(?:^|\n)(?<depName>(?:[a-zA-Z0-9._-]+(?::[0-9]+)?/)?(?:[^\\s:@#/]+/)*[^\\s:@#/]+):(?<currentValue>[^\\s@:]+)(@(?<currentDigest>sha256:[a-f0-9]+))?[ \t]*(?:#.*)?"
       ],
       "datasourceTemplate": "docker",
       "versioningTemplate": "docker"
@@ -230,13 +231,16 @@
       "description": "zarf.yaml image refs (registry with optional port)",
       "managerFilePatterns": ["/(^|/)airgap/zarf\\.yaml$/"],
       "matchStrings": [
-        "- (?<depName>[a-zA-Z0-9._-]+(?::[0-9]+)?/[a-zA-Z0-9._/-]+):(?<currentValue>[^\s@]+)\n"
+        "- (?<depName>[a-zA-Z0-9._-]+(?::[0-9]+)?/[a-zA-Z0-9._/-]+):(?<currentValue>[^\\s@]+)"
       ],
       "datasourceTemplate": "docker",
       "versioningTemplate": "docker"
     },
     // EKS addon versions (*-eksbuild.*) intentionally not managed: they have
     // no public registry datasource. Tracked in issue #74 as manual updates.
+    // Unversioned tags (e.g. localhost:5001/knr-ops-airgap:latest in
+    // zarf.yaml, built locally per run) are also intentionally untracked:
+    // a bare "latest" tag has no comparable version.
     // ── end customManagers ────────────────────────────────────────────────
   ],
   "packageRules": [

--- a/renovate.json5
+++ b/renovate.json5
@@ -196,7 +196,7 @@
         "/(^|/)mgmt/(aws|local-host)/capi-providers/caaph-system/.+\\.ya?ml$/"
       ],
       "matchStrings": ["\\s{2}version: \"v(?<currentValue>[^\"]+)\""],
-      "depNameTemplate": "kubernetes-sigs/cluster-api-addon-helm",
+      "depNameTemplate": "kubernetes-sigs/cluster-api-addon-provider-helm",
       "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^v(?<version>.+)",
       "autoReplaceStringTemplate": "  version: \"v{{newValue}}\""
@@ -265,7 +265,7 @@
       "matchPackageNames": [
         "kubernetes-sigs/cluster-api",
         "kubernetes-sigs/cluster-api-provider-aws",
-        "kubernetes-sigs/cluster-api-addon-helm"
+        "kubernetes-sigs/cluster-api-addon-provider-helm"
       ],
       "groupName": "cluster-api"
     },
@@ -275,15 +275,9 @@
       "separateMajorMinor": true,
       "groupName": null
     },
-    {
-      "description": "Pin floating latest mise values to concrete release versions",
-      "matchPackageNames": [
-        "fluxcd/flux2",
-        "getsops/sops",
-        "FiloSottile/age",
-        "aws/aws-cli"
-      ],
-      "rangeStrategy": "pin"
-    }
+    // Floating "latest" pins (flux2, sops, age, aws-cli in mise; the zarf
+    // local-registry image) are intentionally untracked: Renovate skips a
+    // "latest" currentValue as invalid before any rule can pin it, so they
+    // stay floating by decision until pinned by hand once.
   ]
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -48,19 +48,18 @@
       "customType": "regex",
       "description": "mise: go toolchain pin",
       "managerFilePatterns": ["/(^|/)mise\\.toml$/"],
-      "matchStrings": ["^go = \"(?<currentValue>[^\"]+)\"$"],
-      "depNameTemplate": "golang/go",
-      "datasourceTemplate": "github-releases",
-      "extractVersionTemplate": "^go(?<version>.+)",
+      "matchStrings": ["go = \"(?<currentValue>[^\"]+)\""],
+      "depNameTemplate": "golang",
+      "datasourceTemplate": "golang-version",
       "autoReplaceStringTemplate": "go = \"{{newValue}}\""
     },
     {
       "customType": "regex",
       "description": "mise: python toolchain pin",
       "managerFilePatterns": ["/(^|/)mise\\.toml$/"],
-      "matchStrings": ["^python = \"(?<currentValue>[^\"]+)\"$"],
+      "matchStrings": ["python = \"(?<currentValue>[^\"]+)\""],
       "depNameTemplate": "python/cpython",
-      "datasourceTemplate": "github-releases",
+      "datasourceTemplate": "github-tags",
       "extractVersionTemplate": "^v(?<version>.+)",
       "autoReplaceStringTemplate": "python = \"{{newValue}}\""
     },
@@ -68,7 +67,7 @@
       "customType": "regex",
       "description": "mise: kubectl version pin",
       "managerFilePatterns": ["/(^|/)mise\\.toml$/"],
-      "matchStrings": ["^kubectl = \"(?<currentValue>[^\"]+)\"$"],
+      "matchStrings": ["kubectl = \"(?<currentValue>[^\"]+)\""],
       "depNameTemplate": "kubernetes/kubernetes",
       "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^v(?<version>.+)",
@@ -78,7 +77,7 @@
       "customType": "regex",
       "description": "mise: kind version pin",
       "managerFilePatterns": ["/(^|/)mise\\.toml$/"],
-      "matchStrings": ["^kind = \"(?<currentValue>[^\"]+)\"$"],
+      "matchStrings": ["kind = \"(?<currentValue>[^\"]+)\""],
       "depNameTemplate": "kubernetes-sigs/kind",
       "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^v(?<version>.+)",
@@ -88,7 +87,7 @@
       "customType": "regex",
       "description": "mise: helm version pin",
       "managerFilePatterns": ["/(^|/)mise\\.toml$/"],
-      "matchStrings": ["^helm = \"(?<currentValue>[^\"]+)\"$"],
+      "matchStrings": ["helm = \"(?<currentValue>[^\"]+)\""],
       "depNameTemplate": "helm/helm",
       "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^v(?<version>.+)",
@@ -98,8 +97,8 @@
       "customType": "regex",
       "description": "mise: clusterctl version pin",
       "managerFilePatterns": ["/(^|/)mise\\.toml$/"],
-      "matchStrings": ["^clusterctl = \"(?<currentValue>[^\"]+)\"$"],
-      "depNameTemplate": "fluxcd/clusterctl",
+      "matchStrings": ["clusterctl = \"(?<currentValue>[^\"]+)\""],
+      "depNameTemplate": "kubernetes-sigs/cluster-api",
       "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^v(?<version>.+)",
       "autoReplaceStringTemplate": "clusterctl = \"{{newValue}}\""
@@ -108,7 +107,7 @@
       "customType": "regex",
       "description": "mise: flux2 CLI pin (floating latest tag)",
       "managerFilePatterns": ["/(^|/)mise\\.toml$/"],
-      "matchStrings": ["^flux2 = \"(?<currentValue>[^\"]+)\"$"],
+      "matchStrings": ["flux2 = \"(?<currentValue>[^\"]+)\""],
       "depNameTemplate": "fluxcd/flux2",
       "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^v(?<version>.+)",
@@ -118,7 +117,7 @@
       "customType": "regex",
       "description": "mise: sops pin (floating latest tag)",
       "managerFilePatterns": ["/(^|/)mise\\.toml$/"],
-      "matchStrings": ["^sops = \"(?<currentValue>[^\"]+)\"$"],
+      "matchStrings": ["sops = \"(?<currentValue>[^\"]+)\""],
       "depNameTemplate": "getsops/sops",
       "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^v(?<version>.+)",
@@ -128,7 +127,7 @@
       "customType": "regex",
       "description": "mise: age pin (floating latest tag)",
       "managerFilePatterns": ["/(^|/)mise\\.toml$/"],
-      "matchStrings": ["^age = \"(?<currentValue>[^\"]+)\"$"],
+      "matchStrings": ["age = \"(?<currentValue>[^\"]+)\""],
       "depNameTemplate": "FiloSottile/age",
       "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^v(?<version>.+)",
@@ -138,7 +137,7 @@
       "customType": "regex",
       "description": "mise: zarf CLI pin (github backend, v-prefixed)",
       "managerFilePatterns": ["/(^|/)mise\\.toml$/"],
-      "matchStrings": ["^version = \"v(?<currentValue>[^\"]+)\"$"],
+      "matchStrings": ["version = \"v(?<currentValue>[^\"]+)\""],
       "depNameTemplate": "zarf-dev/zarf",
       "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^v(?<version>.+)",
@@ -148,7 +147,7 @@
       "customType": "regex",
       "description": "mise: aws-cli pin (floating latest tag)",
       "managerFilePatterns": ["/(^|/)mise\\.aws\\.toml$/"],
-      "matchStrings": ["^aws-cli = \"(?<currentValue>[^\"]+)\"$"],
+      "matchStrings": ["aws-cli = \"(?<currentValue>[^\"]+)\""],
       "depNameTemplate": "aws/aws-cli",
       "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^v(?<version>.+)",
@@ -158,7 +157,7 @@
       "customType": "regex",
       "description": "mise: clusterawsadm pin (inline table form)",
       "managerFilePatterns": ["/(^|/)mise\\.aws\\.toml$/"],
-      "matchStrings": ["^clusterawsadm = \\{ version = \"(?<currentValue>[^\"]+)\""],
+      "matchStrings": ["clusterawsadm = \\{ version = \"(?<currentValue>[^\"]+)\""],
       "depNameTemplate": "kubernetes-sigs/clusterawsadm",
       "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^v(?<version>.+)",
@@ -171,7 +170,7 @@
       "managerFilePatterns": [
         "/(^|/)mgmt/(aws|local-host)/capi-providers/(capi-system|capd-system)/.+\\.ya?ml$/"
       ],
-      "matchStrings": ["^\\s{2}version: \"v(?<currentValue>[^\"]+)\"$"],
+      "matchStrings": ["\\s{2}version: \"v(?<currentValue>[^\"]+)\""],
       "depNameTemplate": "kubernetes-sigs/cluster-api",
       "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^v(?<version>.+)",
@@ -183,7 +182,7 @@
       "managerFilePatterns": [
         "/(^|/)mgmt/aws/capi-providers/capa-system/.+\\.ya?ml$/"
       ],
-      "matchStrings": ["^\\s{2}version: \"v(?<currentValue>[^\"]+)\"$"],
+      "matchStrings": ["\\s{2}version: \"v(?<currentValue>[^\"]+)\""],
       "depNameTemplate": "kubernetes-sigs/cluster-api-provider-aws",
       "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^v(?<version>.+)",
@@ -195,7 +194,7 @@
       "managerFilePatterns": [
         "/(^|/)mgmt/(aws|local-host)/capi-providers/caaph-system/.+\\.ya?ml$/"
       ],
-      "matchStrings": ["^\\s{2}version: \"v(?<currentValue>[^\"]+)\"$"],
+      "matchStrings": ["\\s{2}version: \"v(?<currentValue>[^\"]+)\""],
       "depNameTemplate": "kubernetes-sigs/cluster-api-addon-helm",
       "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^v(?<version>.+)",
@@ -221,7 +220,7 @@
       "description": "airgap images.txt container refs",
       "managerFilePatterns": ["/(^|/)airgap/images\\.txt$/"],
       "matchStrings": [
-        "^(?<depName>[^\\s:@]+):(?<currentValue>[^\\s@]+)(@(?<currentDigest>sha256:[a-f0-9]+))?$"
+        "(?:^|\n)(?<depName>(?:[a-zA-Z0-9._-]+(?::[0-9]+)?/)?(?:[^\s:@#/]+/)*[^\s:@#/]+):(?<currentValue>[^\s@:]+)(@(?<currentDigest>sha256:[a-f0-9]+))?[ \t]*(?:#.*)?\n"
       ],
       "datasourceTemplate": "docker",
       "versioningTemplate": "docker"
@@ -231,7 +230,7 @@
       "description": "zarf.yaml image refs (registry with optional port)",
       "managerFilePatterns": ["/(^|/)airgap/zarf\\.yaml$/"],
       "matchStrings": [
-        "- (?<depName>[a-zA-Z0-9._-]+(?::[0-9]+)?/[a-zA-Z0-9._/-]+):(?<currentValue>[^\\s@]+)$"
+        "- (?<depName>[a-zA-Z0-9._-]+(?::[0-9]+)?/[a-zA-Z0-9._/-]+):(?<currentValue>[^\s@]+)\n"
       ],
       "datasourceTemplate": "docker",
       "versioningTemplate": "docker"

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,286 @@
+{
+  // Renovate config for knr-ops (issue #74).
+  // Runs via scheduled GitHub Actions (see .github/workflows/renovate.yml).
+  // Version sources covered:
+  //   - Flux / Helm / Kubernetes manifests under mgmt/ and workload/
+  //   - GitHub Actions workflow action pins (.github/workflows/)
+  //   - mise tool pins (explicit per-tool custom managers below; the native
+  //     mise manager is disabled so dep resolution is deterministic)
+  //   - clusterctl operator provider manifests under mgmt/*/capi-providers/
+  //   - kind node images (cluster classes, airgap scripts, image inventory)
+  //   - airgap image inventory and zarf.yaml image lists
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":dependencyDashboard",
+    ":semanticCommits",
+    ":disableRateLimiting"
+  ],
+  "schedule": ["after 6am on monday"],
+  "timezone": "Europe/Helsinki",
+  "rangeStrategy": "pin",
+  "commitBody": "Refs: #74",
+  "suppressNotifications": ["prEditedNotification", "prIgnoreNotification"],
+  "rebaseWhen": "conflicted",
+  "ignorePaths": [
+    "airgap/rendered/**",
+    "airgap/archives/**",
+    "airgap/sbom/**",
+    "airgap/manifests/**"
+  ],
+  "flux": {
+    "managerFilePatterns": ["/(^|/)(mgmt|workload)/.+\\.ya?ml$/"]
+  },
+  "kubernetes": {
+    "managerFilePatterns": ["/(^|/)(mgmt|workload)/.+\\.ya?ml$/"]
+  },
+  "helm-values": {
+    "managerFilePatterns": ["/(^|/)(mgmt|workload)/.+\\.ya?ml$/"]
+  },
+  // Explicit per-tool custom managers replace the native mise manager so each
+  // tool resolves against the exact upstream GitHub repo we install from.
+  "mise": {
+    "enabled": false
+  },
+  "customManagers": [
+    // ── mise tool pins ────────────────────────────────────────────────────
+    {
+      "customType": "regex",
+      "description": "mise: go toolchain pin",
+      "managerFilePatterns": ["/(^|/)mise\\.toml$/"],
+      "matchStrings": ["^go = \"(?<currentValue>[^\"]+)\"$"],
+      "depNameTemplate": "golang/go",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^go(?<version>.+)",
+      "autoReplaceStringTemplate": "go = \"{{newValue}}\""
+    },
+    {
+      "customType": "regex",
+      "description": "mise: python toolchain pin",
+      "managerFilePatterns": ["/(^|/)mise\\.toml$/"],
+      "matchStrings": ["^python = \"(?<currentValue>[^\"]+)\"$"],
+      "depNameTemplate": "python/cpython",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.+)",
+      "autoReplaceStringTemplate": "python = \"{{newValue}}\""
+    },
+    {
+      "customType": "regex",
+      "description": "mise: kubectl version pin",
+      "managerFilePatterns": ["/(^|/)mise\\.toml$/"],
+      "matchStrings": ["^kubectl = \"(?<currentValue>[^\"]+)\"$"],
+      "depNameTemplate": "kubernetes/kubernetes",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.+)",
+      "autoReplaceStringTemplate": "kubectl = \"{{newValue}}\""
+    },
+    {
+      "customType": "regex",
+      "description": "mise: kind version pin",
+      "managerFilePatterns": ["/(^|/)mise\\.toml$/"],
+      "matchStrings": ["^kind = \"(?<currentValue>[^\"]+)\"$"],
+      "depNameTemplate": "kubernetes-sigs/kind",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.+)",
+      "autoReplaceStringTemplate": "kind = \"{{newValue}}\""
+    },
+    {
+      "customType": "regex",
+      "description": "mise: helm version pin",
+      "managerFilePatterns": ["/(^|/)mise\\.toml$/"],
+      "matchStrings": ["^helm = \"(?<currentValue>[^\"]+)\"$"],
+      "depNameTemplate": "helm/helm",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.+)",
+      "autoReplaceStringTemplate": "helm = \"{{newValue}}\""
+    },
+    {
+      "customType": "regex",
+      "description": "mise: clusterctl version pin",
+      "managerFilePatterns": ["/(^|/)mise\\.toml$/"],
+      "matchStrings": ["^clusterctl = \"(?<currentValue>[^\"]+)\"$"],
+      "depNameTemplate": "fluxcd/clusterctl",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.+)",
+      "autoReplaceStringTemplate": "clusterctl = \"{{newValue}}\""
+    },
+    {
+      "customType": "regex",
+      "description": "mise: flux2 CLI pin (floating latest tag)",
+      "managerFilePatterns": ["/(^|/)mise\\.toml$/"],
+      "matchStrings": ["^flux2 = \"(?<currentValue>[^\"]+)\"$"],
+      "depNameTemplate": "fluxcd/flux2",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.+)",
+      "autoReplaceStringTemplate": "flux2 = \"{{newValue}}\""
+    },
+    {
+      "customType": "regex",
+      "description": "mise: sops pin (floating latest tag)",
+      "managerFilePatterns": ["/(^|/)mise\\.toml$/"],
+      "matchStrings": ["^sops = \"(?<currentValue>[^\"]+)\"$"],
+      "depNameTemplate": "getsops/sops",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.+)",
+      "autoReplaceStringTemplate": "sops = \"{{newValue}}\""
+    },
+    {
+      "customType": "regex",
+      "description": "mise: age pin (floating latest tag)",
+      "managerFilePatterns": ["/(^|/)mise\\.toml$/"],
+      "matchStrings": ["^age = \"(?<currentValue>[^\"]+)\"$"],
+      "depNameTemplate": "FiloSottile/age",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.+)",
+      "autoReplaceStringTemplate": "age = \"{{newValue}}\""
+    },
+    {
+      "customType": "regex",
+      "description": "mise: zarf CLI pin (github backend, v-prefixed)",
+      "managerFilePatterns": ["/(^|/)mise\\.toml$/"],
+      "matchStrings": ["^version = \"v(?<currentValue>[^\"]+)\"$"],
+      "depNameTemplate": "zarf-dev/zarf",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.+)",
+      "autoReplaceStringTemplate": "version = \"v{{newValue}}\""
+    },
+    {
+      "customType": "regex",
+      "description": "mise: aws-cli pin (floating latest tag)",
+      "managerFilePatterns": ["/(^|/)mise\\.aws\\.toml$/"],
+      "matchStrings": ["^aws-cli = \"(?<currentValue>[^\"]+)\"$"],
+      "depNameTemplate": "aws/aws-cli",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.+)",
+      "autoReplaceStringTemplate": "aws-cli = \"{{newValue}}\""
+    },
+    {
+      "customType": "regex",
+      "description": "mise: clusterawsadm pin (inline table form)",
+      "managerFilePatterns": ["/(^|/)mise\\.aws\\.toml$/"],
+      "matchStrings": ["^clusterawsadm = \\{ version = \"(?<currentValue>[^\"]+)\""],
+      "depNameTemplate": "kubernetes-sigs/clusterawsadm",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.+)",
+      "autoReplaceStringTemplate": "clusterawsadm = { version = \"{{newValue}}\""
+    },
+    // ── clusterctl operator provider manifests ───────────────────────────
+    {
+      "customType": "regex",
+      "description": "CAPI core, kubeadm, and CAPD provider versions",
+      "managerFilePatterns": [
+        "/(^|/)mgmt/(aws|local-host)/capi-providers/(capi-system|capd-system)/.+\\.ya?ml$/"
+      ],
+      "matchStrings": ["^\\s{2}version: \"v(?<currentValue>[^\"]+)\"$"],
+      "depNameTemplate": "kubernetes-sigs/cluster-api",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.+)",
+      "autoReplaceStringTemplate": "  version: \"v{{newValue}}\""
+    },
+    {
+      "customType": "regex",
+      "description": "CAPA (AWS infrastructure) provider version",
+      "managerFilePatterns": [
+        "/(^|/)mgmt/aws/capi-providers/capa-system/.+\\.ya?ml$/"
+      ],
+      "matchStrings": ["^\\s{2}version: \"v(?<currentValue>[^\"]+)\"$"],
+      "depNameTemplate": "kubernetes-sigs/cluster-api-provider-aws",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.+)",
+      "autoReplaceStringTemplate": "  version: \"v{{newValue}}\""
+    },
+    {
+      "customType": "regex",
+      "description": "CAAPH (helm add-on) provider version",
+      "managerFilePatterns": [
+        "/(^|/)mgmt/(aws|local-host)/capi-providers/caaph-system/.+\\.ya?ml$/"
+      ],
+      "matchStrings": ["^\\s{2}version: \"v(?<currentValue>[^\"]+)\"$"],
+      "depNameTemplate": "kubernetes-sigs/cluster-api-addon-helm",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.+)",
+      "autoReplaceStringTemplate": "  version: \"v{{newValue}}\""
+    },
+    // ── kind node images ─────────────────────────────────────────────────
+    {
+      "customType": "regex",
+      "description": "kindest/node image pins in cluster classes and airgap scripts",
+      "managerFilePatterns": [
+        "/(^|/)mgmt/.+\\.ya?ml$/",
+        "/(^|/)airgap/scripts/.+\\.sh$/"
+      ],
+      "matchStrings": ["kindest/node:v(?<currentValue>[0-9A-Za-z.\\-]+)"],
+      "depNameTemplate": "kindest/node",
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "docker",
+      "autoReplaceStringTemplate": "kindest/node:v{{newValue}}"
+    },
+    // ── airgap image inventory and zarf package ──────────────────────────
+    {
+      "customType": "regex",
+      "description": "airgap images.txt container refs",
+      "managerFilePatterns": ["/(^|/)airgap/images\\.txt$/"],
+      "matchStrings": [
+        "^(?<depName>[^\\s:@]+):(?<currentValue>[^\\s@]+)(@(?<currentDigest>sha256:[a-f0-9]+))?$"
+      ],
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "description": "zarf.yaml image refs (registry with optional port)",
+      "managerFilePatterns": ["/(^|/)airgap/zarf\\.yaml$/"],
+      "matchStrings": [
+        "- (?<depName>[a-zA-Z0-9._-]+(?::[0-9]+)?/[a-zA-Z0-9._/-]+):(?<currentValue>[^\\s@]+)$"
+      ],
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "docker"
+    },
+    // EKS addon versions (*-eksbuild.*) intentionally not managed: they have
+    // no public registry datasource. Tracked in issue #74 as manual updates.
+    // ── end customManagers ────────────────────────────────────────────────
+  ],
+  "packageRules": [
+    {
+      "description": "No automerge anywhere; merges stay manual (issue #74)",
+      "matchUpdateTypes": ["major", "minor", "patch", "digest", "pin", "pinDigest"],
+      "automerge": false
+    },
+    {
+      "description": "Group Flux controller images and CLI updates",
+      "matchDatasources": ["docker", "github-releases", "helm"],
+      "matchPackageNames": [
+        "/^ghcr\\.io/fluxcd//",
+        "/^ghcr\\.io/controlplaneio-fluxcd//",
+        "/^fluxcd//"
+      ],
+      "groupName": "flux"
+    },
+    {
+      "description": "Group the CAPI family (core, kubeadm, CAPD, CAPA, CAAPH)",
+      "matchDatasources": ["github-releases"],
+      "matchPackageNames": [
+        "kubernetes-sigs/cluster-api",
+        "kubernetes-sigs/cluster-api-provider-aws",
+        "kubernetes-sigs/cluster-api-addon-helm"
+      ],
+      "groupName": "cluster-api"
+    },
+    {
+      "description": "Kubernetes node/cluster versions stay independent of each other",
+      "matchDepNames": ["kindest/node"],
+      "separateMajorMinor": true,
+      "groupName": null
+    },
+    {
+      "description": "Pin floating latest mise values to concrete release versions",
+      "matchPackageNames": [
+        "fluxcd/flux2",
+        "getsops/sops",
+        "FiloSottile/age",
+        "aws/aws-cli"
+      ],
+      "rangeStrategy": "pin"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Implements the first phase of #74: automated dependency update discovery and pull-request preparation via Renovate, running as a scheduled GitHub Actions workflow.

- `renovate.json5`: flux / kubernetes / helm-values managers scoped to `mgmt/` and `workload/`, GitHub Actions action pins, explicit per-tool mise custom managers (native mise manager disabled for deterministic dep resolution), clusterctl provider manifests (CAPI, CAPD, CAPA, CAAPH), kindest/node image pins, airgap `images.txt` and `zarf.yaml` image refs.
- `.github/workflows/renovate.yml`: weekly Monday 05:00 UTC run plus `workflow_dispatch` with dry-run default; `renovatebot/github-action@v42`; `permissions: {}`; concurrency group.
- Global `automerge: false`; merges stay manual per #74. Flux and cluster-api families grouped; kindest/node versions kept independent. EKS addon versions left unmanaged (no public datasource), noted in config comments.

Config validated with `renovate-config-validator`.

Stacked PRs to follow: air-gap inventory consistency check in CI, then catalog retirement.

Refs #74

## Required follow-up (repo admin)

- Add repo secret `RENOVATE_TOKEN` (fine-grained PAT, contents and pull request read/write on this repo only).
- Trigger the workflow with dry-run enabled to verify dependency extraction.