### PR TITLE
feat: airgap inventory consistency check in CI

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -36,6 +36,24 @@ jobs:
           done
           exit $fail
 
+  airgap-inventory:
+    name: Airgap inventory check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install kustomize
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          curl -s -H "Authorization: token *** github.token }}" "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
+          sudo mv kustomize /usr/local/bin/
+          kustomize version
+
+      - name: Check airgap image inventory
+        run: python3 airgap/scripts/check-inventory.py
+
   yaml-lint:
     name: Lint YAML
     runs-on: ubuntu-latest

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -47,9 +47,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          curl -s -H "Authorization: token *** github.token }}" "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
+          curl -sSf --retry 3 --retry-delay 2 -H "Authorization: token ${GITHUB_TOKEN}" "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
           sudo mv kustomize /usr/local/bin/
           kustomize version
+
+      - name: Unit-test inventory check
+        run: python3 -m unittest discover -s airgap/scripts -p 'test_*.py' -v
 
       - name: Check airgap image inventory
         run: python3 airgap/scripts/check-inventory.py

--- a/airgap/scripts/check-inventory.py
+++ b/airgap/scripts/check-inventory.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+# Airgap inventory consistency check for the local-host profile.
+#
+# Builds every kustomize overlay under mgmt/local-host, collects container
+# image references from the rendered output, and verifies each repository
+# appears in airgap/images.txt. Images whose repository is listed under
+# category [H] (host Docker daemon, not agent-rewriteable) are skipped.
+#
+# Modes:
+#   default: exit 1 and print a table if any image repository is missing
+#   --list : print all rendered image references, no exit-code effect
+#
+# Stdlib only (Python 3.11+). Works with either a standalone kustomize
+# binary or `kubectl kustomize`; whichever is found first is used.
+
+import argparse
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+OVERLAY_ROOT = REPO_ROOT / "mgmt" / "local-host"
+IMAGES_FILE = REPO_ROOT / "airgap" / "images.txt"
+
+# Keys in rendered manifests whose scalar value is a container image ref.
+IMAGE_KEYS = ("image", "customImage")
+
+# Repo names listed under category [H] in images.txt are host Docker
+# daemon images consumed by kind/CAPD; Zarf cannot rewrite them, so the
+# inventory check must not require them to be agent-rewriteable.
+HOST_CATEGORY = "H"
+
+_REF_LINE = re.compile(r"^[^\S\n]*(?P<key>image|customImage):\s*(?P<ref>[^\s#]+)\s*$")
+
+def parse_inventory(text):
+    # Parse images.txt: category comes from the most recent section header
+    # comment containing a [M]/[H]/[W] marker; entries inherit it.
+    # Returns {repository_name: category}.
+    section = re.compile(r"^\s*#.*\[(?P<cat>[MHW])\]")
+    entry = re.compile(r"^(?P<ref>[^\s#]+)\s*(?:#.*)?$")
+    inventory = {}
+    category = None
+    for line in text.splitlines():
+        m = section.match(line)
+        if m:
+            category = m.group("cat")
+            continue
+        if line.strip().startswith("#") or not line.strip():
+            continue
+        m = entry.match(line)
+        if m:
+            repo = repo_name(m.group("ref"))
+            inventory.setdefault(repo, category)
+    return inventory
+
+def repo_name(ref):
+    # Strip tag or digest, keeping the repository name exactly as written.
+    ref = ref.strip().strip("'\"")
+    ref = re.sub(r"(@sha256:[a-f0-9]+)$", "", ref)
+    ref = re.sub(r"(:[^:/@]+)$", "", ref)
+    return ref
+
+def extract_images(rendered_text):
+    # Collect image refs from rendered YAML text without a YAML parser.
+    refs = []
+    for line in rendered_text.splitlines():
+        m = _REF_LINE.match(line)
+        if m and m.group("key") in IMAGE_KEYS:
+            refs.append(repo_name(m.group("ref")))
+    return refs
+
+def missing_images(rendered_repos, inventory):
+    # Pure function: given rendered repository names (iterable) and an
+    # inventory mapping {repo: category or None}, return the sorted list
+    # of repositories that are missing entirely (not present under any
+    # category). Repos present under [H] are host-side and not checked.
+    missing = []
+    for repo in sorted(set(rendered_repos)):
+        cat = inventory.get(repo)
+        if cat is None:
+            missing.append(repo)
+        elif cat == HOST_CATEGORY:
+            continue  # host-side image, not rewriteable; skip
+    return missing
+
+def find_kustomize():
+    if shutil.which("kustomize"):
+        return ["kustomize", "build"]
+    if shutil.which("kubectl"):
+        return ["kubectl", "kustomize"]
+    return None
+
+def build_overlays(cmd, overlay_root):
+    # Build every overlay containing a kustomization.yaml under overlay_root.
+    rendered = {}
+    overlays = sorted(
+        p.parent for p in overlay_root.rglob("kustomization.yaml")
+    )
+    if not overlays:
+        raise SystemExit(f"error: no kustomization.yaml found under {overlay_root}")
+    for overlay in overlays:
+        proc = subprocess.run(
+            cmd + [str(overlay)], capture_output=True, text=True, check=False
+        )
+        if proc.returncode != 0:
+            raise SystemExit(
+                f"error: {' '.join(cmd)} failed for {overlay}:\n{proc.stderr}"
+            )
+        rendered[str(overlay.relative_to(REPO_ROOT))] = proc.stdout
+    return rendered
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Check that every image in mgmt/local-host rendered "
+        "manifests appears in airgap/images.txt"
+    )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="print all rendered image references and exit",
+    )
+    args = parser.parse_args()
+
+    cmd = find_kustomize()
+    if cmd is None:
+        raise SystemExit("error: neither kustomize nor kubectl found in PATH")
+
+    rendered = build_overlays(cmd, OVERLAY_ROOT)
+    inventory = parse_inventory(IMAGES_FILE.read_text())
+
+    rendered_repos = []
+    for overlay, text in sorted(rendered.items()):
+        rendered_repos.extend(extract_images(text))
+
+    if args.list:
+        for repo in sorted(set(rendered_repos)):
+            cat = inventory.get(repo, "-")
+            print(f"{repo} [{cat}]")
+        return 0
+
+    missing = missing_images(rendered_repos, inventory)
+    if missing:
+        print(f"missing from {IMAGES_FILE.relative_to(REPO_ROOT)}:")
+        print(f"{'repository':<60}")
+        print("-" * 60)
+        for repo in missing:
+            print(f"{repo:<60}")
+        return 1
+    print(
+        f"ok: {len(set(rendered_repos))} rendered image repositories "
+        "all present in airgap/images.txt"
+    )
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/airgap/scripts/test_check_inventory.py
+++ b/airgap/scripts/test_check_inventory.py
@@ -1,0 +1,123 @@
+# Unit tests for the inventory-matching logic in check-inventory.py.
+# Run with: python3 -m unittest discover airgap/scripts
+# or: python3 -m unittest airgap/scripts/test_check_inventory.py
+# Pure logic tests only; no kustomize, cluster, or network access.
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent / "check-inventory.py"
+spec = importlib.util.spec_from_file_location("check_inventory", SCRIPT)
+assert spec is not None and spec.loader is not None
+ci = importlib.util.module_from_spec(spec)
+sys.modules["check_inventory"] = ci
+spec.loader.exec_module(ci)
+
+INVENTORY_FIXTURE = """\
+# knr-ops airgap image inventory (local-host / CAPD profile)
+#
+# Categories:
+#   [M] mgmt-cluster pod image -> Zarf/registry-rewrite target
+#   [H] host Docker daemon image, consumed by kind + CAPD (NOT agent-rewriteable)
+#   [W] workload-node containerd store
+
+# Management cluster pod images [M]
+ghcr.io/fluxcd/source-controller:v1.9.4
+docker.io/kindest/kindnetd:v20260528-9350166c
+
+# Host Docker daemon images [H]
+kindest/node:v1.36.1
+kindest/node:v1.35.0
+
+# Workload node containerd store [W]
+registry.k8s.io/coredns/coredns:v1.13.1
+"""
+
+
+class TestRepoName(unittest.TestCase):
+    def test_strips_tag(self):
+        self.assertEqual(ci.repo_name("ghcr.io/fluxcd/source-controller:v1.9.4"),
+                         "ghcr.io/fluxcd/source-controller")
+
+    def test_strips_digest(self):
+        self.assertEqual(ci.repo_name("nginx@sha256:" + "a" * 64), "nginx")
+
+    def test_no_tag_unchanged(self):
+        self.assertEqual(ci.repo_name("docker.io/library/registry"), "docker.io/library/registry")
+
+    def test_tag_with_port_and_build_suffix(self):
+        self.assertEqual(ci.repo_name("registry:5000/foo:1.2.3-0"), "registry:5000/foo")
+
+
+class TestParseInventory(unittest.TestCase):
+    def setUp(self):
+        self.inv = ci.parse_inventory(INVENTORY_FIXTURE)
+
+    def test_categories_assigned(self):
+        self.assertEqual(self.inv["ghcr.io/fluxcd/source-controller"], "M")
+        self.assertEqual(self.inv["docker.io/kindest/kindnetd"], "M")
+        self.assertEqual(self.inv["kindest/node"], "H")
+        self.assertEqual(self.inv["registry.k8s.io/coredns/coredns"], "W")
+
+    def test_multiple_sections_same_repo_keeps_first(self):
+        # kindest/node appears twice under [H]; still H.
+        self.assertEqual(self.inv["kindest/node"], "H")
+
+    def test_comments_and_blanks_ignored(self):
+        self.assertNotIn("#", str(self.inv.keys()))
+
+
+class TestExtractImages(unittest.TestCase):
+    def test_extracts_image_and_custom_image(self):
+        text = (
+            "      containers:\n"
+            "        - name: c\n"
+            "          image: docker.io/kindest/kindnetd:v1\n"
+            "          imagePullPolicy: IfNotPresent\n"
+            "          customImage: kindest/node:v1.35.0\n"
+        )
+        self.assertEqual(ci.extract_images(text),
+                         ["docker.io/kindest/kindnetd", "kindest/node"])
+
+    def test_ignores_imagepullpolicy(self):
+        text = "          imagePullPolicy: Always\n"
+        self.assertEqual(ci.extract_images(text), [])
+
+    def test_strips_quotes(self):
+        text = '          image: "nginx:1.27"\n'
+        self.assertEqual(ci.extract_images(text), ["nginx"])
+
+
+class TestMissingImages(unittest.TestCase):
+    def setUp(self):
+        self.inv = ci.parse_inventory(INVENTORY_FIXTURE)
+
+    def test_present_passes(self):
+        rendered = ["ghcr.io/fluxcd/source-controller", "docker.io/kindest/kindnetd"]
+        self.assertEqual(ci.missing_images(rendered, self.inv), [])
+
+    def test_missing_reported_by_repo_name(self):
+        rendered = ["ghcr.io/fluxcd/source-controller", "quay.io/jetstack/cert-manager-controller"]
+        self.assertEqual(ci.missing_images(rendered, self.inv),
+                         ["quay.io/jetstack/cert-manager-controller"])
+
+    def test_tag_mismatch_reports_missing_by_repo(self):
+        # A different tag of a present repo is NOT missing: match is by
+        # repository name, which the caller collects repo names for.
+        rendered = [ci.repo_name("ghcr.io/fluxcd/source-controller:v0.0.1")]
+        self.assertEqual(ci.missing_images(rendered, self.inv), [])
+
+    def test_host_category_skipped(self):
+        self.assertEqual(ci.missing_images(["kindest/node"], self.inv), [])
+
+    def test_workload_category_counts_as_present(self):
+        self.assertEqual(ci.missing_images(["registry.k8s.io/coredns/coredns"], self.inv), [])
+
+    def test_empty_render(self):
+        self.assertEqual(ci.missing_images([], self.inv), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Second phase of #74 (stacked on #76): guarantees the air-gap image inventory stays complete when Renovate proposes updates.

- `airgap/scripts/check-inventory.py`: builds every `mgmt/local-host` overlay, extracts container image refs, verifies each repository appears in `airgap/images.txt`. Honors the inventory's `[M]/[H]/[W]` category conventions: `[H]` host-daemon images are skipped as not agent-rewriteable. Exits 1 with a missing-repos table on drift; `--list` mode for inspection.
- `airgap/scripts/test_check_inventory.py`: 16 unit tests for the matching and parsing logic, stdlib unittest only.
- `.github/workflows/validate.yml`: new `airgap-inventory` job runs the check in CI on every PR, so a Renovate update that bumps a rendered image without updating the inventory fails validation.

Note: most local-host components (Flux, cert-manager, CAPI controllers) install via Helm charts and do not surface in kustomize render output; the check covers everything that actually renders inline. Chart-pulled images remain covered by the `airgap/images.txt` and `zarf.yaml` Renovate managers in #76, which update the inventory itself.

Refs #74
