### PR TITLE
ci: harden kustomize install in kustomize-build job

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -20,7 +20,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          curl -s -H "Authorization: token ${{ github.token }}" "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
+          curl -sSf --retry 3 --retry-delay 2 -H "Authorization: token ${GITHUB_TOKEN}" "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
           sudo mv kustomize /usr/local/bin/
           kustomize version
 


### PR DESCRIPTION
## Summary

Applies the same one-line hardening from #77 to the pre-existing kustomize-install step in the `kustomize-build` job of the validate workflow:

- `curl -s` -> `curl -sSf --retry 3 --retry-delay 2` so transient raw.githubusercontent failures retry and HTTP errors (e.g. a 404 body piped into bash, exit 127) fail loudly instead.

Seen in the wild on #77's first CI run and #78's run at 05:13 on 2026-08-27; all validate runs since were green, i.e. transient network flake.

Refs #74