### PR TITLE
fix: point clusterawsadm manager at cluster-api-provider-aws (refs #74)

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -159,7 +159,7 @@
       "description": "mise: clusterawsadm pin (inline table form)",
       "managerFilePatterns": ["/(^|/)mise\\.aws\\.toml$/"],
       "matchStrings": ["clusterawsadm = \\{ version = \"(?<currentValue>[^\"]+)\""],
-      "depNameTemplate": "kubernetes-sigs/clusterawsadm",
+      "depNameTemplate": "kubernetes-sigs/cluster-api-provider-aws",
       "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^v(?<version>.+)",
       "autoReplaceStringTemplate": "clusterawsadm = { version = \"{{newValue}}\""


### PR DESCRIPTION
## Problem

The clusterawsadm custom manager in renovate.json5 uses depName `kubernetes-sigs/clusterawsadm`, which does not exist (GitHub API 404). clusterawsadm releases ship from `kubernetes-sigs/cluster-api-provider-aws` — the same repo mise resolves the tool to (`mise registry clusterawsadm` -> `github:kubernetes-sigs/cluster-api-provider-aws`). Commit 58f7179's title said it corrected both CAAPH and clusterawsadm depNames, but its diff only changed CAAPH, so every Renovate run would log a failed lookup for clusterawsadm.

## Fix

One line: depNameTemplate now `kubernetes-sigs/cluster-api-provider-aws`. The dep then also joins the existing cluster-api package group (clusterawsadm tracks CAPA per the catalog note), which already lists that repo.

## Verification

- `gh api repos/kubernetes-sigs/cluster-api-provider-aws/releases/latest` -> v2.13.0 (matches the current mise.aws.toml pin; `^v` extractVersion fits the tag format).
- Full local dry-run (renovate CLI 42.99.0, `--platform=local --dry-run=full`, token active): **zero failed lookups** across the whole run (previously 8, driven by the two 404 repos), and the dep resolves with currentValue 2.13.0 against latest v2.13.0 producing no spurious update PR.

Refs #74