### PR TITLE
feat: management cluster definitions for the CAPI pivot (aws + local-host)

### DIFF
--- a/mgmt/aws/clusters/eu-north-1/kustomization.yaml
+++ b/mgmt/aws/clusters/eu-north-1/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - staging
+  - management

--- a/mgmt/aws/clusters/eu-north-1/management/capi-nameref.yaml
+++ b/mgmt/aws/clusters/eu-north-1/management/capi-nameref.yaml
@@ -1,0 +1,19 @@
+nameReference:
+  - kind: AWSManagedCluster
+    fieldSpecs:
+      - path: spec/infrastructureRef/name
+        kind: Cluster
+  - kind: AWSManagedControlPlane
+    fieldSpecs:
+      - path: spec/controlPlaneRef/name
+        kind: Cluster
+  - kind: AWSManagedMachinePool
+    fieldSpecs:
+      - path: spec/template/spec/infrastructureRef/name
+        kind: MachinePool
+  - kind: Cluster
+    fieldSpecs:
+      - path: spec/clusterName
+        kind: MachinePool
+      - path: spec/template/spec/clusterName
+        kind: MachinePool

--- a/mgmt/aws/clusters/eu-north-1/management/cluster.yaml
+++ b/mgmt/aws/clusters/eu-north-1/management/cluster.yaml
@@ -1,0 +1,93 @@
+---
+# ── EKS management Cluster ──────────────────────────────────────────────────
+# The management cluster manages itself: this object is created by CAPA in the
+# kind bootstrap cluster, moved into the management cluster by `clusterctl
+# move` (pivot.sh), and from then on reconciled from Git by the Flux instance
+# running inside it. See docs/operations.md "Bootstrap and pivot".
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: management
+  namespace: default
+  labels:
+    region: eu-north-1
+    # Deliberately NOT `fluxcd: enabled`: the ClusterResourceSets in
+    # mgmt/aws/addons/flux-apps/ select on fluxcd=enabled + region and would
+    # deploy a workload-cluster FluxInstance into the management cluster.
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+        - 192.168.0.0/16
+    services:
+      cidrBlocks:
+        - 10.128.0.0/12
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    kind: AWSManagedControlPlane
+    name: management-control-plane
+  # Literal final name: the AWSManagedCluster lives outside this overlay (in
+  # mgmt/aws/infrastructure/aws-clusters-resources/) so the nameReference for
+  # it does not fire — same as the workload clusters.
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    kind: AWSManagedCluster
+    name: eu-north-1-management
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+kind: AWSManagedControlPlane
+metadata:
+  name: management-control-plane
+  namespace: default
+spec:
+  region: eu-north-1
+  version: "1.34.6"
+  endpointAccess:
+    public: true
+    private: false
+  addons:
+    - name: vpc-cni
+      version: v1.21.1-eksbuild.7
+      conflictResolution: overwrite
+    - name: coredns
+      version: v1.13.2-eksbuild.4
+      conflictResolution: overwrite
+    - name: kube-proxy
+      version: v1.34.6-eksbuild.2
+      conflictResolution: overwrite
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachinePool
+metadata:
+  name: management-pool
+  namespace: default
+spec:
+  clusterName: management
+  replicas: 2
+  template:
+    spec:
+      clusterName: management
+      bootstrap:
+        dataSecretName: ""
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: AWSManagedMachinePool
+        name: management-pool
+      version: "1.34.6"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: AWSManagedMachinePool
+metadata:
+  name: management-pool
+  namespace: default
+spec:
+  instanceType: t4g.medium
+  scaling:
+    minSize: 2
+    maxSize: 3
+  amiType: AL2023_ARM_64_STANDARD
+  capacityType: onDemand
+  availabilityZones:
+    - eu-north-1a
+    - eu-north-1b
+    - eu-north-1c

--- a/mgmt/aws/clusters/eu-north-1/management/kustomization.yaml
+++ b/mgmt/aws/clusters/eu-north-1/management/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namePrefix: eu-north-1-
+configurations:
+  - capi-nameref.yaml
+resources:
+  - cluster.yaml

--- a/mgmt/aws/infrastructure/aws-clusters-resources/managedclusters.yaml
+++ b/mgmt/aws/infrastructure/aws-clusters-resources/managedclusters.yaml
@@ -14,3 +14,12 @@ metadata:
   name: eu-west-1-workload
   namespace: default
 spec: {}
+---
+# Infrastructure resource for the EKS management cluster. The Cluster in
+# mgmt/aws/clusters/eu-north-1/management/ references this literal name.
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: AWSManagedCluster
+metadata:
+  name: eu-north-1-management
+  namespace: default
+spec: {}

--- a/mgmt/local-host/clusters/flux-ks.yaml
+++ b/mgmt/local-host/clusters/flux-ks.yaml
@@ -20,3 +20,29 @@ spec:
       kind: Cluster
       name: local-workload
       namespace: default
+---
+# The CAPD management cluster: created by CAPD in the kind bootstrap cluster,
+# moved into itself by `clusterctl move` (pivot.sh), and from then on
+# reconciled from the OCI artifact by the Flux instance running inside it.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: docker-management-cluster
+  namespace: flux-system
+spec:
+  interval: 5m
+  retryInterval: 2m
+  timeout: 5m
+  prune: true
+  wait: false
+  sourceRef:
+    kind: OCIRepository
+    name: flux-system
+  path: ./mgmt/local-host/clusters/management
+  dependsOn:
+    - name: capd-system
+  healthChecks:
+    - apiVersion: cluster.x-k8s.io/v1beta2
+      kind: Cluster
+      name: local-management
+      namespace: default

--- a/mgmt/local-host/clusters/management/cluster-class.yaml
+++ b/mgmt/local-host/clusters/management/cluster-class.yaml
@@ -1,0 +1,121 @@
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: ClusterClass
+metadata:
+  name: docker-management
+  namespace: default
+spec:
+  infrastructure:
+    templateRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: DevClusterTemplate
+      name: docker-management
+  controlPlane:
+    templateRef:
+      apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+      kind: KubeadmControlPlaneTemplate
+      name: docker-management-control-plane
+    machineInfrastructure:
+      templateRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: DevMachineTemplate
+        name: docker-management-control-plane
+  workers:
+    machineDeployments:
+      - class: default-worker
+        bootstrap:
+          templateRef:
+            apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
+            kind: KubeadmConfigTemplate
+            name: docker-management-worker
+        infrastructure:
+          templateRef:
+            apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+            kind: DevMachineTemplate
+            name: docker-management-worker
+---
+# NOTE: CAPD places every node/lb container on the docker network "kind" by
+# default (no API field for it). That is load-bearing here: knr-registry is
+# attached to the same network, so nodes can pull the OCI artifact that Flux
+# syncs mgmt/local-host from, and the network survives `kind delete cluster`
+# because the registry stays attached.
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: DevClusterTemplate
+metadata:
+  name: docker-management
+  namespace: default
+spec:
+  template:
+    spec:
+      backend:
+        docker: {}
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+kind: KubeadmControlPlaneTemplate
+metadata:
+  name: docker-management-control-plane
+  namespace: default
+spec:
+  template:
+    spec:
+      kubeadmConfigSpec:
+        clusterConfiguration:
+          apiServer:
+            certSANs:
+              - localhost
+              - 127.0.0.1
+              - 0.0.0.0
+              - host.docker.internal
+        initConfiguration:
+          nodeRegistration:
+            kubeletExtraArgs:
+              - name: eviction-hard
+                value: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+        joinConfiguration:
+          nodeRegistration:
+            kubeletExtraArgs:
+              - name: eviction-hard
+                value: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: DevMachineTemplate
+metadata:
+  name: docker-management-control-plane
+  namespace: default
+spec:
+  template:
+    spec:
+      backend:
+        docker:
+          customImage: kindest/node:v1.35.0
+          extraMounts:
+            - hostPath: /var/run/docker.sock
+              containerPath: /var/run/docker.sock
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: DevMachineTemplate
+metadata:
+  name: docker-management-worker
+  namespace: default
+spec:
+  template:
+    spec:
+      backend:
+        docker:
+          customImage: kindest/node:v1.35.0
+          extraMounts:
+            - hostPath: /var/run/docker.sock
+              containerPath: /var/run/docker.sock
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
+kind: KubeadmConfigTemplate
+metadata:
+  name: docker-management-worker
+  namespace: default
+spec:
+  template:
+    spec:
+      joinConfiguration:
+        nodeRegistration:
+          kubeletExtraArgs:
+            - name: eviction-hard
+              value: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%

--- a/mgmt/local-host/clusters/management/cluster.yaml
+++ b/mgmt/local-host/clusters/management/cluster.yaml
@@ -1,0 +1,31 @@
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: Cluster
+metadata:
+  name: local-management
+  namespace: default
+  labels:
+    # profile=local-host makes the kindnet ClusterResourceSet supply the CNI
+    # (CAPD clusters ship none). Deliberately NOT `fluxcd: enabled`: that
+    # label would make the local-workload-flux-instance ClusterResourceSet
+    # deploy a workload FluxInstance into the management cluster.
+    profile: local-host
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+        - 192.168.0.0/16
+    serviceDomain: cluster.local
+    services:
+      cidrBlocks:
+        - 10.128.0.0/12
+  topology:
+    classRef:
+      name: docker-management
+    version: v1.35.0
+    controlPlane:
+      replicas: 1
+    workers:
+      machineDeployments:
+        - class: default-worker
+          name: md-0
+          replicas: 1

--- a/mgmt/local-host/clusters/management/kustomization.yaml
+++ b/mgmt/local-host/clusters/management/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cluster-class.yaml
+  - cluster.yaml


### PR DESCRIPTION
## What

Declares the management clusters that issue #79 pivots into, one per profile, following each profile's existing cluster pattern exactly:

- **aws**: `mgmt/aws/clusters/eu-north-1/management/` — EKS-based (`AWSManagedControlPlane` + `AWSManagedCluster` + `AWSManagedMachinePool`), 2x t4g.medium (min 2 / max 3, AZs a/b/c), public endpoint, k8s 1.34.6. The `AWSManagedCluster` infra resource joins the central list in `mgmt/aws/infrastructure/aws-clusters-resources/` with the literal name `eu-north-1-management`.
- **local-host**: `mgmt/local-host/clusters/management/` — CAPD/Docker via a new ClusterClass `docker-management` (DevClusterTemplate + KubeadmControlPlaneTemplate + DevMachineTemplates, `kindest/node:v1.35.0`), Cluster `local-management`, 1 CP + 1 worker, wired with a `docker-management-cluster` Flux Kustomization.

## Why

First PR of the #79 stack: the definitions exist in Git so the providers running in the kind bootstrap cluster can create these clusters, and `clusterctl move` (pivot tooling, next PR) can adopt them.

## Details worth review

- **Label wiring (the CRS trap)**: the aws management Cluster carries `region: eu-north-1` but deliberately **no** `fluxcd: enabled`; the local-host one carries `profile: local-host` (so the kindnet CRS supplies the CNI — CAPD clusters ship none) but also no `fluxcd: enabled`. Either label would trigger a ClusterResourceSet that deploys a workload FluxInstance into the management cluster.
- CAPD places node/lb containers on the docker `kind` network by default (no API field), which is what makes `knr-registry` reachable from the management cluster nodes; the network survives `kind delete cluster` because the registry stays attached. Commented in the ClusterClass.
- No new images; airgap inventory check stays green (`check-inventory.py` verified locally).

## Merge-timing note (aws)

Merging this starts provisioning the EKS management cluster from the current kind management cluster (~15-25 min, billing starts). The pivot runbook lands in the next PR; run it promptly after this merges.

## Validation

- `mise run validate` green (deps-check, bash -n, every kustomize overlay incl. the two new ones)
- namePrefix/nameReference rewriting verified in the rendered output (`infrastructureRef` stays the literal `eu-north-1-management`, matching the central infra list)
- `python3 airgap/scripts/check-inventory.py` — ok

Part 1 of 4 (definitions -> pivot tooling -> teardown -> docs). Refs #79.