### PR TITLE
feat: EKS management cluster definition for self-management (aws)

### DIFF
--- a/mgmt/aws/clusters/eu-north-1/kustomization.yaml
+++ b/mgmt/aws/clusters/eu-north-1/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - staging
+  - management

--- a/mgmt/aws/clusters/eu-north-1/management/capi-nameref.yaml
+++ b/mgmt/aws/clusters/eu-north-1/management/capi-nameref.yaml
@@ -1,0 +1,19 @@
+nameReference:
+  - kind: AWSManagedCluster
+    fieldSpecs:
+      - path: spec/infrastructureRef/name
+        kind: Cluster
+  - kind: AWSManagedControlPlane
+    fieldSpecs:
+      - path: spec/controlPlaneRef/name
+        kind: Cluster
+  - kind: AWSManagedMachinePool
+    fieldSpecs:
+      - path: spec/template/spec/infrastructureRef/name
+        kind: MachinePool
+  - kind: Cluster
+    fieldSpecs:
+      - path: spec/clusterName
+        kind: MachinePool
+      - path: spec/template/spec/clusterName
+        kind: MachinePool

--- a/mgmt/aws/clusters/eu-north-1/management/cluster.yaml
+++ b/mgmt/aws/clusters/eu-north-1/management/cluster.yaml
@@ -1,0 +1,93 @@
+---
+# ── EKS management Cluster ──────────────────────────────────────────────────
+# The management cluster manages itself: this object is created by CAPA in the
+# kind bootstrap cluster, moved into the management cluster by `clusterctl
+# move` (pivot.sh), and from then on reconciled from Git by the Flux instance
+# running inside it. See docs/operations.md "Bootstrap and pivot".
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: management
+  namespace: default
+  labels:
+    region: eu-north-1
+    # Deliberately NOT `fluxcd: enabled`: the ClusterResourceSets in
+    # mgmt/aws/addons/flux-apps/ select on fluxcd=enabled + region and would
+    # deploy a workload-cluster FluxInstance into the management cluster.
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+        - 192.168.0.0/16
+    services:
+      cidrBlocks:
+        - 10.128.0.0/12
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    kind: AWSManagedControlPlane
+    name: management-control-plane
+  # Literal final name: the AWSManagedCluster lives outside this overlay (in
+  # mgmt/aws/infrastructure/aws-clusters-resources/) so the nameReference for
+  # it does not fire — same as the workload clusters.
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    kind: AWSManagedCluster
+    name: eu-north-1-management
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+kind: AWSManagedControlPlane
+metadata:
+  name: management-control-plane
+  namespace: default
+spec:
+  region: eu-north-1
+  version: "1.34.6"
+  endpointAccess:
+    public: true
+    private: false
+  addons:
+    - name: vpc-cni
+      version: v1.21.1-eksbuild.7
+      conflictResolution: overwrite
+    - name: coredns
+      version: v1.13.2-eksbuild.4
+      conflictResolution: overwrite
+    - name: kube-proxy
+      version: v1.34.6-eksbuild.2
+      conflictResolution: overwrite
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachinePool
+metadata:
+  name: management-pool
+  namespace: default
+spec:
+  clusterName: management
+  replicas: 2
+  template:
+    spec:
+      clusterName: management
+      bootstrap:
+        dataSecretName: ""
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: AWSManagedMachinePool
+        name: management-pool
+      version: "1.34.6"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: AWSManagedMachinePool
+metadata:
+  name: management-pool
+  namespace: default
+spec:
+  instanceType: t4g.medium
+  scaling:
+    minSize: 2
+    maxSize: 3
+  amiType: AL2023_ARM_64_STANDARD
+  capacityType: onDemand
+  availabilityZones:
+    - eu-north-1a
+    - eu-north-1b
+    - eu-north-1c

--- a/mgmt/aws/clusters/eu-north-1/management/kustomization.yaml
+++ b/mgmt/aws/clusters/eu-north-1/management/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namePrefix: eu-north-1-
+configurations:
+  - capi-nameref.yaml
+resources:
+  - cluster.yaml

--- a/mgmt/aws/infrastructure/aws-clusters-resources/managedclusters.yaml
+++ b/mgmt/aws/infrastructure/aws-clusters-resources/managedclusters.yaml
@@ -14,3 +14,12 @@ metadata:
   name: eu-west-1-workload
   namespace: default
 spec: {}
+---
+# Infrastructure resource for the EKS management cluster. The Cluster in
+# mgmt/aws/clusters/eu-north-1/management/ references this literal name.
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: AWSManagedCluster
+metadata:
+  name: eu-north-1-management
+  namespace: default
+spec: {}


### PR DESCRIPTION
## What

Declares the EKS management cluster that issue #79 pivots into for the `aws` environment, following the environment's existing cluster pattern exactly: `mgmt/aws/clusters/eu-north-1/management/` with `AWSManagedControlPlane` + `AWSManagedCluster` + `AWSManagedMachinePool`, 2x t4g.medium (min 2 / max 3, AZs a/b/c), public endpoint, k8s 1.34.6. The `AWSManagedCluster` infra resource joins the central list in `mgmt/aws/infrastructure/aws-clusters-resources/` under the literal name `eu-north-1-management`.

## Why

Definitions stage of the #79 self-management stack: with this in Git, the providers running in the kind bootstrap cluster can create the cluster, and `clusterctl move` (the CAPI pivot step, a later PR in the stack) can adopt it. After the pivot the management cluster reconciles its own definition from Git.

## Details worth review

- Label wiring (the CRS trap): the management Cluster carries `region: eu-north-1` but deliberately no `fluxcd: enabled`. That label would trigger a ClusterResourceSet that deploys a workload FluxInstance into the management cluster.
- No new images; the airgap inventory check stays green (`check-inventory.py` verified locally).

## Merge-timing note

Merging this starts provisioning the EKS management cluster from the current kind management cluster (~15-25 min, billing starts). The pivot runbook lands in a later PR of the stack; run it promptly after this merges.

## Validation

- `mise run validate` green (deps-check, bash -n, every kustomize overlay incl. `mgmt/aws/clusters/eu-north-1/management`)
- namePrefix/nameReference rewriting verified in the rendered output (`infrastructureRef` stays the literal `eu-north-1-management`, matching the central infra list)
- `python3 airgap/scripts/check-inventory.py` ok

Supersedes the aws half of #84 (split by environment per review). Refs #79.
