### PR TITLE
feat: CAPD management cluster definition for self-management (local-host)

### DIFF
--- a/mgmt/local-host/clusters/flux-ks.yaml
+++ b/mgmt/local-host/clusters/flux-ks.yaml
@@ -20,3 +20,29 @@ spec:
       kind: Cluster
       name: local-workload
       namespace: default
+---
+# The CAPD management cluster: created by CAPD in the kind bootstrap cluster,
+# moved into itself by `clusterctl move` (pivot.sh), and from then on
+# reconciled from the OCI artifact by the Flux instance running inside it.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: docker-management-cluster
+  namespace: flux-system
+spec:
+  interval: 5m
+  retryInterval: 2m
+  timeout: 5m
+  prune: true
+  wait: false
+  sourceRef:
+    kind: OCIRepository
+    name: flux-system
+  path: ./mgmt/local-host/clusters/management
+  dependsOn:
+    - name: capd-system
+  healthChecks:
+    - apiVersion: cluster.x-k8s.io/v1beta2
+      kind: Cluster
+      name: local-management
+      namespace: default

--- a/mgmt/local-host/clusters/management/cluster-class.yaml
+++ b/mgmt/local-host/clusters/management/cluster-class.yaml
@@ -1,0 +1,121 @@
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: ClusterClass
+metadata:
+  name: docker-management
+  namespace: default
+spec:
+  infrastructure:
+    templateRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: DevClusterTemplate
+      name: docker-management
+  controlPlane:
+    templateRef:
+      apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+      kind: KubeadmControlPlaneTemplate
+      name: docker-management-control-plane
+    machineInfrastructure:
+      templateRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: DevMachineTemplate
+        name: docker-management-control-plane
+  workers:
+    machineDeployments:
+      - class: default-worker
+        bootstrap:
+          templateRef:
+            apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
+            kind: KubeadmConfigTemplate
+            name: docker-management-worker
+        infrastructure:
+          templateRef:
+            apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+            kind: DevMachineTemplate
+            name: docker-management-worker
+---
+# NOTE: CAPD places every node/lb container on the docker network "kind" by
+# default (no API field for it). That is load-bearing here: knr-registry is
+# attached to the same network, so nodes can pull the OCI artifact that Flux
+# syncs mgmt/local-host from, and the network survives `kind delete cluster`
+# because the registry stays attached.
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: DevClusterTemplate
+metadata:
+  name: docker-management
+  namespace: default
+spec:
+  template:
+    spec:
+      backend:
+        docker: {}
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+kind: KubeadmControlPlaneTemplate
+metadata:
+  name: docker-management-control-plane
+  namespace: default
+spec:
+  template:
+    spec:
+      kubeadmConfigSpec:
+        clusterConfiguration:
+          apiServer:
+            certSANs:
+              - localhost
+              - 127.0.0.1
+              - 0.0.0.0
+              - host.docker.internal
+        initConfiguration:
+          nodeRegistration:
+            kubeletExtraArgs:
+              - name: eviction-hard
+                value: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+        joinConfiguration:
+          nodeRegistration:
+            kubeletExtraArgs:
+              - name: eviction-hard
+                value: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: DevMachineTemplate
+metadata:
+  name: docker-management-control-plane
+  namespace: default
+spec:
+  template:
+    spec:
+      backend:
+        docker:
+          customImage: kindest/node:v1.35.0
+          extraMounts:
+            - hostPath: /var/run/docker.sock
+              containerPath: /var/run/docker.sock
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: DevMachineTemplate
+metadata:
+  name: docker-management-worker
+  namespace: default
+spec:
+  template:
+    spec:
+      backend:
+        docker:
+          customImage: kindest/node:v1.35.0
+          extraMounts:
+            - hostPath: /var/run/docker.sock
+              containerPath: /var/run/docker.sock
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
+kind: KubeadmConfigTemplate
+metadata:
+  name: docker-management-worker
+  namespace: default
+spec:
+  template:
+    spec:
+      joinConfiguration:
+        nodeRegistration:
+          kubeletExtraArgs:
+            - name: eviction-hard
+              value: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%

--- a/mgmt/local-host/clusters/management/cluster.yaml
+++ b/mgmt/local-host/clusters/management/cluster.yaml
@@ -1,0 +1,31 @@
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: Cluster
+metadata:
+  name: local-management
+  namespace: default
+  labels:
+    # profile=local-host makes the kindnet ClusterResourceSet supply the CNI
+    # (CAPD clusters ship none). Deliberately NOT `fluxcd: enabled`: that
+    # label would make the local-workload-flux-instance ClusterResourceSet
+    # deploy a workload FluxInstance into the management cluster.
+    profile: local-host
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+        - 192.168.0.0/16
+    serviceDomain: cluster.local
+    services:
+      cidrBlocks:
+        - 10.128.0.0/12
+  topology:
+    classRef:
+      name: docker-management
+    version: v1.35.0
+    controlPlane:
+      replicas: 1
+    workers:
+      machineDeployments:
+        - class: default-worker
+          name: md-0
+          replicas: 1

--- a/mgmt/local-host/clusters/management/kustomization.yaml
+++ b/mgmt/local-host/clusters/management/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cluster-class.yaml
+  - cluster.yaml


### PR DESCRIPTION
## What

Declares the CAPD management cluster that issue #79 pivots into for the `local-host` environment: `mgmt/local-host/clusters/management/` with a new ClusterClass `docker-management` (DevClusterTemplate + KubeadmControlPlaneTemplate + DevMachineTemplates, `kindest/node:v1.35.0`), Cluster `local-management`, 1 CP + 1 worker, wired with a `docker-management-cluster` Flux Kustomization.

## Why

Definitions stage of the #79 self-management stack: with this in Git, the providers running in the kind bootstrap cluster can create the cluster, and `clusterctl move` (the CAPI pivot step, a later PR in the stack) can adopt it. After the pivot the management cluster reconciles its own definition from the OCI artifact.

## Details worth review

- Label wiring (the CRS trap): the management Cluster carries `profile: local-host` (the literal manifest label) so the kindnet ClusterResourceSet supplies the CNI (CAPD clusters ship none), but deliberately no `fluxcd: enabled`: that label would make the local-workload-flux-instance ClusterResourceSet deploy a workload FluxInstance into the management cluster.
- CAPD places node/lb containers on the docker `kind` network by default (no API field), which is what makes `knr-registry` reachable from the management cluster nodes; the network survives `kind delete cluster` because the registry stays attached. Commented in the ClusterClass.
- No new images (`kindest/node:v1.35.0` already in `airgap/images.txt`); inventory check stays green.

## Validation

- `mise run validate` green (deps-check, bash -n, every kustomize overlay incl. `mgmt/local-host/clusters/management`)
- `python3 airgap/scripts/check-inventory.py` ok

Supersedes the local-host half of #84 (split by environment per review). Refs #79.
