### PR TITLE
refactor: migrate profile label to qualified environment label

### DIFF
--- a/airgap/scripts/build-config-artifact.sh
+++ b/airgap/scripts/build-config-artifact.sh
@@ -50,7 +50,7 @@ spec:
   clusterSelector:
     matchLabels:
       fluxcd: enabled
-      profile: local-host
+      knr-ops.polarsquad.com/environment: local-host
   repoURL: oci://knr-registry:5000/charts
   chartName: flux-operator
   version: "0.58.0"
@@ -158,7 +158,7 @@ spec:
   clusterSelector:
     matchLabels:
       fluxcd: enabled
-      profile: local-host
+      knr-ops.polarsquad.com/environment: local-host
   strategy: ApplyOnce
   resources:
     - kind: ConfigMap

--- a/mgmt/local-host/addons/cni/kindnet.yaml
+++ b/mgmt/local-host/addons/cni/kindnet.yaml
@@ -123,7 +123,7 @@ metadata:
 spec:
   clusterSelector:
     matchLabels:
-      profile: local-host
+      knr-ops.polarsquad.com/environment: local-host
   strategy: ApplyOnce
   resources:
     - kind: ConfigMap

--- a/mgmt/local-host/addons/flux-apps/flux-instance.yaml
+++ b/mgmt/local-host/addons/flux-apps/flux-instance.yaml
@@ -57,7 +57,7 @@ spec:
   clusterSelector:
     matchLabels:
       fluxcd: enabled
-      profile: local-host
+      knr-ops.polarsquad.com/environment: local-host
   strategy: ApplyOnce
   resources:
     - kind: ConfigMap

--- a/mgmt/local-host/addons/flux-apps/flux-operator.yaml
+++ b/mgmt/local-host/addons/flux-apps/flux-operator.yaml
@@ -7,7 +7,7 @@ spec:
   clusterSelector:
     matchLabels:
       fluxcd: enabled
-      profile: local-host
+      knr-ops.polarsquad.com/environment: local-host
   repoURL: oci://ghcr.io/controlplaneio-fluxcd/charts
   chartName: flux-operator
   version: "0.58.0"

--- a/mgmt/local-host/clusters/docker/cluster.yaml
+++ b/mgmt/local-host/clusters/docker/cluster.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: default
   labels:
     fluxcd: enabled
-    profile: local-host
+    knr-ops.polarsquad.com/environment: local-host
 spec:
   clusterNetwork:
     pods:

--- a/mgmt/local-host/clusters/management/cluster.yaml
+++ b/mgmt/local-host/clusters/management/cluster.yaml
@@ -4,11 +4,11 @@ metadata:
   name: local-management
   namespace: default
   labels:
-    # profile=local-host makes the kindnet ClusterResourceSet supply the CNI
-    # (CAPD clusters ship none). Deliberately NOT `fluxcd: enabled`: that
+    # environment=local-host makes the kindnet ClusterResourceSet supply the
+    # CNI (CAPD clusters ship none). Deliberately NOT `fluxcd: enabled`: that
     # label would make the local-workload-flux-instance ClusterResourceSet
     # deploy a workload FluxInstance into the management cluster.
-    profile: local-host
+    knr-ops.polarsquad.com/environment: local-host
 spec:
   clusterNetwork:
     pods:


### PR DESCRIPTION
## What

Migrates the bare `profile: local-host` Cluster label and every selector that consumes it to the qualified environment label `knr-ops.polarsquad.com/environment: local-host`, per #87 (follow-up from the #86 review).

## Scope (verified on current main, post-#86)

Label sources:
- `mgmt/local-host/clusters/docker/cluster.yaml` (workload Cluster labels)
- `mgmt/local-host/clusters/management/cluster.yaml` (management Cluster labels; this consumer arrived with #86 after #87 was filed)

Selectors:
- `mgmt/local-host/addons/cni/kindnet.yaml` (kindnet ClusterResourceSet matchLabels)
- `mgmt/local-host/addons/flux-apps/flux-operator.yaml` (HelmChartProxy clusterSelector)
- `mgmt/local-host/addons/flux-apps/flux-instance.yaml` (ClusterResourceSet clusterSelector)
- `airgap/scripts/build-config-artifact.sh`: both generated clusterSelectors (flux-operator HelmChartProxy and the CRS heredoc) moved in the same commit, so the rendered airgap artifact cannot drift from the Git labels. The script copies `clusters/docker` verbatim, so that Cluster's label flows through unchanged; `clusters/management` is not part of the airgap artifact.

Unchanged, deliberately: `profile: default` under `mgmt/aws/infrastructure/ack-controllers/` stays; it is the AWS SDK credentials profile key inside HelmRelease values, not this label (#87 explicitly scopes it out). The label appears in no docs, README, or AGENTS.md text, so no doc updates are needed.

## Sequencing

All label and selector changes land atomically in this one commit. The Clusters carry the qualified label at creation; the docker workload Cluster already running in the local environment gets it on the next Flux reconciliation of its definition together with the reconciled selectors, so there is no window where a selector matches nothing. This lands before the #79 pivot, as the issue prescribes.

## Validation

- `mise run validate` green (all 43 overlays)
- Rendered output checked: both Cluster labels and all three selectors carry the qualified key, and `git grep 'profile[:=] local-host'` over the branch returns nothing
- `bash -n` on the modified script; `python3 airgap/scripts/check-inventory.py` ok

Closes #87. Refs #79.
