### PR TITLE
feat: pivot tooling for management-cluster self-management (aws + local-host)

### DIFF
--- a/bootstrap-common.sh
+++ b/bootstrap-common.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+# bootstrap-common.sh – Shared preflight and Flux-seeding helpers used by
+# bootstrap.sh and pivot.sh. Sourced, never executed directly.
+#
+# Environment variables set by these helpers are plain globals in the
+# sourcing shell (bash 3.2 compatible: no namerefs, no associative arrays).
+
+# ── Preflight: environment (aws) ──────────────────────────────────────────────
+# Validates the GitHub + age inputs the Flux seed needs on the aws environment.
+# Sets: GITHUB_USER, GITHUB_REPO, AGE_KEY_FILE, AGE_PUBKEY.
+require_flux_env() {
+  : "${GITHUB_TOKEN:?GITHUB_TOKEN must be set (a PAT with read access to the repo)}"
+  : "${GIT_REPO_URL:?GIT_REPO_URL must be set}"
+  # GITHUB_USER is used in the Flux GitHub secret for repo clone authentication
+  GITHUB_USER="${GITHUB_USER:-git}"
+
+  case "$GIT_REPO_URL" in
+    https://github.com/*/*) ;;
+    *)
+      echo "ERROR: GIT_REPO_URL must be an HTTPS GitHub repository URL" >&2
+      exit 1
+      ;;
+  esac
+  GITHUB_REPO="${GIT_REPO_URL#https://github.com/}"
+  GITHUB_REPO="${GITHUB_REPO%/}"
+  GITHUB_REPO="${GITHUB_REPO%.git}"
+  GITHUB_AUTH="Authorization: Bearer ${GITHUB_TOKEN}"
+  github_branch_path="${GIT_BRANCH//\//%2F}"
+  github_branch_status="$(curl -sS -o /dev/null -w '%{http_code}' \
+    -H 'Accept: application/vnd.github+json' \
+    -H "${GITHUB_AUTH}" \
+    "https://api.github.com/repos/${GITHUB_REPO}/branches/${github_branch_path}" || true)"
+  if [ "$github_branch_status" != 200 ]; then
+    echo "ERROR: GitHub repository or branch '${GIT_BRANCH}' is unavailable at '${GIT_REPO_URL}' (HTTP ${github_branch_status})" >&2
+    exit 1
+  fi
+
+  AGE_KEY_FILE="${AGE_KEY_FILE:-age.agekey}"
+  if [ ! -f "$AGE_KEY_FILE" ]; then
+    echo "ERROR: age key file not found at '$AGE_KEY_FILE'." >&2
+    echo "       Generate one with:  mise run sops-keygen" >&2
+    echo "       and add its PUBLIC key to .sops.yaml. See docs/secrets.md." >&2
+    exit 1
+  fi
+  # Validate age key file format first (before attempting to extract the public key).
+  # This avoids silent grep failure if the file is malformed.
+  AGE_CONTENT=$(cat "${AGE_KEY_FILE}")
+  missing_fields=""
+  echo "$AGE_CONTENT" | grep -q '^# created:' 2>/dev/null || missing_fields="${missing_fields}# created: header, "
+  echo "$AGE_CONTENT" | grep -q '^# public key:' 2>/dev/null || missing_fields="${missing_fields}# public key: comment, "
+  echo "$AGE_CONTENT" | grep -q '^AGE-SECRET-KEY-' 2>/dev/null || missing_fields="${missing_fields}AGE-SECRET-KEY- line, "
+
+  if [ -n "$missing_fields" ]; then
+    echo "ERROR: '${AGE_KEY_FILE}' is not a valid age key file." >&2
+    echo "       Missing: ${missing_fields%, }" >&2
+    exit 1
+  fi
+  # Now safely extract the public key (validation already passed).
+  AGE_PUBKEY="${AGE_PUBLIC_KEY:-$(echo "$AGE_CONTENT" | grep '^# public key:' | sed 's/^# public key: //')}"
+  if [ -z "$AGE_PUBKEY" ]; then
+    echo "ERROR: Cannot determine age public key from '${AGE_KEY_FILE}' or from AGE_PUBLIC_KEY env var." >&2
+    echo "       Set AGE_PUBLIC_KEY in .env, or regenerate the key with: mise run sops-keygen" >&2
+    exit 1
+  fi
+}
+
+# ── Preflight: container engine ───────────────────────────────────────────────
+# Detects and selects a running container engine. Sets: CONTAINER_ENGINE,
+# ENGINE_SOCK (and exports KIND_EXPERIMENTAL_PROVIDER for podman).
+# Note: when using podman via the docker CLI shim (e.g., on macOS),
+# `docker --version` reports podman; we check for that case first.
+detect_container_engine() {
+  if [ -z "${CONTAINER_ENGINE:-}" ]; then
+    if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
+      if docker --version 2>/dev/null | grep -qi podman; then
+        CONTAINER_ENGINE=podman
+      else
+        CONTAINER_ENGINE=docker
+      fi
+    elif command -v podman >/dev/null 2>&1 && podman info >/dev/null 2>&1; then
+      CONTAINER_ENGINE=podman
+    else
+      echo "ERROR: No running container engine found (tried docker and podman)" >&2
+      exit 1
+    fi
+  fi
+
+  case "$CONTAINER_ENGINE" in
+    docker)
+      docker info >/dev/null 2>&1 || { echo "ERROR: Docker daemon not running" >&2; exit 1; }
+      ENGINE_SOCK="/var/run/docker.sock"
+      ;;
+    podman)
+      podman info >/dev/null 2>&1 || { echo "ERROR: Podman is not running (is 'podman machine' started?)" >&2; exit 1; }
+      export KIND_EXPERIMENTAL_PROVIDER=podman
+      ENGINE_SOCK="$(podman info --format '{{.Host.RemoteSocket.Path}}' 2>/dev/null || true)"
+      ENGINE_SOCK="${ENGINE_SOCK#unix://}"
+      if [ -z "$ENGINE_SOCK" ]; then
+        ENGINE_SOCK="/run/podman/podman.sock"
+        echo ">>> WARNING: Could not detect the podman API socket path; assuming ${ENGINE_SOCK}" >&2
+      fi
+      ;;
+    *)
+      echo "ERROR: Unsupported CONTAINER_ENGINE '${CONTAINER_ENGINE}' (expected 'docker' or 'podman')" >&2
+      exit 1
+      ;;
+  esac
+}
+
+# ── Flux seeding ──────────────────────────────────────────────────────────────
+# Installs the Flux Operator, the bootstrap secrets (aws), and the FluxInstance
+# that syncs the management tree, then waits for the instance to become Ready.
+# Used by bootstrap.sh (against the kind cluster) and by pivot.sh (against the
+# management cluster). Reads the PROFILE global ("aws" or "local-host").
+
+# Optional target: set to a kubeconfig path to seed a cluster other than the
+# current kubectl context. Empty means "current context".
+SEED_KUBECONFIG=""
+# Temp files created by seed_flux, removed by seed_cleanup (callers wire this
+# into their EXIT traps; bootstrap.sh exec'ing pivot.sh relies on pivot.sh's).
+SEED_CLEANUP_FILES=""
+
+seed_register_cleanup() {
+  SEED_CLEANUP_FILES="${SEED_CLEANUP_FILES}${1} "
+}
+
+seed_cleanup() {
+  # shellcheck disable=SC2086  # intentional word splitting over registered files
+  for f in $SEED_CLEANUP_FILES; do
+    rm -f "$f"
+  done
+  SEED_CLEANUP_FILES=""
+}
+
+seed_kubectl() {
+  if [ -n "$SEED_KUBECONFIG" ]; then
+    kubectl --kubeconfig "$SEED_KUBECONFIG" "$@"
+  else
+    kubectl "$@"
+  fi
+}
+
+seed_helm() {
+  if [ -n "$SEED_KUBECONFIG" ]; then
+    helm --kubeconfig "$SEED_KUBECONFIG" "$@"
+  else
+    helm "$@"
+  fi
+}
+
+# seed_flux [kubeconfig]
+# Requires (aws only): GITHUB_TOKEN, GIT_REPO_URL, AGE_KEY_FILE, AGE_PUBKEY
+# (run require_flux_env first). Requires the PROFILE global.
+seed_flux() {
+  SEED_KUBECONFIG="${1:-}"
+
+  local registry_name="${REGISTRY_NAME:-knr-registry}"
+  local registry_port="${REGISTRY_PORT:-5001}"
+  local anon_registry_config
+  anon_registry_config="$(mktemp)"
+  seed_register_cleanup "$anon_registry_config"
+  printf '{}\n' > "$anon_registry_config"
+
+  # ── Install the Flux Operator ───────────────────────────────────────────────
+  echo ">>> Installing Flux Operator..."
+  # The empty registry config keeps helm from picking up local container
+  # registry credentials when pulling the public OCI chart below.
+  seed_helm install flux-operator oci://ghcr.io/controlplaneio-fluxcd/charts/flux-operator \
+    --namespace flux-system \
+    --create-namespace \
+    --wait \
+    --registry-config "$anon_registry_config"
+
+  if [ "$PROFILE" = aws ]; then
+    # ── GitHub PAT credentials secret ─────────────────────────────────────────
+    # Basic-auth secret consumed by Flux's source-controller to clone the repo.
+    # Idempotent (apply) so pivot re-runs do not fail on existing secrets.
+    echo ">>> Creating GitHub PAT credentials secret in flux-system..."
+    seed_kubectl create secret generic flux-github-pat \
+      --namespace flux-system \
+      --from-literal=username="${GITHUB_USER}" \
+      --from-literal=password="${GITHUB_TOKEN}" \
+      --dry-run=client -o yaml | seed_kubectl apply -f -
+
+    # ── SOPS age decryption key secret ────────────────────────────────────────
+    # Flux's kustomize-controller uses this key to decrypt *.sops.yaml manifests
+    # (such as the CAPA AWS credentials) during reconciliation. Flux scans the
+    # Secret for keys matching the pattern `keys.<public-key>.agekey` — each
+    # matching key is passed to the age library for decryption.
+    # Delete first: kubectl apply merges stringData keys, which would leave
+    # stale keys from a previous bootstrap with a different age key behind.
+    echo ">>> Creating sops-age decryption secret in flux-system..."
+    seed_kubectl delete secret sops-age -n flux-system --ignore-not-found
+    seed_kubectl create secret generic sops-age \
+      --namespace flux-system \
+      --from-file="keys.${AGE_PUBKEY}.agekey=${AGE_KEY_FILE}" \
+      --dry-run=client -o yaml | seed_kubectl apply -f -
+  fi
+
+  # ── Install the FluxInstance via Helm ───────────────────────────────────────
+  echo ">>> Installing FluxInstance via Helm..."
+  FLUX_INSTANCE_ARGS=(
+    --set instance.cluster.type=kubernetes
+    --set instance.cluster.size=small
+    --set instance.cluster.multitenant=false
+    --set instance.cluster.networkPolicy=true
+    --set instance.cluster.domain=cluster.local
+    --registry-config "$anon_registry_config"
+  )
+  if [ "$PROFILE" = aws ]; then
+    FLUX_INSTANCE_ARGS+=(
+      --set instance.sync.kind=GitRepository
+      --set instance.sync.url="${GIT_REPO_URL}"
+      --set instance.sync.ref=refs/heads/main
+      --set instance.sync.path=mgmt/aws
+      --set instance.sync.pullSecret=flux-github-pat
+    )
+  else
+    FLUX_INSTANCE_ARGS+=(
+      --set instance.sync.kind=OCIRepository
+      --set instance.sync.url="oci://${registry_name}:5000/${OCI_REPOSITORY:-knr-ops}"
+      --set instance.sync.ref="${OCI_TAG:-latest}"
+      --set instance.sync.path=mgmt/local-host
+      --set-json 'instance.kustomize.patches=[{"patch":"- op: add\n  path: /spec/insecure\n  value: true","target":{"kind":"OCIRepository"}}]'
+    )
+  fi
+  # Helm 4's watcher strategy treats the FluxInstance's transient InProgress
+  # condition as a terminal failure. Use the legacy chart-resource wait here,
+  # then wait explicitly for the operator-owned Ready condition below.
+  seed_helm upgrade --install flux \
+    oci://ghcr.io/controlplaneio-fluxcd/charts/flux-instance \
+    --namespace flux-system \
+    --wait=legacy \
+    --timeout 10m \
+    "${FLUX_INSTANCE_ARGS[@]}"
+
+  echo ">>> Waiting for FluxInstance reconciliation to complete..."
+  seed_kubectl wait fluxinstance/flux \
+    --namespace flux-system \
+    --for=condition=Ready \
+    --timeout=10m
+
+  # ── Health check ────────────────────────────────────────────────────────────
+  # Verify the Flux controllers are running before declaring success.
+  echo ">>> Waiting for Flux controllers to be ready..."
+  seed_kubectl wait --namespace flux-system --for=condition=ready pod \
+    --selector='app.kubernetes.io/part-of=flux' \
+    --timeout=90s || true
+}

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -3,6 +3,8 @@
 # Everything after this script runs is driven by GitOps (Flux).
 set -euo pipefail
 
+source "$(dirname "$0")/bootstrap-common.sh"
+
 PROFILE="${KNR_OPS_PROFILE:-${1:-aws}}"
 GIT_BRANCH="main"
 REGISTRY_NAME="knr-registry"
@@ -29,98 +31,10 @@ preflight_checks() {
   fi
 
   if [ "$PROFILE" = aws ]; then
-    : "${GITHUB_TOKEN:?GITHUB_TOKEN must be set (a PAT with read access to the repo)}"
-    : "${GIT_REPO_URL:?GIT_REPO_URL must be set}"
-    # GITHUB_USER is used in the Flux GitHub secret for repo clone authentication
-    GITHUB_USER="${GITHUB_USER:-git}"
-
-    case "$GIT_REPO_URL" in
-      https://github.com/*/*) ;;
-      *)
-        echo "ERROR: GIT_REPO_URL must be an HTTPS GitHub repository URL" >&2
-        exit 1
-        ;;
-    esac
-    GITHUB_REPO="${GIT_REPO_URL#https://github.com/}"
-    GITHUB_REPO="${GITHUB_REPO%/}"
-    GITHUB_REPO="${GITHUB_REPO%.git}"
-    GITHUB_AUTH="Authorization: Bearer ${GITHUB_TOKEN}"
-    github_branch_path="${GIT_BRANCH//\//%2F}"
-    github_branch_status="$(curl -sS -o /dev/null -w '%{http_code}' \
-      -H 'Accept: application/vnd.github+json' \
-      -H "${GITHUB_AUTH}" \
-      "https://api.github.com/repos/${GITHUB_REPO}/branches/${github_branch_path}" || true)"
-    if [ "$github_branch_status" != 200 ]; then
-      echo "ERROR: GitHub repository or branch '${GIT_BRANCH}' is unavailable at '${GIT_REPO_URL}' (HTTP ${github_branch_status})" >&2
-      exit 1
-    fi
-
-    AGE_KEY_FILE="${AGE_KEY_FILE:-age.agekey}"
-    if [ ! -f "$AGE_KEY_FILE" ]; then
-      echo "ERROR: age key file not found at '$AGE_KEY_FILE'." >&2
-      echo "       Generate one with:  mise run sops-keygen" >&2
-      echo "       and add its PUBLIC key to .sops.yaml. See docs/secrets.md." >&2
-      exit 1
-    fi
-    # Validate age key file format first (before attempting to extract the public key).
-    # This avoids silent grep failure if the file is malformed.
-    AGE_CONTENT=$(cat "${AGE_KEY_FILE}")
-    missing_fields=""
-    echo "$AGE_CONTENT" | grep -q '^# created:' 2>/dev/null || missing_fields="${missing_fields}# created: header, "
-    echo "$AGE_CONTENT" | grep -q '^# public key:' 2>/dev/null || missing_fields="${missing_fields}# public key: comment, "
-    echo "$AGE_CONTENT" | grep -q '^AGE-SECRET-KEY-' 2>/dev/null || missing_fields="${missing_fields}AGE-SECRET-KEY- line, "
-
-    if [ -n "$missing_fields" ]; then
-      echo "ERROR: '${AGE_KEY_FILE}' is not a valid age key file." >&2
-      echo "       Missing: ${missing_fields%, }" >&2
-      exit 1
-    fi
-    # Now safely extract the public key (validation already passed).
-    AGE_PUBKEY="${AGE_PUBLIC_KEY:-$(echo "$AGE_CONTENT" | grep '^# public key:' | sed 's/^# public key: //')}"
-    if [ -z "$AGE_PUBKEY" ]; then
-      echo "ERROR: Cannot determine age public key from '${AGE_KEY_FILE}' or from AGE_PUBLIC_KEY env var." >&2
-      echo "       Set AGE_PUBLIC_KEY in .env, or regenerate the key with: mise run sops-keygen" >&2
-      exit 1
-    fi
+    require_flux_env
   fi
 
-  # Detect and select a running container engine. Note: when using podman via the docker CLI
-  # shim (e.g., on macOS), `docker --version` reports podman; we check for that case first.
-  if [ -z "${CONTAINER_ENGINE:-}" ]; then
-    if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
-      if docker --version 2>/dev/null | grep -qi podman; then
-        CONTAINER_ENGINE=podman
-      else
-        CONTAINER_ENGINE=docker
-      fi
-    elif command -v podman >/dev/null 2>&1 && podman info >/dev/null 2>&1; then
-      CONTAINER_ENGINE=podman
-    else
-      echo "ERROR: No running container engine found (tried docker and podman)" >&2
-      exit 1
-    fi
-  fi
-
-  case "$CONTAINER_ENGINE" in
-    docker)
-      docker info >/dev/null 2>&1 || { echo "ERROR: Docker daemon not running" >&2; exit 1; }
-      ENGINE_SOCK="/var/run/docker.sock"
-      ;;
-    podman)
-      podman info >/dev/null 2>&1 || { echo "ERROR: Podman is not running (is 'podman machine' started?)" >&2; exit 1; }
-      export KIND_EXPERIMENTAL_PROVIDER=podman
-      ENGINE_SOCK="$(podman info --format '{{.Host.RemoteSocket.Path}}' 2>/dev/null || true)"
-      ENGINE_SOCK="${ENGINE_SOCK#unix://}"
-      if [ -z "$ENGINE_SOCK" ]; then
-        ENGINE_SOCK="/run/podman/podman.sock"
-        echo ">>> WARNING: Could not detect the podman API socket path; assuming ${ENGINE_SOCK}" >&2
-      fi
-      ;;
-    *)
-      echo "ERROR: Unsupported CONTAINER_ENGINE '${CONTAINER_ENGINE}' (expected 'docker' or 'podman')" >&2
-      exit 1
-      ;;
-  esac
+  detect_container_engine
 }
 
 preflight_checks
@@ -206,10 +120,7 @@ if [ "$PROFILE" = local-host ]; then
   echo ">>> Initial OCI artifact is available at oci://localhost:${REGISTRY_PORT}/${OCI_REPOSITORY:-knr-ops}:${OCI_TAG:-latest}"
 fi
 
-# ── Step 2: Install the Flux Operator ────────────────────────────────────────
-echo ">>> Installing Flux Operator..."
-ANONYMOUS_REGISTRY_CONFIG="$(mktemp)"
-printf '{}\n' > "$ANONYMOUS_REGISTRY_CONFIG"
+# ── Steps 2–4: Seed Flux (operator, secrets, FluxInstance) ────────────────────
 workload_flux_log_pid=""
 workload_kubeconfig=""
 cleanup_workload_reconciliation() {
@@ -225,88 +136,10 @@ cleanup_workload_reconciliation() {
 }
 cleanup_bootstrap() {
   cleanup_workload_reconciliation
-  rm -f "$ANONYMOUS_REGISTRY_CONFIG"
+  seed_cleanup
 }
 trap cleanup_bootstrap EXIT
-helm install flux-operator oci://ghcr.io/controlplaneio-fluxcd/charts/flux-operator \
-  --namespace flux-system \
-  --create-namespace \
-  --wait \
-  --registry-config "$ANONYMOUS_REGISTRY_CONFIG"
-
-# ── Step 3: Create GitHub PAT credentials secret ─────────────────────────────
-# Basic-auth secret consumed by Flux's source-controller to clone the repo.
-if [ "$PROFILE" = aws ]; then
-  echo ">>> Creating GitHub PAT credentials secret in flux-system..."
-  kubectl create secret generic flux-github-pat \
-    --namespace flux-system \
-    --from-literal=username="${GITHUB_USER}" \
-    --from-literal=password="${GITHUB_TOKEN}"
-
-# ── Step 3b: Create SOPS age decryption key secret ────────────────────────────
-# Flux's kustomize-controller uses this key to decrypt *.sops.yaml manifests
-# (such as the CAPA AWS credentials) during reconciliation. Flux scans the
-# Secret for keys matching the pattern `keys.<public-key>.agekey` — each
-# matching key is passed to the age library for decryption.
-# Note: the age key file and public key are already validated in preflight_checks.
-echo ">>> Creating sops-age decryption secret in flux-system..."
-# Remove any existing sops-age secret to avoid stale keys from previous bootstrap runs
-kubectl delete secret sops-age -n flux-system --ignore-not-found
-kubectl create secret generic sops-age \
-  --namespace flux-system \
-  --from-file="keys.${AGE_PUBKEY}.agekey=${AGE_KEY_FILE}" \
-  --dry-run=client -o yaml | kubectl apply -f -
-fi
-
-# ── Step 4: Install the FluxInstance via Helm ────────────────────────────────
-echo ">>> Installing FluxInstance via Helm..."
-FLUX_INSTANCE_ARGS=(
-  --set instance.cluster.type=kubernetes
-  --set instance.cluster.size=small
-  --set instance.cluster.multitenant=false
-  --set instance.cluster.networkPolicy=true
-  --set instance.cluster.domain=cluster.local
-  --registry-config "$ANONYMOUS_REGISTRY_CONFIG"
-)
-if [ "$PROFILE" = aws ]; then
-  FLUX_INSTANCE_ARGS+=(
-    --set instance.sync.kind=GitRepository
-    --set instance.sync.url="${GIT_REPO_URL}"
-    --set instance.sync.ref=refs/heads/main
-    --set instance.sync.path=mgmt/aws
-    --set instance.sync.pullSecret=flux-github-pat
-  )
-else
-  FLUX_INSTANCE_ARGS+=(
-    --set instance.sync.kind=OCIRepository
-    --set instance.sync.url="oci://${REGISTRY_NAME}:5000/${OCI_REPOSITORY:-knr-ops}"
-    --set instance.sync.ref="${OCI_TAG:-latest}"
-    --set instance.sync.path=mgmt/local-host
-    --set-json 'instance.kustomize.patches=[{"patch":"- op: add\n  path: /spec/insecure\n  value: true","target":{"kind":"OCIRepository"}}]'
-  )
-fi
-# Helm 4's watcher strategy treats the FluxInstance's transient InProgress
-# condition as a terminal failure. Use the legacy chart-resource wait here,
-# then wait explicitly for the operator-owned Ready condition below.
-helm upgrade --install flux \
-  oci://ghcr.io/controlplaneio-fluxcd/charts/flux-instance \
-  --namespace flux-system \
-  --wait=legacy \
-  --timeout 10m \
-  "${FLUX_INSTANCE_ARGS[@]}"
-
-echo ">>> Waiting for FluxInstance reconciliation to complete..."
-kubectl wait fluxinstance/flux \
-  --namespace flux-system \
-  --for=condition=Ready \
-  --timeout=10m
-
-# ── Post-bootstrap health check ───────────────────────────────────────────────
-# Verify the Flux controllers are running before declaring success.
-echo ">>> Waiting for Flux controllers to be ready..."
-kubectl wait --namespace flux-system --for=condition=ready pod \
-  --selector='app.kubernetes.io/part-of=flux' \
-  --timeout=90s || true
+seed_flux
 
 # ── Step 5: Watch local-host reconciliation ──────────────────────────────────
 # Stream the GitOps handoff in the bootstrap terminal for the local profile.
@@ -412,4 +245,17 @@ else
   echo ">>> OCI source: oci://${REGISTRY_NAME}:5000/${OCI_REPOSITORY:-knr-ops}:${OCI_TAG:-latest} (path: mgmt/local-host)"
   echo ">>> Watch progress with: flux get sources oci --watch"
   echo ">>> No AWS resources were provisioned"
+fi
+
+# ── Pivot to the self-managed management cluster ──────────────────────────────
+# This is the DEFAULT exit of bootstrap: the Flux instance seeded above
+# reconciles the management-cluster definition (creating the management
+# cluster via CAPA/CAPD), then pivot.sh moves the CAPI inventory into it and
+# deletes the kind cluster. Opt out with BOOTSTRAP_PIVOT=0 to keep the kind
+# bootstrap cluster as the management cluster (pre-#79 behavior).
+export KNR_OPS_PROFILE="$PROFILE"
+if [ "${BOOTSTRAP_PIVOT:-1}" = 1 ]; then
+  # EXIT traps do not fire across exec; clean up the seed temp files first.
+  cleanup_bootstrap
+  exec "$(dirname "$0")/pivot.sh"
 fi

--- a/deps/versions.toml
+++ b/deps/versions.toml
@@ -120,3 +120,17 @@ key = "mise"
 file = "mise.toml"
 pattern = 'min_version = "{version}"'
 count = 1
+
+# pivot.sh installs these imperatively in the management cluster before Flux
+# exists; the literals must track the catalog like the HelmReleases do.
+[[slot]]
+key = "cert_manager"
+file = "pivot.sh"
+pattern = 'CERT_MANAGER_VERSION="{version}"'
+count = 1
+
+[[slot]]
+key = "capi_operator_chart"
+file = "pivot.sh"
+pattern = 'CAPI_OPERATOR_VERSION="{version}"'
+count = 1

--- a/mise.toml
+++ b/mise.toml
@@ -35,7 +35,7 @@ if ! python3 deps/scripts/check.py --forbid; then
   echo "    FAILED: dependency drift" >&2
   fail=1
 fi
-for script in bootstrap.sh teardown.sh; do
+for script in bootstrap.sh bootstrap-common.sh pivot.sh teardown.sh; do
   echo "==> bash -n $script"
   if ! bash -n "$script"; then
     echo "    FAILED: $script" >&2
@@ -84,8 +84,42 @@ done
 """
 
 [tasks.bootstrap]
-description = "Bootstrap the management kind cluster and hand off to Flux/GitOps"
+description = "Bootstrap the management kind cluster, hand off to Flux/GitOps, then pivot to the self-managed management cluster"
 run = "./bootstrap.sh"
+
+[tasks.pivot]
+description = "Pivot the management cluster from local kind to the CAPI-managed management cluster (aws=CAPA/EKS, local-host=CAPD)"
+run = "./pivot.sh"
+
+[tasks.mgmt-kubeconfig]
+description = "Export the management-cluster kubeconfig to ~/.kube/knr-ops-mgmt.yaml"
+run = '''
+MGMT_CLUSTER="${MGMT_CLUSTER:-$([ "${KNR_OPS_PROFILE:-aws}" = local-host ] && echo local-management || echo eu-north-1-management)}"
+MGMT_KUBECONFIG="${MGMT_KUBECONFIG:-$HOME/.kube/knr-ops-mgmt.yaml}"
+clusterctl get kubeconfig "$MGMT_CLUSTER" -n default > "$MGMT_KUBECONFIG"
+chmod 600 "$MGMT_KUBECONFIG"
+if [ "${KNR_OPS_PROFILE:-aws}" = local-host ]; then
+  # CAPD records the load balancer's container-network IP, which is not
+  # routable from macOS. Point at the port published on localhost instead.
+  engine="${CONTAINER_ENGINE:-docker}"
+  endpoint="$($engine port "${MGMT_CLUSTER}-lb" 6443/tcp | head -1)"
+  port="${endpoint##*:}"
+  case "$port" in
+    ''|*[!0-9]*)
+      echo "ERROR: cannot determine the ${MGMT_CLUSTER} API server port" >&2
+      exit 1
+      ;;
+  esac
+  kubectl config set-cluster "$MGMT_CLUSTER" \
+    --server="https://127.0.0.1:${port}" \
+    --kubeconfig="$MGMT_KUBECONFIG" >/dev/null
+fi
+kubectl --kubeconfig "$MGMT_KUBECONFIG" config rename-context \
+  "$(kubectl --kubeconfig "$MGMT_KUBECONFIG" config current-context)" \
+  knr-ops-mgmt >/dev/null
+echo "Wrote ${MGMT_KUBECONFIG}"
+echo "Use with: KUBECONFIG=${MGMT_KUBECONFIG} kubectl get clusters"
+'''
 
 [tasks.aws-credentials]
 description = "Export AWS credentials as a profile string for SOPS-encrypted secrets"

--- a/pivot.sh
+++ b/pivot.sh
@@ -1,0 +1,365 @@
+#!/usr/bin/env bash
+# pivot.sh – Move the CAPI management inventory from the local kind bootstrap
+# cluster into the self-managed management cluster (issue #79).
+#
+# The management cluster definition (mgmt/aws/clusters/eu-north-1/management
+# or mgmt/local-host/clusters/management) is created by the providers running
+# in the kind bootstrap cluster; this script then:
+#
+#   1. waits for the management cluster to be provisioned,
+#   2. exports its kubeconfig (rewriting the endpoint to localhost for CAPD),
+#   3. installs the CAPI operator + provider CRs in the target (imperatively,
+#      at the same versions as Git, because HelmReleases need Flux first),
+#   4. suspends Flux in kind and runs `clusterctl move`,
+#   5. unpauses the moved Clusters and seeds Flux on the target,
+#   6. deletes the kind bootstrap cluster.
+#
+# Run from a checkout of the revision you want self-managed (normally main):
+#   mise run pivot                  # aws environment (KNR_OPS_PROFILE=aws)
+#   mise -E local-host run pivot    # local-host environment
+#
+# bootstrap.sh execs this script by default (BOOTSTRAP_PIVOT=0 opts out).
+# The move is re-runnable: objects are deleted from the source only after
+# they were created successfully on the target, so kind stays authoritative
+# until step 6. If the move fails midway, NEVER delete moved Cluster /
+# AWSManaged* / MachinePool / Dev* objects on the target to "retry clean" —
+# the provider would deprovision the real infrastructure. Re-run the move,
+# or delete only pure-config duplicates (e.g. an identity). See
+# docs/operations.md "Pivot recovery".
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+source ./bootstrap-common.sh
+
+PROFILE="${KNR_OPS_PROFILE:-${1:-aws}}"
+GIT_BRANCH="${GIT_BRANCH:-main}"
+REGISTRY_NAME="${REGISTRY_NAME:-knr-registry}"
+REGISTRY_PORT="${REGISTRY_PORT:-5001}"
+MGMT_NS="default"
+MGMT_KUBECONFIG="${MGMT_KUBECONFIG:-$HOME/.kube/knr-ops-mgmt.yaml}"
+PIVOT_SKIP_DELETE="${PIVOT_SKIP_DELETE:-0}"
+
+# Chart versions installed imperatively in the target before Flux exists.
+# Keep in sync with deps/versions.toml (cert_manager, capi_operator_chart);
+# both are slot-validated by `mise run deps-check`.
+CERT_MANAGER_VERSION="1.21.1"
+CAPI_OPERATOR_VERSION="0.28.0"
+
+case "$PROFILE" in
+  aws)
+    MGMT_CLUSTER="eu-north-1-management"
+    MGMT_READY_TIMEOUT="${MGMT_READY_TIMEOUT:-40m}"
+    ;;
+  local-host)
+    MGMT_CLUSTER="local-management"
+    MGMT_READY_TIMEOUT="${MGMT_READY_TIMEOUT:-15m}"
+    ;;
+  *)
+    echo "ERROR: unsupported environment '$PROFILE' (expected 'local-host' or 'aws')" >&2
+    exit 1
+    ;;
+esac
+
+# ── Phase 0: preflight ────────────────────────────────────────────────────────
+pivot_preflight() {
+  for cmd in clusterctl helm kubectl kind mise; do
+    command -v "$cmd" >/dev/null 2>&1 || { echo "ERROR: $cmd not found in PATH" >&2; exit 1; }
+  done
+
+  local expected_context="${BOOTSTRAP_KUBECONTEXT:-kind-mgmt}"
+  local current_context
+  current_context="$(kubectl config current-context 2>/dev/null || true)"
+  if [ "$current_context" != "$expected_context" ]; then
+    echo "ERROR: current kubectl context is '${current_context}', expected '${expected_context}'." >&2
+    echo "       The kind bootstrap cluster must be the move SOURCE." >&2
+    echo "       Fix with: kubectl config use-context ${expected_context}" >&2
+    exit 1
+  fi
+
+  if ! kubectl get cluster "$MGMT_CLUSTER" -n "$MGMT_NS" >/dev/null 2>&1; then
+    echo "ERROR: Cluster '$MGMT_CLUSTER' not found in the bootstrap cluster." >&2
+    echo "       The management cluster definition must be reconciled first:" >&2
+    echo "       aws:        merged to main, Flux-in-kind creates it (~15-25 min)" >&2
+    echo "       local-host: mise -E local-host run oci-push, then wait ~2 min" >&2
+    exit 1
+  fi
+
+  if [ "$PROFILE" = aws ]; then
+    require_flux_env
+  else
+    detect_container_engine
+    if ! curl --fail --silent --show-error \
+      "http://localhost:${REGISTRY_PORT}/v2/" >/dev/null 2>&1; then
+      echo "ERROR: local registry is unavailable at localhost:${REGISTRY_PORT}" >&2
+      echo "       The management cluster's Flux syncs from it; it must stay running." >&2
+      exit 1
+    fi
+  fi
+}
+
+# ── Phase 1: wait for the management cluster ──────────────────────────────────
+# CAPI Clusters do not expose a uniform Ready condition across providers, so
+# readiness = the kubeconfig secret exists (control plane has an endpoint).
+# Node readiness is verified in Phase 2 against the exported kubeconfig.
+wait_for_management_cluster() {
+  echo ">>> Waiting for the management cluster kubeconfig (timeout: ${MGMT_READY_TIMEOUT})..."
+  # Readiness = the kubeconfig secret exists (the control plane has an
+  # endpoint). Poll rather than kubectl-wait so a not-yet-created secret is
+  # waited on instead of erroring immediately.
+  local timeout_s attempts=0
+  case "$MGMT_READY_TIMEOUT" in
+    *h) timeout_s=$(( $(echo "$MGMT_READY_TIMEOUT" | tr -dc '0-9') * 3600 )) ;;
+    *m) timeout_s=$(( $(echo "$MGMT_READY_TIMEOUT" | tr -dc '0-9') * 60 )) ;;
+    *s) timeout_s="$(echo "$MGMT_READY_TIMEOUT" | tr -dc '0-9')" ;;
+    *)  timeout_s="$MGMT_READY_TIMEOUT" ;;
+  esac
+  local max_attempts=$(( timeout_s / MGMT_POLL_INTERVAL ))
+  until kubectl get "secret/${MGMT_CLUSTER}-kubeconfig" -n "$MGMT_NS" >/dev/null 2>&1; do
+    attempts=$((attempts + 1))
+    if [ "$attempts" -ge "$max_attempts" ]; then
+      echo "ERROR: management cluster kubeconfig not available within ${MGMT_READY_TIMEOUT}" >&2
+      kubectl describe cluster "$MGMT_CLUSTER" -n "$MGMT_NS" || true
+      exit 1
+    fi
+    sleep "$MGMT_POLL_INTERVAL"
+  done
+  clusterctl describe cluster "$MGMT_CLUSTER" -n "$MGMT_NS" || true
+}
+
+# ── Phase 2: export the target kubeconfig ─────────────────────────────────────
+export_mgmt_kubeconfig() {
+  echo ">>> Exporting management-cluster kubeconfig to ${MGMT_KUBECONFIG}..."
+  mkdir -p "$(dirname "$MGMT_KUBECONFIG")"
+  clusterctl get kubeconfig "$MGMT_CLUSTER" -n "$MGMT_NS" > "$MGMT_KUBECONFIG"
+  chmod 600 "$MGMT_KUBECONFIG"
+
+  if [ "$PROFILE" = local-host ]; then
+    # CAPD records the load balancer's container-network IP, which is not
+    # routable from macOS. Point the kubeconfig at the port published on
+    # localhost instead (same rewrite as the workload kubeconfigs).
+    local endpoint port
+    endpoint="$($CONTAINER_ENGINE port "${MGMT_CLUSTER}-lb" 6443/tcp | head -1)"
+    port="${endpoint##*:}"
+    case "$port" in
+      ''|*[!0-9]*)
+        echo "ERROR: cannot determine the ${MGMT_CLUSTER} API server port" >&2
+        exit 1
+        ;;
+    esac
+    kubectl config set-cluster "$MGMT_CLUSTER" \
+      --server="https://127.0.0.1:${port}" \
+      --kubeconfig="$MGMT_KUBECONFIG" >/dev/null
+  fi
+
+  kubectl --kubeconfig "$MGMT_KUBECONFIG" config rename-context \
+    "$(kubectl --kubeconfig "$MGMT_KUBECONFIG" config current-context)" \
+    knr-ops-mgmt >/dev/null
+
+  echo ">>> Waiting for management-cluster nodes to be ready..."
+  kubectl --kubeconfig "$MGMT_KUBECONFIG" wait --for=condition=Ready node --all --timeout=15m
+}
+
+# ── Phase 3: install CAPI in the target ───────────────────────────────────────
+# Imperative but Git-identical: the target has no Flux yet, so the HelmReleases
+# cannot be reconciled. After Phase 5 Flux adopts these releases and provider
+# CRs without drift (same charts, same versions, same CRs).
+install_capi_in_target() {
+  echo ">>> Installing cert-manager ${CERT_MANAGER_VERSION} in the target..."
+  local anon_registry_config
+  anon_registry_config="$(mktemp)"
+  seed_register_cleanup "$anon_registry_config"
+  printf '{}\n' > "$anon_registry_config"
+  # Values mirror mgmt/<env>/infrastructure/cert-manager/helmrelease.yaml
+  helm install cert-manager cert-manager \
+    --repo https://charts.jetstack.io \
+    --version "$CERT_MANAGER_VERSION" \
+    --namespace cert-manager --create-namespace --wait \
+    --set crds.enabled=true \
+    --registry-config "$anon_registry_config" \
+    --kubeconfig "$MGMT_KUBECONFIG"
+
+  echo ">>> Installing CAPI operator ${CAPI_OPERATOR_VERSION} in the target..."
+  # Values mirror mgmt/<env>/infrastructure/capi-operator/helmrelease.yaml
+  helm install capi-operator cluster-api-operator \
+    --repo https://kubernetes-sigs.github.io/cluster-api-operator \
+    --version "$CAPI_OPERATOR_VERSION" \
+    --namespace capi-operator-system --create-namespace --wait \
+    --set cert-manager.enabled=false \
+    --registry-config "$anon_registry_config" \
+    --kubeconfig "$MGMT_KUBECONFIG"
+
+  echo ">>> Applying provider CRs in the target..."
+  # Apply the plain manifests verbatim (NOT the kustomization dirs: capa-system
+  # contains the SOPS-encrypted aws-credentials which only Flux can decrypt).
+  local infra_ns infra_name
+  if [ "$PROFILE" = aws ]; then
+    infra_ns="capa-system"; infra_name="aws"
+    kubectl --kubeconfig "$MGMT_KUBECONFIG" apply -f mgmt/aws/capi-providers/capi-system/namespace.yaml
+    kubectl --kubeconfig "$MGMT_KUBECONFIG" apply -f mgmt/aws/capi-providers/capi-system/providers.yaml
+    kubectl --kubeconfig "$MGMT_KUBECONFIG" apply -f mgmt/aws/capi-providers/capa-system/namespace.yaml
+    kubectl --kubeconfig "$MGMT_KUBECONFIG" apply -f mgmt/aws/capi-providers/capa-system/providers.yaml
+    kubectl --kubeconfig "$MGMT_KUBECONFIG" apply -f mgmt/aws/capi-providers/caaph-system/namespace.yaml
+    kubectl --kubeconfig "$MGMT_KUBECONFIG" apply -f mgmt/aws/capi-providers/caaph-system/addon-provider.yaml
+
+    # CAPA credentials: the InfrastructureProvider above references the
+    # aws-credentials secret (configSecret.name). On the bootstrap cluster
+    # Flux decrypts aws-credentials.sops.yaml; here it is created directly
+    # with the same shape (stringData.AWS_B64ENCODED_CREDENTIALS).
+    # Do NOT pre-apply mgmt/aws/infrastructure/aws-identity/: the
+    # AWSClusterControllerIdentity carries a move hook and comes over with
+    # the Phase 4 move.
+    echo ">>> Creating CAPA credentials secret in capa-system..."
+    local aws_b64_credentials
+    aws_b64_credentials="$(mise -E aws run aws-credentials)"
+    kubectl --kubeconfig "$MGMT_KUBECONFIG" create secret generic aws-credentials \
+      --namespace capa-system \
+      --from-literal="AWS_B64ENCODED_CREDENTIALS=${aws_b64_credentials}" \
+      --dry-run=client -o yaml | kubectl --kubeconfig "$MGMT_KUBECONFIG" apply -f -
+  else
+    infra_ns="capd-system"; infra_name="docker"
+    kubectl --kubeconfig "$MGMT_KUBECONFIG" apply -f mgmt/local-host/capi-providers/capi-system/namespace.yaml
+    kubectl --kubeconfig "$MGMT_KUBECONFIG" apply -f mgmt/local-host/capi-providers/capi-system/providers.yaml
+    kubectl --kubeconfig "$MGMT_KUBECONFIG" apply -f mgmt/local-host/capi-providers/capd-system/namespace.yaml
+    kubectl --kubeconfig "$MGMT_KUBECONFIG" apply -f mgmt/local-host/capi-providers/capd-system/provider.yaml
+    kubectl --kubeconfig "$MGMT_KUBECONFIG" apply -f mgmt/local-host/capi-providers/caaph-system/namespace.yaml
+    kubectl --kubeconfig "$MGMT_KUBECONFIG" apply -f mgmt/local-host/capi-providers/caaph-system/provider.yaml
+  fi
+
+  echo ">>> Waiting for providers in the target..."
+  kubectl --kubeconfig "$MGMT_KUBECONFIG" wait --for=condition=Ready \
+    coreprovider/cluster-api -n capi-system --timeout=15m
+  kubectl --kubeconfig "$MGMT_KUBECONFIG" wait --for=condition=Ready \
+    bootstrapprovider/kubeadm controlplaneprovider/kubeadm -n capi-system --timeout=15m
+  kubectl --kubeconfig "$MGMT_KUBECONFIG" wait --for=condition=Ready \
+    "infrastructureprovider/${infra_name}" -n "$infra_ns" --timeout=15m
+  kubectl --kubeconfig "$MGMT_KUBECONFIG" wait --for=condition=Ready \
+    addonprovider/helm -n caaph-system --timeout=15m
+
+  # `clusterctl move` requires every source provider to exist in the target
+  # at >= its source version. Same files + same catalog = same versions; the
+  # listings below make the comparison visible in the pivot log.
+  echo ">>> Source providers:"
+  kubectl get coreproviders,bootstrapproviders,controlplaneproviders,infrastructureproviders,addonproviders -A || true
+  echo ">>> Target providers:"
+  kubectl --kubeconfig "$MGMT_KUBECONFIG" get \
+    coreproviders,bootstrapproviders,controlplaneproviders,infrastructureproviders,addonproviders -A || true
+}
+
+# ── Phase 4: suspend Flux in kind, then move ──────────────────────────────────
+suspend_and_move() {
+  # clusterctl move pauses Clusters on the source and deletes the moved
+  # objects after creating them on the target. Flux-in-kind must not
+  # reconcile mid-move (Git carries no spec.paused, so it would unpause the
+  # Clusters and recreate deleted objects). kind is abandoned after the
+  # pivot, so the suspension is never lifted there.
+  echo ">>> Suspending Flux Kustomizations in the bootstrap cluster..."
+  local ks
+  for ks in $(kubectl get kustomizations -n flux-system -o name); do
+    kubectl patch "$ks" -n flux-system --type merge -p '{"spec":{"suspend":true}}'
+  done
+
+  echo ">>> Moving the CAPI inventory to the management cluster..."
+  if ! clusterctl move --to-kubeconfig "$MGMT_KUBECONFIG" -n "$MGMT_NS"; then
+    echo "" >&2
+    echo "ERROR: clusterctl move failed." >&2
+    echo "       The move is re-runnable: objects are deleted from the source only" >&2
+    echo "       after they were created on the target, so kind stays authoritative." >&2
+    echo "       NEVER delete moved Cluster / AWSManaged* / MachinePool / Dev* objects" >&2
+    echo "       on the target to work around a failure — the provider would" >&2
+    echo "       deprovision the real infrastructure. See docs/operations.md" >&2
+    echo "       'Pivot recovery'." >&2
+    exit 1
+  fi
+
+  # Moved Clusters are created on the target with spec.paused=true (the move
+  # pauses them); Git carries no paused field, so Flux would never clear it.
+  # Flux is not seeded on the target yet, so unpausing here is race-free.
+  echo ">>> Unpausing moved Clusters on the target..."
+  local cluster
+  for cluster in $(kubectl --kubeconfig "$MGMT_KUBECONFIG" get clusters -n "$MGMT_NS" -o name); do
+    kubectl --kubeconfig "$MGMT_KUBECONFIG" patch "$cluster" -n "$MGMT_NS" \
+      --type merge -p '{"spec":{"paused":false}}' || true
+  done
+
+  echo ">>> Clusters on the management cluster after the move:"
+  kubectl --kubeconfig "$MGMT_KUBECONFIG" get clusters -n "$MGMT_NS"
+
+  if [ "$PROFILE" = aws ]; then
+    # The AWSClusterControllerIdentity carries a clusterctl move hook and
+    # comes over with the inventory; verify, and fall back to the Git
+    # manifest only if it is missing.
+    if ! kubectl --kubeconfig "$MGMT_KUBECONFIG" get \
+        awsclustercontrolleridentities.infrastructure.cluster.x-k8s.io default \
+        -n "$MGMT_NS" >/dev/null 2>&1; then
+      echo ">>> AWSClusterControllerIdentity missing after the move; applying from Git..."
+      kubectl --kubeconfig "$MGMT_KUBECONFIG" apply -f mgmt/aws/infrastructure/aws-identity/identity.yaml
+    fi
+  fi
+}
+
+# ── Phase 5: seed Flux on the target ──────────────────────────────────────────
+seed_target() {
+  # aws:       syncs mgmt/aws from GitHub main.
+  # local-host: syncs mgmt/local-host from the local OCI registry; the
+  #            artifact must contain the management manifests.
+  if [ "$PROFILE" = local-host ]; then
+    echo ">>> Publishing the current checkout as the OCI artifact..."
+    mise -E local-host run oci-push
+  fi
+
+  seed_flux "$MGMT_KUBECONFIG"
+
+  echo ">>> Kustomizations on the management cluster:"
+  kubectl --kubeconfig "$MGMT_KUBECONFIG" get kustomizations -n flux-system
+}
+
+# ── Phase 6: delete the bootstrap cluster ─────────────────────────────────────
+delete_bootstrap_cluster() {
+  if [ "$PIVOT_SKIP_DELETE" = 1 ]; then
+    echo ">>> PIVOT_SKIP_DELETE=1: keeping the kind bootstrap cluster for inspection"
+    return
+  fi
+
+  # Guard: only delete kind once the management cluster demonstrably owns
+  # everything (all clusters present; local-host: registry still serving).
+  local clusters
+  clusters="$(kubectl --kubeconfig "$MGMT_KUBECONFIG" get clusters -n "$MGMT_NS" -o name)"
+  if [ -z "$clusters" ]; then
+    echo "ERROR: no Clusters on the management cluster; refusing to delete kind." >&2
+    exit 1
+  fi
+  if [ "$PROFILE" = local-host ]; then
+    if ! curl --fail --silent --show-error \
+      "http://localhost:${REGISTRY_PORT}/v2/" >/dev/null 2>&1; then
+      echo "ERROR: local registry unavailable; the management cluster's Flux depends on it." >&2
+      echo "       Refusing to delete kind until it is serving." >&2
+      exit 1
+    fi
+  fi
+
+  echo ">>> Deleting the kind bootstrap cluster..."
+  kind delete cluster --name mgmt
+
+  echo ""
+  echo ">>> Pivot complete: the management cluster is self-managed."
+  echo ">>> Management kubeconfig: ${MGMT_KUBECONFIG}"
+  echo ">>> Use with: KUBECONFIG=${MGMT_KUBECONFIG} kubectl get clusters"
+  if kubectl config use-context knr-ops-mgmt >/dev/null 2>&1; then
+    echo ">>> kubectl context switched to knr-ops-mgmt"
+  else
+    echo ">>> To use it by default: export KUBECONFIG=${MGMT_KUBECONFIG}"
+  fi
+}
+
+MGMT_POLL_INTERVAL="${MGMT_POLL_INTERVAL:-10}"
+
+trap seed_cleanup EXIT
+
+pivot_preflight
+wait_for_management_cluster
+export_mgmt_kubeconfig
+install_capi_in_target
+suspend_and_move
+seed_target
+delete_bootstrap_cluster


### PR DESCRIPTION
Refs #79. Follow-up to #85/#86 (definitions merged): the tooling that moves the CAPI management inventory from the kind bootstrap cluster into the self-managed management cluster, on both environments.

## What

- **`pivot.sh`** — re-runnable pivot runbook, one script branching on environment like `bootstrap.sh`:
  1. preflight (context guard: kind must be the move source; aws: GitHub/age inputs; local-host: registry alive)
  2. wait for the management cluster (`eu-north-1-management` / `local-management`) — kubeconfig-secret poll, endpoint-agnostic across CAPA/CAPD
  3. export the target kubeconfig (`~/.kube/knr-ops-mgmt.yaml`, context `knr-ops-mgmt`; local-host: rewrite server to the lb container's published port, same as the workload kubeconfigs)
  4. install cert-manager + CAPI operator in the target imperatively at **catalog versions** (slots validated by deps-check), apply the provider CRs verbatim from Git (plain manifests only — capa-system's SOPS secret is Flux-only), create the CAPA `aws-credentials` secret directly (aws only; the identity is NOT pre-applied — it carries a move hook)
  5. suspend all Flux Kustomizations in kind (blocks the mid-move unpause race), `clusterctl move`, then **unpause the moved Clusters** on the target (the move pauses them; Git carries no `spec.paused`, so this must happen before Flux is seeded)
  6. seed Flux on the target (local-host republishes the OCI artifact first so it contains the management manifests), verify Kustomizations
  7. delete kind, guarded (clusters present on the target; local-host: registry serving)
- **`bootstrap-common.sh`** — shared preflight (`require_flux_env`, `detect_container_engine`) and `seed_flux` (operator, secrets, FluxInstance, Ready wait) extracted verbatim from `bootstrap.sh`; `pivot.sh` seeds the target exactly as bootstrap seeds kind. No behavior change to bootstrap.
- **`bootstrap.sh`** — execs `pivot.sh` by default on both environments (`BOOTSTRAP_PIVOT=0` opts out, pre-#79 behavior). Fresh installs pivot automatically once Flux creates the management cluster.
- **`mise.toml`** — `pivot` and `mgmt-kubeconfig` tasks; `validate` bash-n's the new scripts.
- **`deps/versions.toml`** — slots pinning `pivot.sh`'s `CERT_MANAGER_VERSION` / `CAPI_OPERATOR_VERSION` literals to the catalog.

## Why imperative provider install in the target

HelmReleases need Flux. The target has none pre-move, so pivot installs the same charts (same versions, same values) helm-wise, and applies the same provider CRs kubectl-wise; once Flux is seeded it adopts both without drift (identical Git content).

## Safety

- Move failure guidance built into the script: re-run, never delete moved infra objects on the target (providers would deprovision real infrastructure).
- `PIVOT_SKIP_DELETE=1` keeps kind for inspection.
- kind deletion only after all checks pass.

## Validation

- `bash -n` (plus macOS bash 3.2) on all scripts; `mise run validate` green (45 checks); deps-check green with the new slots.
- Preflight smoke-tested against the live kind (`local-management` not yet reconciled, clean error with next-step hints).
- CLI contracts verified against the pinned tools: `clusterctl move` flags, helm 4 `--kubeconfig`, multi-resource `kubectl wait`.

## Not in this PR

- `teardown.sh` self-hosted-mgmt awareness — next PR.
- Docs (operations/architecture) and AGENTS.md update — final PR. The AGENTS.md touch (pivot.sh/bootstrap-common.sh layout bullets, new mise tasks) is required by repo policy for workflow changes; it belongs with the end-to-end documentation.

## Live-run notes (for the merge-to-pivot window)

- aws: definitions are on main; an operator runs `mise run pivot` on the machine hosting the kind cluster for the aws environment. EKS control-plane and 2x t4g.medium billing for `eu-north-1-management` starts when its Cluster object is created.
- local-host: `mise -E local-host run pivot` (the script republishes the OCI artifact first).

Single logical commit; per the #84 review convention this PR covers both environments because the tooling does not separate cleanly (shared bootstrap-common.sh, shared skeleton, shared mise wiring).
