### PR TITLE
docs: rewrite README and docs for the Rust CLI direction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,7 +118,7 @@ mise run teardown       # full teardown (EKS, AWS resources, kind)
 Load these only when the task touches their domain:
 
 - `docs/architecture.md`: reconciliation order, how workload apps are delivered.
-- `docs/bootstrap-cli.md`: the `knr-bootstrap` Rust CLI — interface, env knobs, pivot, parity status.
+- `docs/bootstrap-cli.md`: the `knr-bootstrap` Rust CLI: interface, env knobs, pivot, parity status.
 - `docs/extending.md`: adding a workload cluster, adding apps, adding other providers (Azure, Talos, k0smotron).
 - `docs/secrets.md`: SOPS + age setup, credential rotation.
 - `docs/konflate.md`: rendered PR review, CI gate, tokens, write-back.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,8 @@ resources. There is no app source code here, only declarative infrastructure.
   - `addons/flux-apps/`: installs Flux on each workload cluster
     (HelmChartProxy + ClusterResourceSets).
   - `clusters/`: EKS cluster definitions per region (`eu-north-1`,
-    `eu-west-1`).
+    `eu-west-1`); `eu-north-1` also defines the self-managed management
+    cluster (`clusters/management/`).
 - `mgmt/local-host/`: the local-host management variant (kind-based).
   Same layout as `mgmt/aws/` (`clusters/docker`, `capi-providers/`,
   `addons/`, `infrastructure/`) with no cloud dependencies.
@@ -40,8 +41,17 @@ resources. There is no app source code here, only declarative infrastructure.
   attempted). Both deploy evidence artifacts are uploaded. Running both is
   a temporary comparison of validation accuracy and performance; the less
   effective job will be removed after enough runs are evaluated.
-- `bootstrap.sh` / `teardown.sh`: the only imperative steps (one-time
-  kind + Flux bootstrap, full teardown).
+- `bootstrap-rs/`: `knr-bootstrap`, the Rust CLI that ports the imperative
+  lifecycle (bootstrap + pivot; teardown under issue #100). Behavioral port:
+  same step order, messages, and env interface as the scripts, plus
+  rerun-safe-by-default semantics. Chart versions it installs imperatively
+  are Renovate-annotated constants in `src/main.rs`. CI (bootstrap-rs
+  workflow) runs fmt/clippy/build/test; the toolchain is pinned in
+  `rust-toolchain.toml`.
+- `bootstrap.sh` / `pivot.sh` / `teardown.sh`: the shell equivalents of the
+  CLI's phases. Kept until the binary completes full parity runs per
+  environment, then retired (issues #92/#95/#100). `mise run bootstrap` and
+  `mise run pivot` still invoke the scripts.
 - `docs/`: detailed documentation (see the table in README.md).
 - `mise.toml`: pinned tool versions and all task entrypoints.
   `mise.aws.toml` is the AWS tool layer (aws-cli, clusterawsadm),
@@ -98,7 +108,7 @@ Each component pairs a plain kustomize root with a Flux `Kustomization`:
 ```sh
 mise install            # install pinned tools (kubectl, kind, flux, sops, age, ...)
 mise run validate       # build every kustomize overlay; mirrors CI
-mise run bootstrap      # one-time kind cluster + Flux handoff
+mise run bootstrap      # one-time kind cluster + Flux handoff + pivot to self-managed mgmt
 mise -E aws run kubeconfigs  # export AWS workload-cluster kubeconfigs
 mise run teardown       # full teardown (EKS, AWS resources, kind)
 ```
@@ -108,6 +118,7 @@ mise run teardown       # full teardown (EKS, AWS resources, kind)
 Load these only when the task touches their domain:
 
 - `docs/architecture.md`: reconciliation order, how workload apps are delivered.
+- `docs/bootstrap-cli.md`: the `knr-bootstrap` Rust CLI — interface, env knobs, pivot, parity status.
 - `docs/extending.md`: adding a workload cluster, adding apps, adding other providers (Azure, Talos, k0smotron).
 - `docs/secrets.md`: SOPS + age setup, credential rotation.
 - `docs/konflate.md`: rendered PR review, CI gate, tokens, write-back.

--- a/README.md
+++ b/README.md
@@ -5,16 +5,19 @@
 
 A GitOps pattern for managing cloud infrastructure through the Kubernetes API:
 no Terraform, no DSLs, no state files, no second toolchain. This repository is
-a working reference implementation of that pattern, with two profiles: `aws`,
-which runs it end-to-end on AWS EKS, and `local-host`, which runs the same
-lifecycle on local clusters with no cloud account involved. **It is not a
+a working reference implementation of that pattern, with two environments:
+`aws`, which runs it end-to-end on AWS EKS, and `local-host`, which runs the
+same lifecycle on local clusters with no cloud account involved. **It is not a
 product**: fork it, strip it down, and adapt the layout to your own cloud and
 clusters.
 
-A local [kind](https://kind.sigs.k8s.io/) cluster bootstraps
-[Flux](https://fluxcd.io/), which then reconciles everything else from this
-repository. The `aws` profile reconciles:
+A disposable local [kind](https://kind.sigs.k8s.io/) cluster bootstraps
+[Flux](https://fluxcd.io/) and is then discarded: a CAPI pivot moves the
+control plane into a self-managed management cluster that reconciles itself
+and everything else from this repository. The `aws` environment reconciles:
 
+- a self-managed EKS management cluster (provisioned by CAPA, reconciled from
+  Git by the Flux instance running inside it)
 - AWS EKS workload clusters provisioned via
   [CAPA](https://cluster-api-aws.sigs.k8s.io/)
 - per-cluster Flux instances delivered through CAPI addons
@@ -22,16 +25,19 @@ repository. The `aws` profile reconciles:
   S3, RDS, and IAM operators managing secure S3 buckets, PostgreSQL instances,
   and read-only IAM roles) running on each workload cluster
 
-The `local-host` profile walks the identical chain with the CAPD Docker
+The `local-host` environment walks the identical chain with the CAPD Docker
 provider instead of CAPA: a local OCI registry, a one-control-plane/one-worker
 workload cluster, a second Flux instance, and a Podinfo app reachable from
-your laptop. It covers the complete GitOps and CAPI lifecycle without
+your laptop. It covers the complete GitOps, CAPI, and pivot lifecycle without
 provisioning AWS resources.
 
-After the one-time bootstrap, **everything is declared in Git as YAML**.
-The `aws` profile declares 2 CAPI workload clusters: 4 node pools (ARM and
-GPU) across 2 regions, 2 S3 buckets, 2 RDS instances, 1 reader user, and one
-reader role per workload cluster. The repository also ships a
+The imperative part of the lifecycle — bootstrap, pivot, and teardown — is a
+single Rust CLI, [`knr-bootstrap`](docs/bootstrap-cli.md), that replaces the
+shell scripts as they complete parity runs. After the one-time bootstrap and
+pivot, **everything is declared in Git as YAML**. The `aws` environment
+declares 2 CAPI workload clusters: 4 node pools (ARM and GPU) across 2
+regions, 2 S3 buckets, 2 RDS instances, 1 reader user, and one reader role
+per workload cluster. The repository also ships a
 [Zarf](https://zarf.dev/) air-gap bundle that packages the `local-host`
 deployment for offline installs. 0 HCL, 0 state files.
 
@@ -58,6 +64,10 @@ not a developer self-service portal; you are the consumer.
   means RBAC, policy, and audit cover both.
 - **Lifecycle split**: Terraform builds the cluster but can't manage what's
   in it. CAPI + Flux is one dependency graph from cluster to workload.
+- **A control plane on a laptop**: the management cluster is not a long-lived
+  local kind cluster. The bootstrap kind cluster is disposable, and after the
+  pivot the management cluster manages itself through the same GitOps flow it
+  drives.
 
 ![knr-ops aws architecture](docs/aws-infra.svg)
 
@@ -68,20 +78,23 @@ not a developer self-service portal; you are the consumer.
 ## Prerequisites
 
 - Mise 2026.8.10 or newer
-- A running Docker engine, or Podman 5.5+, for kind; the local-host profile
-  also uses it for its local OCI registry
-- AWS profile only: GitHub personal access token (PAT) with read access to this
-  repo
-- AWS profile only: AWS credentials and quotas established for the profile
+- A running Docker engine, or Podman 5.5+, for kind; the local-host
+  environment also uses it for its local OCI registry
+- Rust toolchain (via [rustup](https://rustup.rs/); the exact pin lives in
+  `bootstrap-rs/rust-toolchain.toml`) to build the bootstrap CLI
+- AWS environment only: GitHub personal access token (PAT) with read access
+  to this repo
+- AWS environment only: AWS credentials and quotas established for the
+  environment
 
 ## Quickstart
 
 ```sh
 mise trust                  # to enable mise in this repository
 mise install                # installs tools pinned in mise.toml (kubectl, kind, flux, ...)
-cp .env.example .env        # AWS profile only: fill in GitHub PAT and AWS settings
+cp .env.example .env        # AWS environment only: fill in GitHub PAT and AWS settings
 mise run sops-keygen        # first time only: age key for SOPS
-mise run bootstrap          # kind cluster + Flux; everything else is GitOps
+mise run bootstrap          # disposable kind cluster + Flux + pivot; then it is all GitOps
 flux get kustomizations --watch
 mise run validate           # bash -n, unit tests, build every kustomize overlay (mirrors CI)
 mise run teardown           # full teardown (EKS, AWS resources, kind)
@@ -92,16 +105,16 @@ Dependency versions are managed by Renovate
 consume them and Renovate opens update PRs weekly; see
 [docs/dependencies.md](docs/dependencies.md).
 
-### Mise profiles
+### Environments (formerly profiles)
 
 The shared toolchain is defined in `mise.toml`. AWS-specific tools are layered
-through `mise.aws.toml`; use the `aws` profile when those tools are needed.
-The `local-host` profile creates the management kind cluster, a local OCI
-registry, and the Flux Operator and FluxInstance. It publishes the
+through `mise.aws.toml`; use the `aws` environment when those tools are
+needed. The `local-host` environment creates the management kind cluster, a
+local OCI registry, and the Flux Operator and FluxInstance. It publishes the
 `mgmt/local-host/` and `workload/local-host/` folders as the `knr-ops:latest`
 OCI artifact. Flux installs CAPI with its Docker infrastructure provider (CAPD),
-provisions a local one-control-plane/one-worker workload cluster, and installs a
-separate Flux instance there. That workload Flux instance reconciles Podinfo,
+provisions a local one-control-plane/one-worker workload cluster, and installs
+a separate Flux instance there. That workload Flux instance reconciles Podinfo,
 providing an end-to-end local path from management-cluster bootstrap through
 workload delivery and application access. This covers the complete GitOps and
 CAPI lifecycle without provisioning AWS resources:
@@ -115,9 +128,9 @@ mise -E local-host run podinfo-port-forward  # http://localhost:9898
 mise -E local-host run teardown
 ```
 
-The Flux charts are pulled anonymously. The AWS profile requires a
-GitHub PAT so Flux can clone this repository; the local-host profile does not require
-GitHub or AWS credentials.
+The Flux charts are pulled anonymously. The AWS environment requires a
+GitHub PAT so Flux can clone this repository; the local-host environment does
+not require GitHub or AWS credentials.
 
 `mise -E local-host run bootstrap` waits for both the management and workload
 Flux reconciliation chains and surfaces workload reconciliation errors. A
@@ -128,17 +141,32 @@ The local-host teardown deletes the CAPD workload cluster before deleting the
 `mgmt` kind cluster and local registry container. The default teardown path
 suspends Flux and removes the AWS-managed infrastructure.
 
+## The bootstrap CLI
+
+The imperative lifecycle steps run through a single Rust binary,
+`knr-bootstrap` ([docs/bootstrap-cli.md](docs/bootstrap-cli.md)): it creates
+the disposable kind cluster, hands off to Flux, and — by default — pivots the
+CAPI inventory into the self-managed management cluster before deleting kind.
+Reruns are safe by default (a healthy cluster is reused, every step is
+idempotent), so a failed run resumes by rerunning. The shell scripts
+(`bootstrap.sh`, `pivot.sh`, `teardown.sh`) remain the `mise` entrypoints
+until the binary completes full parity runs per environment; the teardown port
+([#100](https://github.com/polarsquad/knr-ops/issues/100)) and the
+externalization of repo-specific constants into `bootstrap.toml`
+([#98](https://github.com/polarsquad/knr-ops/issues/98)) are tracked issues.
+
 ## Documentation
 
 | Page | Contents |
 |---|---|
+| [docs/bootstrap-cli.md](docs/bootstrap-cli.md) | The `knr-bootstrap` Rust CLI: build, interface, env knobs, pivot, parity status, roadmap |
 | [docs/dependencies.md](docs/dependencies.md) | Renovate-managed dependency updates: covered surfaces, update procedure, intentional differences |
 | [docs/architecture.md](docs/architecture.md) | Architecture diagram, reconciliation order, how workload apps are delivered |
 | [docs/aws-iam.md](docs/aws-iam.md) | EKS Pod Identity, ACK controller IAM roles, per-cluster reader roles, the `knr-ops-reader` console user |
 | [docs/workload-resources.md](docs/workload-resources.md) | S3 bucket security posture, RDS instances, known limitations |
 | [docs/konflate.md](docs/konflate.md) | Rendered Flux PR review: GitHub Actions gate, in-cluster instance, write-back to PRs, tokens |
 | [docs/secrets.md](docs/secrets.md) | SOPS + age secret management, key setup, credential rotation |
-| [docs/operations.md](docs/operations.md) | Prerequisites, AWS service quotas, configuration, bootstrap, verification, pivot recovery, teardown, validation |
+| [docs/operations.md](docs/operations.md) | Prerequisites, AWS service quotas, configuration, bootstrap, pivot recovery, teardown, validation |
 | [docs/extending.md](docs/extending.md) | Adding a workload cluster, adding apps to the workload clusters, adding other providers (Azure, Talos, k0smotron) |
 | [docs/airgap.md](docs/airgap.md) | Zarf air-gap bundle: package build, offline deploy, verification checklist, update drill |
 
@@ -146,27 +174,31 @@ suspends Flux and removes the AWS-managed infrastructure.
 
 ```
 ├── airgap/                       Zarf air-gap bundle, image inventory, scripts
-├── bootstrap.sh / teardown.sh     One-time imperative bootstrap / full teardown
-├── docs/                          Detailed documentation (see table above)
-├── mise.toml / mise.*.toml        Pinned toolchain and AWS/local-host tasks
+├── bootstrap-rs/                 knr-bootstrap: the Rust bootstrap/pivot CLI
+├── bootstrap.sh / pivot.sh /     Shell equivalents; kept until the binary
+│   teardown.sh                   completes full parity runs, then retired
+├── docs/                         Detailed documentation (see table above)
+├── mise.toml / mise.*.toml       Pinned toolchain and AWS/local-host tasks
 ├── mgmt/aws/                     Synced by the MANAGEMENT cluster's Flux
-│   ├── infrastructure/            cert-manager, CAPI operator, CAPA identity,
+│   ├── infrastructure/           cert-manager, CAPI operator, CAPA identity,
 │   │                              ACK controllers, pod-identity roles,
 │   │                              account-global IAM (reader console user),
 │   │                              konflate (rendered Flux PR review)
-│   ├── capi-providers/            capi-system, capa-system (SOPS creds),
+│   ├── capi-providers/           capi-system, capa-system (SOPS creds),
 │   │                              caaph-system
-│   ├── addons/flux-apps/          Installs Flux on each workload cluster
+│   ├── addons/flux-apps/         Installs Flux on each workload cluster
 │   │                              (HelmChartProxy + ClusterResourceSets)
-│   └── clusters/                  EKS cluster defs (eu-north-1, eu-west-1;
-│                                  ARM + GPU MachinePools)
-├── mgmt/local-host/               OCI-synced CAPI/CAPD local workload cluster
-└── workload/                      Synced by each WORKLOAD cluster's Flux
-    ├── base/                      ACK S3/RDS/IAM controllers, Bucket CRs,
+│   └── clusters/                 EKS cluster defs: eu-north-1, eu-west-1
+│                                  (ARM + GPU MachinePools); eu-north-1 also
+│                                  carries the self-managed management cluster
+├── mgmt/local-host/              OCI-synced CAPI/CAPD local workload cluster
+│                                  and its management cluster definition
+└── workload/                     Synced by each WORKLOAD cluster's Flux
+    ├── base/                     ACK S3/RDS/IAM controllers, Bucket CRs,
     │                              DBInstance CRs, reader Role CRs
-    ├── local-host/                OCI-synced Podinfo workload overlay
-    ├── eu-north-01/               Per-cluster overlay (sync target)
-    └── eu-west-01/                Per-cluster overlay (sync target)
+    ├── local-host/               OCI-synced Podinfo workload overlay
+    ├── eu-north-01/              Per-cluster overlay (sync target)
+    └── eu-west-01/               Per-cluster overlay (sync target)
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ workload cluster, a second Flux instance, and a Podinfo app reachable from
 your laptop. It covers the complete GitOps, CAPI, and pivot lifecycle without
 provisioning AWS resources.
 
-The imperative part of the lifecycle — bootstrap, pivot, and teardown — is a
+The imperative part of the lifecycle (bootstrap, pivot, and teardown) is a
 single Rust CLI, [`knr-bootstrap`](docs/bootstrap-cli.md), that replaces the
 shell scripts as they complete parity runs. After the one-time bootstrap and
 pivot, **everything is declared in Git as YAML**. The `aws` environment
@@ -145,7 +145,7 @@ suspends Flux and removes the AWS-managed infrastructure.
 
 The imperative lifecycle steps run through a single Rust binary,
 `knr-bootstrap` ([docs/bootstrap-cli.md](docs/bootstrap-cli.md)): it creates
-the disposable kind cluster, hands off to Flux, and — by default — pivots the
+the disposable kind cluster, hands off to Flux, and (by default) pivots the
 CAPI inventory into the self-managed management cluster before deleting kind.
 Reruns are safe by default (a healthy cluster is reused, every step is
 idempotent), so a failed run resumes by rerunning. The shell scripts

--- a/docs/airgap.md
+++ b/docs/airgap.md
@@ -1,4 +1,4 @@
-# Air-gapped knr-ops with Zarf (local-host / CAPD profile)
+# Air-gapped knr-ops with Zarf (local-host / CAPD environment)
 
 This document describes how knr-ops is packaged with [Zarf](https://zarf.dev)
 on a connected machine and deployed end-to-end with **no internet access**:
@@ -72,7 +72,7 @@ CNI addon, the per-cluster Flux addon), reconciled from the config artifact.
 The `mgmt/` and `workload/` trees in git are **not** modified; the airgap
 variant is generated at build time by `build-config-artifact.sh`.
 
-**Why OCI, not Gitea.** The local-host profile moved from a GitHub
+**Why OCI, not Gitea.** The local-host environment moved from a GitHub
 `GitRepository` to an OCI-artifact sync (`oci://knr-registry:5000/knr-ops`)
 in PRs #30/#31/#33. There is no `GitRepository` left to rewrite, so the Zarf
 git-server is unused; the config crosses the gap as an OCI artifact inside the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -142,7 +142,7 @@ konflate (no dependencies)
 The `eu-north-1` cluster definitions include the management cluster itself
 (`clusters/management/`): after the pivot, the management cluster's own Flux
 instance reconciles the Cluster objects that define it. The bootstrap kind
-cluster no longer exists at this point — nothing runs from an operator's
+cluster no longer exists at this point; nothing runs from an operator's
 laptop.
 
 ## PR review: konflate

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,8 +1,10 @@
 # Architecture
 
 GitOps-driven [Cluster API](https://cluster-api.sigs.k8s.io/) (CAPI) management
-platform. A local [kind](https://kind.sigs.k8s.io/) cluster bootstraps
-[Flux](https://fluxcd.io/), which then reconciles everything else from this
+platform. A disposable local [kind](https://kind.sigs.k8s.io/) cluster
+bootstraps [Flux](https://fluxcd.io/), provisions the self-managed management
+cluster through CAPI, and is deleted after a `clusterctl move` pivot: the
+management cluster then reconciles itself and everything else from this
 repository — AWS EKS workload clusters provisioned via
 [CAPA](https://cluster-api-aws.sigs.k8s.io/), per-cluster Flux instances
 delivered through CAPI addons, and application workloads (the
@@ -12,8 +14,8 @@ running on each workload cluster.
 
 ```mermaid
 flowchart TD
-    subgraph bootstrap["Bootstrap (one-time, bootstrap.sh)"]
-        KIND[kind cluster: mgmt]
+    subgraph bootstrap["Bootstrap (one-time, knr-bootstrap CLI)"]
+        KIND[kind cluster: mgmt, disposable]
         HELM[Helm: flux-operator + FluxInstance]
         SEC[Secrets: flux-github-pat + sops-age]
         KIND --> HELM
@@ -26,12 +28,13 @@ flowchart TD
 
     HELM -->|"sync: mgmt/aws/"| REPO
 
-    subgraph mgmt["Management cluster - Flux Kustomizations (dependsOn order)"]
+    subgraph mgmt["Management cluster (self-managed after the pivot) - Flux Kustomizations (dependsOn order)"]
         FS[flux-system root]
         CM[cert-manager]
         CO[capi-operator]
         CI[capa-identity]
         AMC[aws-managed-clusters]
+        MGMT[management cluster def<br/>self-hosted via the pivot]
         CAPIS[capi-system]
         CAPAS["capa-system (SOPS creds)"]
         CAAPH[caaph-system]
@@ -48,6 +51,7 @@ flowchart TD
         CO --> CAPIS --> CAPAS --> CAAPH --> FA
         CAPAS --> EUN
         CAPAS --> EUW
+        CAPAS --> MGMT
         FS --> ACKC --> ACKPI
         ACKC --> AWSIAM
         FS --> KONF
@@ -134,6 +138,12 @@ ack-controllers ▶ ack-pod-identity
 ack-controllers ▶ aws-iam
 konflate (no dependencies)
 ```
+
+The `eu-north-1` cluster definitions include the management cluster itself
+(`clusters/management/`): after the pivot, the management cluster's own Flux
+instance reconciles the Cluster objects that define it. The bootstrap kind
+cluster no longer exists at this point — nothing runs from an operator's
+laptop.
 
 ## PR review: konflate
 

--- a/docs/bootstrap-cli.md
+++ b/docs/bootstrap-cli.md
@@ -1,0 +1,122 @@
+# The bootstrap CLI (knr-bootstrap)
+
+The imperative part of knr-ops — the one-time bootstrap, the CAPI pivot into
+the self-managed management cluster, and (once its port lands) the teardown —
+lives in a single Rust binary, `knr-bootstrap`, in [`bootstrap-rs/`](../bootstrap-rs/).
+Everything the binary runs is a one-time imperative step; after it finishes,
+Flux owns the world and the binary is not needed again until teardown.
+
+The binary is a behavioral port of the shell scripts it replaces
+(`bootstrap.sh` + `pivot.sh`; `teardown.sh` is being ported under
+[#100](https://github.com/polarsquad/knr-ops/issues/100)). It preserves the
+scripts' step order, `>>>` progress messages, error text, and environment
+interface, with two deliberate upgrades over the scripts:
+
+- **Reruns are safe by default.** An existing healthy `mgmt` kind cluster is
+  reused and every step is idempotent, so a partially failed bootstrap or
+  pivot can be resumed by rerunning. Pass `--recreate` to delete and rebuild
+  the kind cluster instead.
+- **No shell, no quoting.** Tool invocations pass typed argv entries, secrets
+  travel through stdin and the environment (never argv), and the HTTP checks
+  (GitHub branch availability, registry readiness) run through reqwest with
+  explicit timeouts instead of `curl`.
+
+## Build
+
+```sh
+cd bootstrap-rs
+cargo build            # debug; add --release for an optimized binary
+./target/debug/knr-bootstrap --help
+```
+
+CI builds, lints (fmt, clippy `-D warnings`), and tests the crate on every
+change under `bootstrap-rs/` (`.github/workflows/bootstrap-rs.yml`). The
+toolchain is pinned in `bootstrap-rs/rust-toolchain.toml`; dependencies are
+locked in `Cargo.lock`.
+
+## Interface
+
+The CLI surface is the scripts' surface: a positional profile, `--recreate`,
+and the environment. The expanded flag interface is intentionally deferred
+(follow the [#92](https://github.com/polarsquad/knr-ops/issues/92) and
+[#95](https://github.com/polarsquad/knr-ops/issues/95) issue threads).
+
+```sh
+knr-bootstrap [PROFILE] [--recreate]
+```
+
+- `PROFILE`: `aws` (default) or `local-host`. A non-empty `KNR_OPS_PROFILE`
+  takes precedence over the positional argument, matching `bootstrap.sh`.
+- `--recreate`: delete and recreate an existing `mgmt` kind cluster instead of
+  reusing it. Required when the profile or the kind/registry configuration
+  changed since the cluster was created; the reuse path does not detect drift.
+
+Every `${VAR:-default}` knob the scripts read is read the same way: unset and
+empty both fall back to the default. Where a knob configures both the binary
+and a delegated `mise` child (for example `oci-push`), the resolved value is
+forwarded to the child explicitly.
+
+| Knob | Default | Used by |
+|---|---|---|
+| `KNR_OPS_PROFILE` | positional arg, then `aws` | profile selection |
+| `REGISTRY_PORT` | `5001` | local-host: host port of the local OCI registry |
+| `REGISTRY_READY_RETRIES` | `120` | local-host: registry readiness poll attempts |
+| `LOCAL_RECONCILE_TIMEOUT` | `15m` | local-host: management/workload reconciliation waits |
+| `CONTAINER_ENGINE` | auto (`docker`, else `podman`) | kind/container engine selection |
+| `GIT_REPO_URL` | — (required, aws) | Flux Git source for the management cluster |
+| `GITHUB_TOKEN` | — (required, aws) | PAT with read access to the repo |
+| `GITHUB_USER` | `git` | Git clone user for the Flux secret |
+| `AGE_KEY_FILE` | `age.agekey` | SOPS age private key loaded into the `sops-age` secret |
+| `AGE_PUBLIC_KEY` | derived from `AGE_KEY_FILE` | `create`-mode public key override |
+| `OCI_REPOSITORY` / `OCI_TAG` | `knr-ops` / `latest` | local-host: OCI artifact name |
+| `BOOTSTRAP_PIVOT` | `1` | `0` skips the pivot; kind stays the management cluster |
+| `MGMT_KUBECONFIG` | `~/.kube/knr-ops-mgmt.yaml` | exported management kubeconfig |
+| `MGMT_READY_TIMEOUT` | `40m` aws / `15m` local-host | management cluster provisioning wait |
+| `MGMT_POLL_INTERVAL` | `10` (seconds) | management cluster provisioning poll |
+| `BOOTSTRAP_KUBECONTEXT` | `kind-mgmt` | context the pivot runs from |
+| `PIVOT_SKIP_DELETE` | `0` | `1` keeps the kind bootstrap cluster for inspection |
+
+## What a run does
+
+1. **Preflight**: profile validation, required tools (`kind`, `helm`,
+   `kubectl`, `clusterctl`, `mise` on both profiles; `flux` and `curl`
+   additionally on local-host), container engine detection, and (aws) the
+   GitHub repo/branch/token checks and age key file validation.
+2. **Bootstrap** the `mgmt` kind cluster: local registry (local-host), Flux
+   Operator install, `flux-github-pat` + `sops-age` secrets (aws) or the
+   initial OCI artifact publish (local-host), `FluxInstance` sync handoff,
+   and the reconciliation watch.
+3. **Pivot** (default; `BOOTSTRAP_PIVOT=0` opts out): wait for the
+   self-managed management cluster (provisioned by CAPI from
+   `mgmt/<env>/clusters/management/`), export its kubeconfig, imperatively
+   install cert-manager + the CAPI operator + provider CRs on the target at
+   the same versions as the Git HelmReleases, suspend Flux in kind,
+   `clusterctl move`, unpause the moved Clusters, seed Flux on the target,
+   and delete the kind bootstrap cluster.
+
+If any phase fails, fix the cause and rerun: the bootstrap steps are
+rerun-safe, an existing healthy kind cluster is reused (a cluster whose
+kubeconfig context is gone can be recovered with
+`kind export kubeconfig --name mgmt` before rerunning), and
+`clusterctl move` is re-runnable. Recovery details and the never-delete-moved-objects
+warning are in [Operations: pivot recovery](./operations.md#pivot-recovery).
+
+## Parity status and script retirement
+
+The shell scripts stay in the repository until the binary has completed full
+real runs per profile; they are removed in a follow-up once both parity gates
+pass. `mise run bootstrap` and `mise run pivot` still invoke the scripts —
+run the binary from `bootstrap-rs/` until the switchover. Chart versions the
+binary installs imperatively are pinned as Renovate-annotated constants in
+`bootstrap-rs/src/main.rs` and grouped with their manifest counterparts (see
+[Dependencies](./dependencies.md)).
+
+## Roadmap
+
+- [#100](https://github.com/polarsquad/knr-ops/issues/100): port `teardown.sh`
+  into the CLI (post-pivot teardown semantics resolved as part of it).
+- [#98](https://github.com/polasquad/knr-ops/issues/98): externalize
+  knr-ops-specific constants (cluster names, sync paths, chart pins) from
+  compiled-in values into a `bootstrap.toml` owned by the repository, so the
+  binary becomes a generic bootstrap engine with knr-ops as its first
+  consumer.

--- a/docs/bootstrap-cli.md
+++ b/docs/bootstrap-cli.md
@@ -1,7 +1,7 @@
 # The bootstrap CLI (knr-bootstrap)
 
-The imperative part of knr-ops — the one-time bootstrap, the CAPI pivot into
-the self-managed management cluster, and (once its port lands) the teardown —
+The imperative part of knr-ops (the one-time bootstrap, the CAPI pivot into
+the self-managed management cluster, and, once its port lands, the teardown)
 lives in a single Rust binary, `knr-bootstrap`, in [`bootstrap-rs/`](../bootstrap-rs/).
 Everything the binary runs is a one-time imperative step; after it finishes,
 Flux owns the world and the binary is not needed again until teardown.
@@ -105,7 +105,7 @@ warning are in [Operations: pivot recovery](./operations.md#pivot-recovery).
 
 The shell scripts stay in the repository until the binary has completed full
 real runs per profile; they are removed in a follow-up once both parity gates
-pass. `mise run bootstrap` and `mise run pivot` still invoke the scripts —
+pass. `mise run bootstrap` and `mise run pivot` still invoke the scripts;
 run the binary from `bootstrap-rs/` until the switchover. Chart versions the
 binary installs imperatively are pinned as Renovate-annotated constants in
 `bootstrap-rs/src/main.rs` and grouped with their manifest counterparts (see

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -220,7 +220,7 @@ Bootstrap ends with a pivot: the CAPI inventory moves from the local `mgmt`
 kind cluster into the self-managed management cluster, and the kind cluster
 is deleted. `mise run bootstrap` runs the pivot by default
 (`BOOTSTRAP_PIVOT=0` opts out); `mise run pivot` runs it standalone. The
-Rust CLI runs the same flow with resume-safe reruns — see
+Rust CLI runs the same flow with resume-safe reruns; see
 [the bootstrap CLI](./bootstrap-cli.md) for its interface and knobs.
 
 `clusterctl move` is re-runnable: an object is deleted from the source kind

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -10,18 +10,20 @@ mise install
 ```
 
 This provides `kubectl`, `kind`, `helm`, `flux`, `clusterctl`, `go`, `sops`,
-`age`, and the `zarf` CLI. The `aws` profile layers on `aws-cli` and
-`clusterawsadm` (`mise -E aws install`); the `local-host` profile needs no
-extra tools.
+`age`, and the `zarf` CLI. The `aws` environment layers on `aws-cli` and
+`clusterawsadm` (`mise -E aws install`); the `local-host` environment needs
+no extra tools. Building the bootstrap CLI additionally requires a Rust
+toolchain ([rustup](https://rustup.rs/); the pin lives in
+`bootstrap-rs/rust-toolchain.toml`).
 
 You also need:
 
 - A running container engine for kind: Docker, or Podman 5.5+ (auto-detected
-  by `bootstrap.sh`; set `CONTAINER_ENGINE=docker|podman` to override).
-  For local-host profile: the same engine is used to host the local container
-  registry for OCI artifacts.
+  at bootstrap; set `CONTAINER_ENGINE=docker|podman` to override).
+  For local-host environment: the same engine is used to host the local
+  container registry for OCI artifacts.
 
-**AWS profile only:**
+**AWS environment only:**
 - A GitHub personal access token (PAT) with read access to this repository
   (fine-grained with read-only Contents permission, or classic with `repo`
   scope). The Flux Operator chart is pulled anonymously.
@@ -63,14 +65,14 @@ cp .env.example .env
 $EDITOR .env
 ```
 
-The Flux Operator chart is pulled anonymously for both profiles. The GitHub PAT,
-AWS credentials, and `AWS_REGION` are only needed with the AWS profile.
+The Flux Operator chart is pulled anonymously for both environments. The GitHub PAT,
+AWS credentials, and `AWS_REGION` are only needed with the AWS environment.
 
 ## Bootstrap
 
 ```sh
-mise run bootstrap                 # AWS profile
-mise -E local-host run bootstrap   # local-host profile
+mise run bootstrap                 # AWS environment
+mise -E local-host run bootstrap   # local-host environment
 ```
 
 > Before the first bootstrap, generate an age key for SOPS (see
@@ -83,12 +85,14 @@ This is the only imperative step. It:
 3. Creates the `flux-github-pat` secret (for Git access) and the `sops-age`
    secret (the age private key Flux uses to decrypt SOPS-encrypted secrets).
 4. Installs a `FluxInstance` that syncs `mgmt/aws/` and hands off to GitOps.
+5. Pivots: moves the CAPI inventory into the self-managed management cluster
+   and deletes the kind cluster (see [Pivot recovery](#pivot-recovery)).
 
 Everything downstream — providers, EKS clusters, workload Flux instances, the
 ACK operator, IAM role, pod identity bindings, and S3 buckets — reconciles
 from Git with no further manual steps.
 
-The local-host profile performs the cluster, Flux Operator, and FluxInstance
+The local-host environment performs the cluster, Flux Operator, and FluxInstance
 steps in the `mgmt` management cluster, but does not create GitHub or SOPS
 secrets. Instead, it bootstraps a local Docker Registry container (`registry:2`)
 running on the host machine (accessible at `localhost:5001` by default),
@@ -102,14 +106,14 @@ FluxInstance on `local-workload`; that instance reconciles
 `workload/local-host/` from the same OCI artifact. CAPD is intended for local
 development and testing, not production.
 
-Together, these stages make `local-host` an end-to-end profile: one command
+Together, these stages make `local-host` an end-to-end environment: one command
 bootstraps the management control plane, publishes and reconciles the OCI
 configuration, provisions a workload cluster through CAPI, installs a distinct
 Flux control plane on that cluster, and reconciles a reachable Podinfo workload.
 It exercises the complete cluster-to-workload GitOps lifecycle locally; only
 the AWS-specific infrastructure and ACK resources are outside its scope.
 
-**OCI Registry (local-host profile only):**
+**OCI Registry (local-host environment only):**
 - Provides a local container registry for development workflows
 - Enables developers to build and push OCI artifacts from git checkouts
 - Flux syncs and deploys the OCI artifact without external dependencies
@@ -126,7 +130,7 @@ OCI_REPOSITORY=my-config OCI_TAG=v1 \
   mise -E local-host run oci-push
 
 # FluxInstance pulls and reconciles the artifact's mgmt/local-host kustomization.
-# bootstrap.sh configures kind's containerd to mirror localhost:5001 to the
+# The bootstrap configures kind's containerd to mirror localhost:5001 to the
 # registry's in-cluster endpoint, knr-registry:5000.
 ```
 
@@ -135,7 +139,7 @@ preserving those directory paths when the artifact is pulled. Keeping the
 source scope narrow also prevents local credentials and age private keys
 elsewhere in the repository from being packaged.
 
-The AWS profile adds the GitHub/SOPS secrets and configures the FluxInstance to sync `mgmt/aws/`.
+The AWS environment adds the GitHub/SOPS secrets and configures the FluxInstance to sync `mgmt/aws/`.
 
 Watch reconciliation:
 
@@ -143,7 +147,7 @@ Watch reconciliation:
 flux get kustomizations --watch
 ```
 
-For the local-host profile, export and verify the CAPD workload kubeconfig after
+For the local-host environment, export and verify the CAPD workload kubeconfig after
 `docker-workload-cluster` reports Ready:
 
 ```sh
@@ -163,7 +167,7 @@ Then browse to <http://localhost:9898>. Press Ctrl-C to stop forwarding.
 The workload uses Kubernetes v1.35.0. A CAPI ClusterResourceSet installs a
 pinned Kindnet daemon as its CNI before the Flux addons are delivered.
 The management cluster needs access to the container-engine socket, which
-`bootstrap.sh` mounts automatically.
+the bootstrap mounts automatically.
 
 Local-host bootstrap first waits for the management `flux-apps` Kustomization
 without printing transient `Unknown` status rows. After `flux-apps` becomes
@@ -215,7 +219,9 @@ aws s3api get-public-access-block  --bucket knr-ops-<account>-eu-north-1-workloa
 Bootstrap ends with a pivot: the CAPI inventory moves from the local `mgmt`
 kind cluster into the self-managed management cluster, and the kind cluster
 is deleted. `mise run bootstrap` runs the pivot by default
-(`BOOTSTRAP_PIVOT=0` opts out); `mise run pivot` runs it standalone.
+(`BOOTSTRAP_PIVOT=0` opts out); `mise run pivot` runs it standalone. The
+Rust CLI runs the same flow with resume-safe reruns — see
+[the bootstrap CLI](./bootstrap-cli.md) for its interface and knobs.
 
 `clusterctl move` is re-runnable: an object is deleted from the source kind
 cluster only after it was created on the target, so kind stays authoritative
@@ -249,7 +255,7 @@ mise run teardown    # or: ./teardown.sh
 
 Tears down in reverse order: suspends Flux, deletes CAPI workload clusters (so
 CAPA or CAPD deprovisions their infrastructure), removes providers, uninstalls
-Flux, and deletes the kind cluster. The local-host profile waits for CAPD to
+Flux, and deletes the kind cluster. The local-host environment waits for CAPD to
 remove the workload containers before deleting `mgmt`. The `clusterawsadm` IAM
 stack is intentionally left in place.
 

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -7,7 +7,7 @@ safely in Git and Flux decrypts them at reconcile time.
 - **`.sops.yaml`** declares the age *public* key (safe to commit) and a rule
   that encrypts only `data`/`stringData` fields of any `*.sops.yaml` file under
   `mgmt/aws/`.
-- The age *private* key lives in `age.agekey` (gitignored). `bootstrap.sh`
+- The age *private* key lives in `age.agekey` (gitignored). The bootstrap
   loads it into the cluster as the `sops-age` secret in `flux-system`.
 
 SOPS-encrypted secrets in this repo (each referenced by a Flux `Kustomization`
@@ -56,7 +56,7 @@ mise run sops-decrypt <file>.sops.yaml
 ## Setting / rotating the GitHub PAT
 
 The management cluster's own `flux-github-pat` secret is created imperatively
-by `bootstrap.sh` (from `GITHUB_TOKEN` in `.env`) and is **not** in Git — Flux
+at bootstrap (from `GITHUB_TOKEN` in `.env`) and is **not** in Git — Flux
 needs it to clone the repo before it could ever decrypt anything (a
 chicken-and-egg constraint). The workload clusters' copy *is* in Git
 (`flux-pull-secret.sops.yaml`) because the management cluster's Flux decrypts


### PR DESCRIPTION
Rewrites README.md and docs/ to reflect the Rust-CLI direction after #92/#95/#101 (bootstrap + pivot ports, merged) and #79 (self-managed management cluster), and to set expectations for the open follow-ups (#100 teardown port, #98 config externalization).

## What changed

- **New `docs/bootstrap-cli.md`**: the `knr-bootstrap` binary — build, interface (positional profile, `--recreate`, env knobs table with defaults), what a run does (preflight → bootstrap → pivot), rerun/resume semantics, parity status and script-retirement gate, and the #100/#98 roadmap.
- **README.md**: intro rewritten around the disposable kind cluster + CAPI pivot into a self-managed management cluster; new "The bootstrap CLI" section; new bullet in "Problems the pattern solves" (no control plane on a laptop); prerequisites add the Rust toolchain; repository layout adds `bootstrap-rs/`, the management cluster defs, and the script-retirement note; docs table gains the new page. Profile → environment terminology throughout.
- **docs/operations.md**: bootstrap steps now include the pivot; prerequisites mention the Rust toolchain; pivot-recovery section links the CLI page; `bootstrap.sh` prose references generalized; profile → environment.
- **docs/architecture.md**: intro describes the pivot; diagram subgraph renamed to `knr-bootstrap CLI` with the kind node marked disposable and the management-cluster def added; reconciliation-order section explains that the management cluster reconciles its own Cluster objects.
- **docs/secrets.md**, **docs/airgap.md**: script-name prose generalized; profile → environment.
- **AGENTS.md**: structure list gains `bootstrap-rs/` and the three-scripts retirement plan; docs index gains bootstrap-cli.md; mise task comments mention the pivot.

## Verification

- All relative links and anchors in README.md, AGENTS.md, docs/*.md resolve (scripted check).
- CLI facts in bootstrap-cli.md verified against the source: env knob names and defaults (`Config::from_env`), required-tools per profile (`required_tools`, including the both-profiles `clusterctl`/`mise` requirement), `--recreate` semantics, `KNR_OPS_PROFILE` precedence; `cargo build` + `--help` run against de43867.
- Docs-only change; no manifests touched. `mise run validate` unaffected.

## Out of scope

- `mise run bootstrap`/`pivot` still invoke the scripts by design (parity gate not yet passed); docs state this rather than switching entrypoints.
- Two one-line AGENTS.md edits (intro paragraph wording, operations.md index line) were blocked by the agent's protected-file gate; the PR can pick them up if wanted.
