### PR TITLE
feat: add bootstrap.toml and cross-check it against the Git manifests

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -79,6 +79,9 @@ jobs:
           RENOVATE_GITHUB_COM_TOKEN: ${{ github.token }}
         run: python3 tests/test-renovate-coverage.py
 
+      - name: bootstrap.toml cross-check
+        run: python3 tests/test-bootstrap-config.py
+
   yaml-lint:
     name: Lint YAML
     runs-on: ubuntu-latest

--- a/bootstrap.toml
+++ b/bootstrap.toml
@@ -8,6 +8,10 @@
 #
 # Environment order matters: error messages list environments in file order
 # to preserve bootstrap.sh's exact wording ('local-host' before 'aws').
+#
+# Profile resolution: the [environments.*] section name is authoritative;
+# KNR_OPS_PROFILE matches it exactly. Each environment's `kind` restates
+# the section name, and the cross-check fails if the two disagree.
 
 [bootstrap]
 default-environment = "aws"
@@ -26,6 +30,8 @@ mgmt-context = "knr-ops-mgmt"
 # with the HelmReleases/HelmChartProxies in mgmt/<env>/ so Flux adopts the
 # installs without drift; `mise run validate` cross-checks them and Renovate
 # updates both sides together.
+# flux-operator and flux-instance version together upstream, so this one
+# pin serves both chart installs (FLUX_CHART_VERSION in main.rs).
 # renovate: datasource=docker depName=ghcr.io/controlplaneio-fluxcd/charts/flux-operator
 flux-operator = "0.58.0"
 # renovate: datasource=helm registryUrl=https://charts.jetstack.io depName=cert-manager

--- a/bootstrap.toml
+++ b/bootstrap.toml
@@ -1,0 +1,66 @@
+# Repository-owned configuration for knr-bootstrap (issue #98).
+#
+# Everything knr-ops-specific the binary needs is declared here; the binary
+# itself is a generic bootstrap engine. Environment variables (REGISTRY_PORT,
+# GIT_REPO_URL, BOOTSTRAP_KUBECONTEXT, ...) keep their precedence over these
+# values at runtime. Locate this file with BOOTSTRAP_CONFIG when not running
+# from the repository root.
+#
+# Environment order matters: error messages list environments in file order
+# to preserve bootstrap.sh's exact wording ('local-host' before 'aws').
+
+[bootstrap]
+default-environment = "aws"
+git-branch = "main"
+kind-cluster = "mgmt"
+kind-context = "kind-mgmt"
+registry-name = "knr-registry"
+flux-namespace = "flux-system"
+github-pat-secret = "flux-github-pat"
+sops-age-secret = "sops-age"
+mgmt-namespace = "default"
+mgmt-context = "knr-ops-mgmt"
+
+[charts]
+# Chart versions installed imperatively before Flux exists. Keep in sync
+# with the HelmReleases/HelmChartProxies in mgmt/<env>/ so Flux adopts the
+# installs without drift; `mise run validate` cross-checks them and Renovate
+# updates both sides together.
+# renovate: datasource=docker depName=ghcr.io/controlplaneio-fluxcd/charts/flux-operator
+flux-operator = "0.58.0"
+# renovate: datasource=helm registryUrl=https://charts.jetstack.io depName=cert-manager
+cert-manager = "1.21.1"
+# renovate: datasource=helm registryUrl=https://kubernetes-sigs.github.io/cluster-api-operator depName=cluster-api-operator
+capi-operator = "0.28.0"
+
+[environments.local-host]
+kind = "local-host"
+sync-path = "mgmt/local-host"
+mgmt-cluster = "local-management"
+mgmt-ready-timeout = "15m"
+infra-provider-namespace = "capd-system"
+infra-provider-name = "docker"
+provider-manifests = [
+  "mgmt/local-host/capi-providers/capi-system/namespace.yaml",
+  "mgmt/local-host/capi-providers/capi-system/providers.yaml",
+  "mgmt/local-host/capi-providers/capd-system/namespace.yaml",
+  "mgmt/local-host/capi-providers/capd-system/provider.yaml",
+  "mgmt/local-host/capi-providers/caaph-system/namespace.yaml",
+  "mgmt/local-host/capi-providers/caaph-system/provider.yaml",
+]
+
+[environments.aws]
+kind = "aws"
+sync-path = "mgmt/aws"
+mgmt-cluster = "eu-north-1-management"
+mgmt-ready-timeout = "40m"
+infra-provider-namespace = "capa-system"
+infra-provider-name = "aws"
+provider-manifests = [
+  "mgmt/aws/capi-providers/capi-system/namespace.yaml",
+  "mgmt/aws/capi-providers/capi-system/providers.yaml",
+  "mgmt/aws/capi-providers/capa-system/namespace.yaml",
+  "mgmt/aws/capi-providers/capa-system/providers.yaml",
+  "mgmt/aws/capi-providers/caaph-system/namespace.yaml",
+  "mgmt/aws/capi-providers/caaph-system/addon-provider.yaml",
+]

--- a/mise.toml
+++ b/mise.toml
@@ -38,6 +38,11 @@ if ! python3 -m unittest discover -s airgap/tests -p 'test_*.py'; then
   echo "    FAILED: airgap unit tests" >&2
   fail=1
 fi
+echo "==> bootstrap.toml cross-check"
+if ! python3 tests/test-bootstrap-config.py; then
+  echo "    FAILED: bootstrap.toml cross-check" >&2
+  fail=1
+fi
 for dir in $(find mgmt workload -name kustomization.yaml -exec dirname {} \; | sort -u); do
   echo "==> kustomize build $dir"
   if ! kubectl kustomize "$dir" >/dev/null; then

--- a/tests/test-bootstrap-config.py
+++ b/tests/test-bootstrap-config.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Cross-check bootstrap.toml against the Git manifests (issue #98).
+
+The chart versions knr-bootstrap installs imperatively must equal the
+versions Flux reconciles from Git, or Flux cannot adopt the imperative
+installs without drift. Fails when they disagree, when a declared
+provider-manifest or sync path is missing, or when the file does not parse.
+Requires Python 3.11+ (tomllib); mise and CI both provide it.
+"""
+
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# chart key in [charts] -> manifest files that must carry the same version
+CHART_MANIFESTS = {
+    "flux-operator": [
+        "mgmt/aws/addons/flux-apps/flux-operator.yaml",
+        "mgmt/local-host/addons/flux-apps/flux-operator.yaml",
+    ],
+    "cert-manager": [
+        "mgmt/aws/infrastructure/cert-manager/helmrelease.yaml",
+        "mgmt/local-host/infrastructure/cert-manager/helmrelease.yaml",
+    ],
+    "capi-operator": [
+        "mgmt/aws/infrastructure/capi-operator/helmrelease.yaml",
+        "mgmt/local-host/infrastructure/capi-operator/helmrelease.yaml",
+    ],
+}
+
+VERSION_RE = re.compile(r'^\s*version:\s*"([^"]+)"\s*$', re.MULTILINE)
+
+
+def manifest_version(path: Path) -> str:
+    matches = VERSION_RE.findall(path.read_text())
+    if len(matches) != 1:
+        raise SystemExit(
+            f"FAILED: expected exactly one quoted version: line in {path}, found {len(matches)}"
+        )
+    return matches[0]
+
+
+def main() -> int:
+    failures = []
+    config_path = REPO_ROOT / "bootstrap.toml"
+    try:
+        config = tomllib.loads(config_path.read_text())
+    except (OSError, tomllib.TOMLDecodeError) as error:
+        print(f"FAILED: cannot parse {config_path}: {error}")
+        return 1
+
+    charts = config.get("charts", {})
+    for chart, manifests in CHART_MANIFESTS.items():
+        declared = charts.get(chart)
+        if declared is None:
+            failures.append(f"charts.{chart} missing from bootstrap.toml")
+            continue
+        for relative in manifests:
+            actual = manifest_version(REPO_ROOT / relative)
+            if actual != declared:
+                failures.append(
+                    f"charts.{chart} = {declared} but {relative} pins {actual}"
+                )
+
+    for name, env in config.get("environments", {}).items():
+        sync = REPO_ROOT / env.get("sync-path", "")
+        if not sync.is_dir():
+            failures.append(f"environments.{name}.sync-path '{env.get('sync-path')}' is not a directory")
+        for manifest in env.get("provider-manifests", []):
+            if not (REPO_ROOT / manifest).is_file():
+                failures.append(f"environments.{name} provider manifest missing: {manifest}")
+
+    if failures:
+        print("bootstrap.toml cross-check FAILED:")
+        for failure in failures:
+            print(f"  - {failure}")
+        return 1
+    print(f"bootstrap.toml cross-check OK ({len(CHART_MANIFESTS)} charts, "
+          f"{len(config.get('environments', {}))} environments)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test-bootstrap-config.py
+++ b/tests/test-bootstrap-config.py
@@ -4,7 +4,9 @@
 The chart versions knr-bootstrap installs imperatively must equal the
 versions Flux reconciles from Git, or Flux cannot adopt the imperative
 installs without drift. Fails when they disagree, when a declared
-provider-manifest or sync path is missing, or when the file does not parse.
+provider-manifest or sync path is missing, when an environment's kind
+does not match its section name (the section name is authoritative for
+profile resolution), or when the file does not parse.
 Requires Python 3.11+ (tomllib); mise and CI both provide it.
 """
 
@@ -66,6 +68,11 @@ def main() -> int:
                 )
 
     for name, env in config.get("environments", {}).items():
+        kind = env.get("kind")
+        if kind != name:
+            failures.append(
+                f"environments.{name} kind {kind!r} must match its section name"
+            )
         sync = REPO_ROOT / env.get("sync-path", "")
         if not sync.is_dir():
             failures.append(f"environments.{name}.sync-path '{env.get('sync-path')}' is not a directory")


### PR DESCRIPTION
First PR of the issue #98 implementation (plan: schema-first, consumption second, docs third). This lands the contract only: the config file, plus the guardrail that keeps it honest. No Rust changes; the binary does not read the file yet.

## What this adds

- **`bootstrap.toml`** (repo root): the repository-owned bootstrap configuration. `[bootstrap]` carries the global names (git branch, kind cluster/context, registry, Flux namespace, secret names, mgmt namespace/context); `[charts]` carries the three imperative chart pins with `# renovate:` annotations; `[environments.local-host]` / `[environments.aws]` carry the per-environment values (kind, sync path, mgmt cluster name, ready timeout, infra provider, provider-manifest list). Environment order in the file preserves bootstrap.sh's error-message wording (`local-host` before `aws`); a follow-up PR makes the binary read this and delete the compiled `Profile` enum.
- **`tests/test-bootstrap-config.py`**: cross-check failing validate/CI when (a) a `[charts]` pin disagrees with the version in any of the six Git manifest files, (b) a declared `provider-manifests` path or `sync-path` does not exist, or (c) the TOML does not parse (Python 3.11+ tomllib; mise python is 3.13, CI is 3.11+).
- **`mise.toml` / `.github/workflows/validate.yml`**: the cross-check runs in `mise run validate` and as a `validate` workflow step.

## Review focus

The schema is the reviewable part here (section names, the `kind` discriminator, field granularity); PR 2 will be mechanical against whatever this PR approves. Every value was verified equal to today's compiled constants in `bootstrap-rs/src/main.rs` (lines 26-76, 348-375) and every manifest path exists on disk.

## Verification

- `mise exec -- python3 tests/test-bootstrap-config.py` -> `bootstrap.toml cross-check OK (3 charts, 2 environments)`, exit 0.
- Mutation test: `cert-manager = "9.9.9"` -> FAILED listing both cert-manager manifests, exit 1; restored -> OK, exit 0.
- `mise run validate` -> exit 0 with the `==> bootstrap.toml cross-check` / OK lines; all kustomize builds pass.
- No `mgmt/**` or `workload/**` changes; konflate should render no diff.

## Interim-window note

Until PR 2 lands, chart pins are dual-homed: `main.rs` annotations remain Renovate-authoritative and the TOML annotations are inert (no Renovate manager targets them yet). If a Renovate chart-bump PR merges in between, its body must also bump `bootstrap.toml` or the cross-check fails CI on main.

Refs: #98
