### PR TITLE
refactor: consolidate Renovate integration tests on a shared harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ airgap/*.tar.zst
 
 # Hermes agent workspace (local plans, never part of the repo)
 .hermes/
+__pycache__/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,7 +158,7 @@ discovered) and the digest-pinning test run in CI only (the validate.yml
 `renovate-digest-pinning` job), not in `mise run validate`. Both run on the
 shared harness `tests/renovate_harness.py` (issue #97): a new Renovate test
 is a file list plus assertions, never a copy of the subprocess/parsing
-logic. The harness needs Node >= 24 (Renovate 44.50.1 uses `RegExp.escape`);
+logic. The harness needs Node >= 24.11 (renovate's `engines` field);
 locally: `mise x node@24 -- python3 tests/test-renovate-coverage.py`. They
 do not cover lookup liveness or the replacement path; only the
 dry-run and the handlebars simulation cover those.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,8 +155,12 @@ Traps that have bitten this repo (each caught in a live review):
 
 Repo gates: `tests/test-renovate-coverage.py` (every managed pin is
 discovered) and the digest-pinning test run in CI only (the validate.yml
-`renovate-digest-pinning` job), not in `mise run validate`. They do not
-cover lookup liveness or the replacement path; only the
+`renovate-digest-pinning` job), not in `mise run validate`. Both run on the
+shared harness `tests/renovate_harness.py` (issue #97): a new Renovate test
+is a file list plus assertions, never a copy of the subprocess/parsing
+logic. The harness needs Node >= 24 (Renovate 44.50.1 uses `RegExp.escape`);
+locally: `mise x node@24 -- python3 tests/test-renovate-coverage.py`. They
+do not cover lookup liveness or the replacement path; only the
 dry-run and the handlebars simulation cover those.
 
 ## Where to look next

--- a/airgap/tests/test-renovate-digest-pinning.py
+++ b/airgap/tests/test-renovate-digest-pinning.py
@@ -1,88 +1,34 @@
 #!/usr/bin/env python3
 """Verify Renovate proposes digest pins for both air-gap image inventories."""
 
-import json
-import os
-from pathlib import Path
 import re
-import shutil
-import subprocess
 import sys
-import tempfile
+from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "tests"))
+from renovate_harness import run_renovate
 
-EXPECTED_FILES = {"airgap/images.txt", "airgap/zarf.yaml"}
-REPO_ROOT = Path(__file__).resolve().parents[2]
+EXPECTED_FILES = ["airgap/images.txt", "airgap/zarf.yaml"]
 DIGEST = re.compile(r"@sha256:[a-f0-9]{64}")
 
 
 def main() -> int:
-    env = os.environ.copy()
-    env.update(
-        {
-            "LOG_FORMAT": "json",
-            "LOG_LEVEL": "debug",
-            "RENOVATE_ENABLED_MANAGERS": "custom.regex",
-            "RENOVATE_INCLUDE_PATHS": json.dumps(sorted(EXPECTED_FILES)),
-        }
+    # Strip existing digests so the only pinDigest proposals Renovate can
+    # make are new ones: proves the managers propose pins for every ref.
+    result = run_renovate(
+        EXPECTED_FILES, transform=lambda _, text: DIGEST.sub("", text)
     )
 
-    with tempfile.TemporaryDirectory(prefix="renovate-digest-test-") as temp:
-        fixture_root = Path(temp)
-        shutil.copy2(REPO_ROOT / "renovate.json5", fixture_root / "renovate.json5")
-        for relative in EXPECTED_FILES:
-            source = REPO_ROOT / relative
-            target = fixture_root / relative
-            target.parent.mkdir(parents=True, exist_ok=True)
-            target.write_text(DIGEST.sub("", source.read_text()))
-
-        result = subprocess.run(
-            ["renovate", "--platform=local", "--dry-run=lookup"],
-            check=False,
-            cwd=fixture_root,
-            env=env,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
-        )
-
-    pin_counts = {package_file: 0 for package_file in EXPECTED_FILES}
-    diagnostics = []
-    for line in result.stdout.splitlines():
-        try:
-            event = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-
-        if event.get("level", 0) >= 40:
-            diagnostics.append(event.get("msg", line))
-        if event.get("msg") != "packageFiles with updates":
-            continue
-
-        # Renovate records the looked-up package files under `config` in this
-        # debug event. The manager name (currently `regex`) is intentionally
-        # not hard-coded so a future custom-manager migration remains visible.
-        for manager_files in event.get("config", {}).values():
-            for package in manager_files:
-                package_file = package.get("packageFile")
-                if package_file not in pin_counts:
-                    continue
-                pin_counts[package_file] += sum(
-                    update.get("updateType") == "pinDigest"
-                    and update.get("newDigest", "").startswith("sha256:")
-                    for dependency in package.get("deps", [])
-                    for update in dependency.get("updates", [])
-                )
-
+    pin_counts = {
+        package_file: result.pin_digest_count(package_file)
+        for package_file in EXPECTED_FILES
+    }
     missing = [path for path, count in pin_counts.items() if count == 0]
     if result.returncode or missing:
         print("Renovate digest-pinning integration check failed", file=sys.stderr)
         print(f"exit code: {result.returncode}", file=sys.stderr)
         print(f"pin counts: {pin_counts}", file=sys.stderr)
-        if diagnostics:
-            print("Renovate diagnostics:", file=sys.stderr)
-            for diagnostic in diagnostics[-20:]:
-                print(f"  - {diagnostic}", file=sys.stderr)
+        result.print_diagnostics()
         return 1
 
     for package_file in sorted(pin_counts):

--- a/tests/renovate_harness.py
+++ b/tests/renovate_harness.py
@@ -5,7 +5,8 @@ that copies the real renovate.json5 plus selected repo files, parses the JSON
 log event stream, and returns per-file dependency/update data for assertions.
 No writes, no branches, no PRs (lookup only).
 
-Node requirement: Renovate 44.50.1 needs Node >= 24 (RegExp.escape). CI sets
+Node requirement: Renovate 44.50.1 declares Node ^24.11.0 in `engines`
+(RegExp.escape). CI sets
 up Node 24 in the validate.yml renovate job; locally run under a Node 24
 toolchain, e.g. `mise x node@24 -- python3 tests/test-renovate-coverage.py`.
 

--- a/tests/renovate_harness.py
+++ b/tests/renovate_harness.py
@@ -1,0 +1,132 @@
+"""Shared harness for Renovate integration tests.
+
+Runs Renovate with --platform=local --dry-run=lookup against a temp fixture
+that copies the real renovate.json5 plus selected repo files, parses the JSON
+log event stream, and returns per-file dependency/update data for assertions.
+No writes, no branches, no PRs (lookup only).
+
+Node requirement: Renovate 44.50.1 needs Node >= 24 (RegExp.escape). CI sets
+up Node 24 in the validate.yml renovate job; locally run under a Node 24
+toolchain, e.g. `mise x node@24 -- python3 tests/test-renovate-coverage.py`.
+
+A test built on this harness is a file list (plus an optional per-file text
+transform) and assertions against RenovateResult; no subprocess or parsing
+logic lives in the tests (issue #97).
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Renovate records the looked-up package files under `config` in this debug
+# event, keyed by manager. The manager name (currently `regex`) is
+# intentionally not hard-coded so a future custom-manager migration remains
+# visible.
+_PACKAGE_FILES_EVENT = "packageFiles with updates"
+
+
+class RenovateResult:
+    """Parsed outcome of one harness Renovate run."""
+
+    def __init__(self, returncode, fixture_files):
+        self.returncode = returncode
+        self.deps_by_file = {path: [] for path in fixture_files}
+        self.diagnostics = []
+
+    def dep_names(self, package_file):
+        """depName strings Renovate extracted from one fixture file."""
+        return {
+            dep["depName"]
+            for dep in self.deps_by_file[package_file]
+            if dep.get("depName")
+        }
+
+    def pin_digest_count(self, package_file):
+        """Number of pinDigest updates (sha256) proposed for one file."""
+        return sum(
+            update.get("updateType") == "pinDigest"
+            and update.get("newDigest", "").startswith("sha256:")
+            for dep in self.deps_by_file[package_file]
+            for update in dep.get("updates", [])
+        )
+
+    def print_diagnostics(self, stream=None):
+        stream = stream or sys.stderr
+        if self.diagnostics:
+            print("Renovate diagnostics:", file=stream)
+            for diagnostic in self.diagnostics[-20:]:
+                print(f"  - {diagnostic}", file=stream)
+
+
+def run_renovate(fixture_files, transform=None, repo_root=REPO_ROOT):
+    """Run Renovate over a fixture of repo files and parse the event stream.
+
+    fixture_files: iterable of repo-relative paths to copy into the fixture.
+    transform: optional callable (relative_path, text) -> text applied to each
+        copied file (e.g. stripping digests to test pin proposals).
+    Returns a RenovateResult with deps_by_file populated for every fixture
+        file (empty list when Renovate extracted nothing from it).
+    """
+    fixture_files = sorted(fixture_files)
+    env = os.environ.copy()
+    env.update(
+        {
+            "LOG_FORMAT": "json",
+            "LOG_LEVEL": "debug",
+            "RENOVATE_ENABLED_MANAGERS": "custom.regex",
+            "RENOVATE_INCLUDE_PATHS": json.dumps(fixture_files),
+        }
+    )
+
+    with tempfile.TemporaryDirectory(prefix="renovate-harness-") as temp:
+        fixture_root = Path(temp)
+        shutil.copy2(repo_root / "renovate.json5", fixture_root / "renovate.json5")
+        for relative in fixture_files:
+            source = repo_root / relative
+            target = fixture_root / relative
+            target.parent.mkdir(parents=True, exist_ok=True)
+            text = source.read_text()
+            if transform is not None:
+                text = transform(relative, text)
+            target.write_text(text)
+
+        completed = subprocess.run(
+            ["renovate", "--platform=local", "--dry-run=lookup"],
+            check=False,
+            cwd=fixture_root,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+
+    return _parse(completed.returncode, completed.stdout, fixture_files)
+
+
+def _parse(returncode, stdout, fixture_files):
+    result = RenovateResult(returncode, fixture_files)
+    for line in stdout.splitlines():
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+        if event.get("level", 0) >= 40:
+            result.diagnostics.append(event.get("msg", line))
+        if event.get("msg") != _PACKAGE_FILES_EVENT:
+            continue
+
+        for manager_files in event.get("config", {}).values():
+            for package in manager_files:
+                package_file = package.get("packageFile")
+                if package_file in result.deps_by_file:
+                    result.deps_by_file[package_file].extend(
+                        package.get("deps", [])
+                    )
+    return result

--- a/tests/test-renovate-coverage.py
+++ b/tests/test-renovate-coverage.py
@@ -7,14 +7,11 @@ a bump cannot silently stop being proposed for the non-manifest surfaces
 depNames Renovate must extract from it via custom.regex managers.
 """
 
-import json
-import os
-from pathlib import Path
-import shutil
-import subprocess
 import sys
-import tempfile
+from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from renovate_harness import run_renovate
 
 EXPECTED = {
     "bootstrap.toml": {
@@ -25,72 +22,15 @@ EXPECTED = {
     "pivot.sh": {"cert-manager", "cluster-api-operator"},
     ".github/workflows/validate.yml": {"renovate"},
 }
-REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
 def main() -> int:
-    env = os.environ.copy()
-    env.update(
-        {
-            "LOG_FORMAT": "json",
-            "LOG_LEVEL": "debug",
-            "RENOVATE_ENABLED_MANAGERS": "custom.regex",
-            "RENOVATE_INCLUDE_PATHS": json.dumps(sorted(EXPECTED)),
-        }
-    )
-
-    # The fixture copies the real renovate.json5 and the real tracked files
-    # so the test exercises the exact patterns and shapes that ship.
-    # platform=local + dry-run=lookup performs no writes and opens no PRs.
-    with tempfile.TemporaryDirectory(prefix="renovate-coverage-test-") as temp:
-        fixture_root = Path(temp)
-        shutil.copy2(REPO_ROOT / "renovate.json5", fixture_root / "renovate.json5")
-        for relative in EXPECTED:
-            source = REPO_ROOT / relative
-            target = fixture_root / relative
-            target.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copy2(source, target)
-
-        result = subprocess.run(
-            ["renovate", "--platform=local", "--dry-run=lookup"],
-            check=False,
-            cwd=fixture_root,
-            env=env,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
-        )
-
-    detected: dict[str, set[str]] = {path: set() for path in EXPECTED}
-    diagnostics = []
-    for line in result.stdout.splitlines():
-        try:
-            event = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-
-        if event.get("level", 0) >= 40:
-            diagnostics.append(event.get("msg", line))
-        if event.get("msg") != "packageFiles with updates":
-            continue
-
-        # Renovate records the looked-up package files under `config` in this
-        # debug event. The manager name (currently `regex`) is intentionally
-        # not hard-coded so a future custom-manager migration remains visible.
-        for manager_files in event.get("config", {}).values():
-            for package in manager_files:
-                package_file = package.get("packageFile")
-                if package_file not in detected:
-                    continue
-                for dependency in package.get("deps", []):
-                    dep_name = dependency.get("depName")
-                    if dep_name:
-                        detected[package_file].add(dep_name)
+    result = run_renovate(EXPECTED)
 
     missing = {
-        path: sorted(EXPECTED[path] - detected[path])
-        for path in EXPECTED
-        if EXPECTED[path] - detected[path]
+        path: sorted(deps - result.dep_names(path))
+        for path, deps in EXPECTED.items()
+        if deps - result.dep_names(path)
     }
     if result.returncode or missing:
         print("Renovate coverage check failed", file=sys.stderr)
@@ -98,14 +38,11 @@ def main() -> int:
         if missing:
             for path, deps in sorted(missing.items()):
                 print(f"{path}: missing detection for {deps}", file=sys.stderr)
-        if diagnostics:
-            print("Renovate diagnostics:", file=sys.stderr)
-            for diagnostic in diagnostics[-20:]:
-                print(f"  - {diagnostic}", file=sys.stderr)
+        result.print_diagnostics()
         return 1
 
-    for path in sorted(detected):
-        print(f"{path}: pin(s) detected: {sorted(detected[path])}")
+    for path in sorted(EXPECTED):
+        print(f"{path}: pin(s) detected: {sorted(result.dep_names(path))}")
     return 0
 
 


### PR DESCRIPTION
Consolidates the Renovate integration tests on a shared harness. Closes #97.

## Convention decision (scope item 1)

Shared Python module: `tests/renovate_harness.py`, both tests runnable via `python3 <file>` exactly as CI invokes them today. Rejected alternatives: pytest (new dependency and a runner change for two stdlib-only scripts), Rust cargo-target tests (moves the tests away from the config they guard and the validate.yml wiring for no benefit at this size).

## What changes

- New `tests/renovate_harness.py`: `run_renovate(fixture_files, transform=None)` copies the real `renovate.json5` plus the listed repo files into a temp fixture (optional per-file text transform), runs Renovate `--platform=local --dry-run=lookup`, parses the JSON event stream, and returns a `RenovateResult` (`deps_by_file`, `dep_names()`, `pin_digest_count()`, `print_diagnostics()`). Node >= 24 requirement documented in the module docstring (Renovate 44.50.1 uses `RegExp.escape`).
- `tests/test-renovate-coverage.py`: reduced to the EXPECTED map plus assertions (73 lines of harness logic removed).
- `airgap/tests/test-renovate-digest-pinning.py`: reduced to the file list, digest-stripping transform, and assertions.
- `AGENTS.md`: repo-gates note now names the harness, states that a new Renovate test is a file list plus assertions, and records the local Node 24 invocation.
- `.gitignore`: `__pycache__/` (the harness import creates it).

No CI wiring change (scope item 3: keep as-is; both invocations unchanged). No behavior change to what the tests assert.

## Verification

Both tests run exactly as CI does, under mise's Node 24 with Renovate 44.50.1 and a live GitHub token:

- `python3 tests/test-renovate-coverage.py`: all expected depNames detected (bootstrap.toml, pivot.sh, validate.yml)
- `python3 airgap/tests/test-renovate-digest-pinning.py`: 44 + 14 digest pins proposed, identical counts to the pre-refactor tests on the same tree
- Mutation check: corrupting one expected depName fails the test with that exact depName reported
- `mise run validate`: passes (bash -n x4, bootstrap.toml cross-check, 40 kustomize overlays)

