### PR TITLE
fix: align local-host Cluster topology versions with node images (v1.37.0)

### DIFF
--- a/airgap/images.txt
+++ b/airgap/images.txt
@@ -10,8 +10,9 @@
 #   [H] host Docker daemon image, consumed by kind + CAPD (NOT agent-rewriteable)
 #   [W] workload-node containerd store (separate from host daemon)
 #
-# NOTE: workload and management node images are kindest/node:v1.37.0; the
-#       kind bootstrap mgmt node is v1.36.1. Their embedded component
+# NOTE: workload and management CAPD node images are kindest/node:v1.37.0;
+#       the kind bootstrap mgmt node still runs v1.36.1 pending recreation
+#       (KIND_NODE_IMAGE now defaults to v1.37.0). Their embedded component
 #       versions differ (kindnetd, coredns, etcd, k8s).
 
 # ── Management cluster pod images [M] ─────────────────────────────────────────
@@ -50,10 +51,11 @@ docker.io/library/registry:2
 # ── Workload node containerd store [W] (v1.37.0 generation) ──────────────────
 # Pulled by the workload node's OWN containerd; must be pre-seeded or reachable
 # from a registry the workload node can reach over the kind docker network.
-docker.io/kindest/kindnetd:v20251212-v0.29.0-alpha-105-g20ccfc88
-docker.io/kindest/local-path-provisioner:v20251212-v0.29.0-alpha-105-g20ccfc88
-docker.io/kindest/local-path-helper:v20251211-v0.29.0-alpha-100-g82a92c5d
-registry.k8s.io/coredns/coredns:v1.14.7
+docker.io/kindest/kindnetd:v20260820-69b56db7
+docker.io/kindest/kindnetd:v20260528-9350166c
+docker.io/kindest/local-path-provisioner:v20260820-69b56db7
+docker.io/kindest/local-path-helper:v20260131-7181c60a
+registry.k8s.io/coredns/coredns:v1.14.6
 registry.k8s.io/kube-apiserver:v1.37.0
 registry.k8s.io/kube-controller-manager:v1.37.0
 registry.k8s.io/kube-proxy:v1.37.0

--- a/airgap/images.txt
+++ b/airgap/images.txt
@@ -10,8 +10,9 @@
 #   [H] host Docker daemon image, consumed by kind + CAPD (NOT agent-rewriteable)
 #   [W] workload-node containerd store (separate from host daemon)
 #
-# NOTE: workload node image is kindest/node:v1.35.0, mgmt node is v1.36.1.
-#       Their embedded component versions differ (kindnetd, coredns, etcd, k8s).
+# NOTE: workload and management node images are kindest/node:v1.37.0; the
+#       kind bootstrap mgmt node is v1.36.1. Their embedded component
+#       versions differ (kindnetd, coredns, etcd, k8s).
 
 # ── Management cluster pod images [M] ─────────────────────────────────────────
 ghcr.io/controlplaneio-fluxcd/flux-operator:v0.58.0
@@ -46,7 +47,7 @@ kindest/node:v1.37.0
 kindest/haproxy:v20230606-42a2262b
 docker.io/library/registry:2
 
-# ── Workload node containerd store [W] (v1.35.0 generation) ──────────────────
+# ── Workload node containerd store [W] (v1.37.0 generation) ──────────────────
 # Pulled by the workload node's OWN containerd; must be pre-seeded or reachable
 # from a registry the workload node can reach over the kind docker network.
 docker.io/kindest/kindnetd:v20251212-v0.29.0-alpha-105-g20ccfc88
@@ -55,7 +56,7 @@ docker.io/kindest/local-path-helper:v20251211-v0.29.0-alpha-100-g82a92c5d
 registry.k8s.io/coredns/coredns:v1.14.7
 registry.k8s.io/kube-apiserver:v1.37.0
 registry.k8s.io/kube-controller-manager:v1.37.0
-registry.k8s.io/kube-proxy:v1.35.0
+registry.k8s.io/kube-proxy:v1.37.0
 registry.k8s.io/etcd:3.7.1-0
 registry.k8s.io/kube-scheduler:v1.37.0
 registry.k8s.io/pause:3.10.2

--- a/airgap/scripts/build-config-artifact.sh
+++ b/airgap/scripts/build-config-artifact.sh
@@ -168,11 +168,11 @@ EOF
 # cluster-class.yaml: add preLoadImages to both DevMachineTemplates. Two
 # offline-only gaps found by Wi-Fi-off runs (connected runs mask them by
 # pulling silently):
-#   - registry.k8s.io/pause:3.10.1: the node bakes pause:3.10 but kubeadm
-#     v1.35.0 requires 3.10.1; the preflight pull fails offline and
-#     kubeadm init aborts (cluster never becomes Available).
+#   - registry.k8s.io/pause:3.10.1: leftover from the v1.35.0 generation,
+#     whose kubeadm required 3.10.1; v1.37.0 kubeadm pulls 3.10.2 (already
+#     in images.txt). Kept until the pause-pin follow-up removes it.
 #   - docker.io/kindest/kindnetd:v20260528-9350166c: the vendored CNI pins
-#     this tag but the v1.35.0 node bakes v20251212; the CNI pull hangs
+#     this tag but the v1.37.0 node bakes v20260820; the CNI pull hangs
 #     offline so nodes never become Ready.
 # The flux controllers + podinfo are pre-loaded so the per-cluster Flux needs
 # no internet. All entries load from the host Docker daemon

--- a/airgap/scripts/build-package.sh
+++ b/airgap/scripts/build-package.sh
@@ -76,8 +76,8 @@ HOST_IMAGES=(
 for img in "${HOST_IMAGES[@]}"; do
   docker pull --platform linux/arm64 "$img" >/dev/null
 done
-docker save -o airgap/archives/kindest_node_v1.36.1_mgmt.tar kindest/node:v1.37.0
-docker save -o airgap/archives/kindest_node_v1.35.0.tar kindest/node:v1.37.0
+docker save -o airgap/archives/kindest_node_v1.37.0_mgmt.tar kindest/node:v1.37.0
+docker save -o airgap/archives/kindest_node_v1.37.0.tar kindest/node:v1.37.0
 docker save -o airgap/archives/kindest_haproxy_v20230606-42a2262b.tar kindest/haproxy:v20230606-42a2262b
 docker save -o airgap/archives/docker.io_library_registry_2.tar docker.io/library/registry:2
 echo "    saved Zarf init package and host-daemon image archives"

--- a/airgap/scripts/stage-and-create-cluster.sh
+++ b/airgap/scripts/stage-and-create-cluster.sh
@@ -3,7 +3,7 @@
 #
 # 1. docker-loads every image archive from airgap/archives/ into the host
 #    Docker daemon:
-#      - kindest/node v1.36.1 (mgmt kind node) and v1.35.0 (CAPD workload
+#      - kindest/node v1.37.0 (mgmt kind node and CAPD workload/management
 #        nodes) — kind and CAPD `docker run` these directly from the host
 #        daemon, outside kubelet, so the Zarf agent cannot rewrite them.
 #      - kindest/haproxy (CAPD load balancer) and registry:2 (knr-registry,

--- a/docs/airgap.md
+++ b/docs/airgap.md
@@ -88,7 +88,7 @@ The verification linchpin is the agent's **image rewrite** plus a Ready
 | `archives/zarf-init-arm64-v0.83.0.tar.zst` | `zarf init` (registry + agent) |
 | `zarf-package-knr-ops-airgap-arm64-0.1.0.tar.zst` | signed package, including per-component Syft JSON/HTML SBOMs and the Sigstore signature bundle |
 | `archives/kindest_node_v1.36.1_mgmt.tar` | mgmt kind node (host daemon) |
-| `archives/kindest_node_v1.35.0.tar` | CAPD workload nodes (host daemon) |
+| `archives/kindest_node_v1.37.0.tar` | CAPD workload and management nodes (host daemon) |
 | `archives/kindest_haproxy_*.tar` | CAPD load balancer |
 | `archives/docker.io_library_registry_2.tar` | knr-registry container |
 | `archives/workload-pod-images.tar` | flux controllers + podinfo for `preLoadImages` |

--- a/docs/airgap.md
+++ b/docs/airgap.md
@@ -87,7 +87,7 @@ The verification linchpin is the agent's **image rewrite** plus a Ready
 | `zarf` CLI binary | runs the deploy |
 | `archives/zarf-init-arm64-v0.83.0.tar.zst` | `zarf init` (registry + agent) |
 | `zarf-package-knr-ops-airgap-arm64-0.1.0.tar.zst` | signed package, including per-component Syft JSON/HTML SBOMs and the Sigstore signature bundle |
-| `archives/kindest_node_v1.36.1_mgmt.tar` | mgmt kind node (host daemon) |
+| `archives/kindest_node_v1.37.0_mgmt.tar` | mgmt kind node (host daemon) |
 | `archives/kindest_node_v1.37.0.tar` | CAPD workload and management nodes (host daemon) |
 | `archives/kindest_haproxy_*.tar` | CAPD load balancer |
 | `archives/docker.io_library_registry_2.tar` | knr-registry container |

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -164,7 +164,7 @@ mise -E local-host run podinfo-port-forward
 
 Then browse to <http://localhost:9898>. Press Ctrl-C to stop forwarding.
 
-The workload uses Kubernetes v1.35.0. A CAPI ClusterResourceSet installs a
+The workload uses Kubernetes v1.37.0. A CAPI ClusterResourceSet installs a
 pinned Kindnet daemon as its CNI before the Flux addons are delivered.
 The management cluster needs access to the container-engine socket, which
 the bootstrap mounts automatically.

--- a/mgmt/local-host/clusters/docker/cluster.yaml
+++ b/mgmt/local-host/clusters/docker/cluster.yaml
@@ -18,7 +18,7 @@ spec:
   topology:
     classRef:
       name: docker-workload
-    version: v1.35.0
+    version: v1.37.0
     controlPlane:
       replicas: 1
     workers:

--- a/mgmt/local-host/clusters/management/cluster.yaml
+++ b/mgmt/local-host/clusters/management/cluster.yaml
@@ -21,7 +21,7 @@ spec:
   topology:
     classRef:
       name: docker-management
-    version: v1.35.0
+    version: v1.37.0
     controlPlane:
       replicas: 1
     workers:


### PR DESCRIPTION
## Summary

Renovate's kindest/node bumps (PR #117, #124 area) landed in the local-host ClusterClass `customImage` fields, but nothing manages the Cluster `topology.version` pins: they stayed at v1.35.0 while the node images moved to v1.37.0. On the live deployment this broke both local clusters:

- `local-management` (the pivot target): kubeadm inside a v1.37.0 image refuses to init a v1.35.0 control plane ("only supports deploying clusters with the control plane version >= 1.36.0").
- `local-workload`: Flux's apply of the class-level `DevMachineTemplate` image bump is rejected (spec.template.spec is immutable), leaving `docker-workload-cluster` failing since the bump.

This PR aligns both Cluster `topology.version` pins to v1.37.0 (matching the class images and the repo's k8s component direction, registry.k8s.io images already at v1.37.0) and refreshes the airgap surfaces that described the v1.35.0 generation.

## Live validation

Validated end-to-end on the local-host deployment before pushing (kind mgmt + CAPD, branch artifact published via `mise -E local-host run oci-push`):

- Both clusters recreated at v1.37.0; kubeadm init succeeds, CP initialized, nodes Ready.
- All nine mgmt Kustomizations Ready, including `docker-management-cluster` and `docker-workload-cluster`.
- Recovery required deleting the half-provisioned `local-management` Cluster, the stuck `local-workload` Cluster, the two stale immutable class-level `DevMachineTemplate`s, and two CRSs with pre-rename selectors (`profile: local-host` vs the renamed `knr-ops.polarsquad.com/environment`) — all recreated automatically by Flux from the branch artifact.

## Root cause (Renovate gap)

The `kindest/node image pins` customManager only matches `customImage:` lines; the Cluster `topology.version` field has no manager, so image bumps land without their version bump. Known pre-existing Renovate drift, not touched here: `etcd` inventory pin (3.7.1-0) vs live pull (3.7.0-0), `pause` pin in build-package (3.10.1) vs inventory (3.10.2), kube-proxy [M] lagging at v1.36.1. Flagging for a follow-up rather than expanding this PR's scope.

## Test plan

- [x] `mise run validate` green (kustomize builds, deps-check, bash -n)
- [x] Live local-host deployment reconciled from the branch artifact; both clusters Ready=True at v1.37.0
- [x] CI green on the PR

Refs #79 (unblocks the local-host pivot run), milestone 2-rust-bootstrap.

