### PR TITLE
fix: pin the flux-operator HelmChartProxy release name

### DIFF
--- a/airgap/scripts/build-config-artifact.sh
+++ b/airgap/scripts/build-config-artifact.sh
@@ -54,6 +54,9 @@ spec:
   repoURL: oci://knr-registry:5000/charts
   chartName: flux-operator
   version: "0.58.0"
+  # Pinned release name, matching mgmt/*/addons/flux-apps/flux-operator.yaml:
+  # keeps the release stable across proxy generations and cluster recreations.
+  releaseName: flux-operator
   namespace: flux-system
   options:
     waitForJobs: true

--- a/mgmt/aws/addons/flux-apps/flux-operator.yaml
+++ b/mgmt/aws/addons/flux-apps/flux-operator.yaml
@@ -16,6 +16,12 @@ spec:
   repoURL: oci://ghcr.io/controlplaneio-fluxcd/charts
   chartName: flux-operator
   version: "0.58.0"
+  # Pin the Helm release name. Without it CAAPH generates
+  # "flux-operator-<epoch>" per HelmReleaseProxy, and the chart's
+  # keep-policy CRDs/ClusterRoles on a recreated workload cluster carry
+  # the previous generated name, so every subsequent install fails helm's
+  # ownership validation ("cannot be imported into the current release").
+  releaseName: flux-operator
   namespace: flux-system
   options:
     waitForJobs: true

--- a/mgmt/local-host/addons/flux-apps/flux-operator.yaml
+++ b/mgmt/local-host/addons/flux-apps/flux-operator.yaml
@@ -11,6 +11,12 @@ spec:
   repoURL: oci://ghcr.io/controlplaneio-fluxcd/charts
   chartName: flux-operator
   version: "0.58.0"
+  # Pin the Helm release name. Without it CAAPH generates
+  # "flux-operator-<epoch>" per HelmReleaseProxy, and the chart's
+  # keep-policy CRDs/ClusterRoles on a recreated workload cluster carry
+  # the previous generated name, so every subsequent install fails helm's
+  # ownership validation ("cannot be imported into the current release").
+  releaseName: flux-operator
   namespace: flux-system
   options:
     waitForJobs: true


### PR DESCRIPTION
## Summary

The flux-operator HelmChartProxy in both environments left `spec.releaseName` unset, so CAAPH generated a release name of `flux-operator-<creation epoch>` for every HelmReleaseProxy. When the proxy is recreated (workload cluster recreation, a full bootstrap rerun, teardown + re-bootstrap), the new install targets a fresh generated name while the chart's `helm.sh/resource-policy: keep` CRDs and ClusterRoles on the workload cluster still carry the previous generated name in their `meta.helm.sh/release-name` annotation. Helm refuses the install:

```
CustomResourceDefinition "fluxinstances.fluxcd.controlplane.io" ... cannot be imported
into the current release: invalid ownership metadata; annotation validation error:
key "meta.helm.sh/release-name" must equal "flux-operator-1788249015":
current value is "flux-operator-1788246528"
```

and the `flux-apps` Kustomization never becomes Ready.

This pins `releaseName: flux-operator` in both environments so the release name is stable across proxy generations and reruns.

## How this was found

During the #92 full-parity run of `knr-bootstrap` (fresh bootstrap + pivot from a clean main checkout), `flux-apps` stalled post-pivot with exactly this ownership error: the kind-era CAAPH install (Step 5) had seeded the workload cluster's CRDs under a generated name, the post-pivot install generated another. The script path has the same exposure on any from-scratch rerun; the morning pivot run only dodged it because it pivoted a 14-day-old world whose proxy state predated the epoch collision.

## Live validation

- Applied `releaseName: flux-operator` to the live HelmChartProxy (mgmt cluster) plus ownership-annotation adoption on the four flux CRDs and four ClusterRoles still carrying the stale generated name.
- The stalled `flux-apps` Kustomization and the HelmChartProxy converged to Ready within 90 seconds of pinning.
- All 10 mgmt Kustomizations Ready; both clusters Available; workload Flux reconciling the main artifact.

## Test plan

- [x] `mise run validate` green
- [x] Live convergence verified after pinning
- [x] CI green

Refs #92 (found during its full-parity run). Milestone 2-rust-bootstrap.
