### PR TITLE
feat: port teardown.sh into knr-bootstrap (teardown subcommand)

### DIFF
--- a/bootstrap-rs/src/config.rs
+++ b/bootstrap-rs/src/config.rs
@@ -18,6 +18,11 @@ use serde::Deserialize;
 pub struct BootstrapConfig {
     pub bootstrap: BootstrapSection,
     pub charts: IndexMap<String, String>,
+    /// Teardown constants (issue #100): AWS orphan-sweep names and the
+    /// post-pivot controller-host removal rules. Optional so minimal test
+    /// fixtures and non-knr-ops consumers keep parsing.
+    #[serde(default)]
+    pub teardown: TeardownSection,
     /// Environments keyed by section name, in file order (error messages
     /// list environments in file order, e.g. 'local-host' before 'aws').
     pub environments: IndexMap<String, Environment>,
@@ -52,6 +57,9 @@ pub struct Environment {
     pub provider_manifests: Vec<String>,
     #[serde(default)]
     pub move_fallbacks: Vec<MoveFallback>,
+    /// Teardown constants for this environment (issue #100).
+    #[serde(default)]
+    pub teardown: TeardownEnv,
 }
 
 /// One `[[environments.<name>.move-fallbacks]]` entry.
@@ -61,6 +69,69 @@ pub struct MoveFallback {
     pub resource: String,
     pub name: String,
     pub manifest: String,
+}
+
+/// Global `[teardown]` constants (issue #100). These mirror the literal
+/// lists in `teardown.sh`; the Python cross-check pins them to the Git
+/// manifests that define the same names.
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
+pub struct TeardownSection {
+    /// CloudFormation stack created by `clusterawsadm bootstrap iam`.
+    #[serde(default)]
+    pub cfn_stack_name: Option<String>,
+    /// Region-independent IAM roles: the ACK controller pod-identity roles
+    /// and the per-cluster reader roles (workload/base/iam-roles/role.yaml).
+    #[serde(default)]
+    pub global_iam_roles: Vec<String>,
+    /// Region-independent IAM users (the console reader user).
+    #[serde(default)]
+    pub global_iam_users: Vec<String>,
+    /// S3 bucket name pattern with `{account_id}` and `{cluster_name}`
+    /// placeholders (workload/base/s3-buckets/bucket.yaml).
+    #[serde(default)]
+    pub s3_bucket_pattern: Option<String>,
+}
+
+/// One `[[environments.<name>.teardown.aws-workloads]]` entry: the AWS
+/// resources a workload cluster owns, derivable from its name.
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
+pub struct AwsWorkload {
+    /// AWS region the cluster's resources live in.
+    pub region: String,
+    /// K8s Cluster name (e.g. `eu-north-1-workload`).
+    pub cluster_name: String,
+    /// EKS cluster name: CAPA creates it with dashes converted to
+    /// underscores (e.g. `default_eu-north-1-workload-control-plane`).
+    pub eks_cluster_name: String,
+    /// RDS instance identifier (e.g. `knr-ops-eu-north-1-workload-db`).
+    pub rds_instance: String,
+}
+
+/// Per-environment teardown constants (issue #100).
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
+pub struct TeardownEnv {
+    /// AWS workload clusters this environment manages (aws only). The
+    /// orphan sweep visits every entry; empty for local-host.
+    #[serde(default)]
+    pub aws_workloads: Vec<AwsWorkload>,
+    /// CAPD/CAPI workload clusters to delete before the management
+    /// cluster (local-host only; e.g. `local-workload`).
+    #[serde(default)]
+    pub capi_workloads: Vec<String>,
+    /// Remove the self-managed management cluster at the container level
+    /// after the workload clusters are gone (local-host only): the mgmt
+    /// node/lb containers share this name prefix.
+    #[serde(default)]
+    pub mgmt_container_prefix: Option<String>,
+    /// Include the management cluster's own AWS names in the orphan sweep
+    /// (aws only): its EKS cluster name and IAM role prefix.
+    #[serde(default)]
+    pub mgmt_eks_cluster_name: Option<String>,
+    #[serde(default)]
+    pub mgmt_iam_role_prefix: Option<String>,
 }
 
 impl BootstrapConfig {

--- a/bootstrap-rs/src/main.rs
+++ b/bootstrap-rs/src/main.rs
@@ -18,6 +18,7 @@
 //! a generic bootstrap engine and knr-ops is its first consumer.
 
 mod config;
+mod teardown;
 
 use config::{BootstrapConfig, Environment};
 
@@ -96,6 +97,23 @@ struct Cli {
     /// since the cluster was created (the reuse path does not detect drift).
     #[arg(long)]
     recreate: bool,
+
+    /// Tear down everything the bootstrap created (issue #100): the port
+    /// of teardown.sh with post-pivot semantics. Knobs stay env-only
+    /// (AWS_ONLY, FORCE_KIND_DELETE, CLUSTER_DELETE_TIMEOUT,
+    /// PROVIDER_DELETE_TIMEOUT), matching the script's interface.
+    #[command(subcommand)]
+    command: Option<SubCommand>,
+}
+
+#[derive(clap::Subcommand, Debug)]
+enum SubCommand {
+    /// Destroy all infrastructure the bootstrap created, in reverse order.
+    Teardown {
+        /// Deployment profile (KNR_OPS_PROFILE takes precedence, as
+        /// everywhere else; default: bootstrap.default-environment).
+        profile: Option<String>,
+    },
 }
 
 /// Resolved run configuration: the environment knobs bootstrap.sh and
@@ -394,7 +412,7 @@ async fn run(cmd: &str, args: &[&str]) -> Result<()> {
 }
 
 /// Run a command silently; report only whether it succeeded.
-async fn run_quiet(cmd: &str, args: &[&str]) -> bool {
+pub(crate) async fn run_quiet(cmd: &str, args: &[&str]) -> bool {
     Command::new(cmd)
         .args(args)
         .stdin(Stdio::null())
@@ -407,7 +425,7 @@ async fn run_quiet(cmd: &str, args: &[&str]) -> bool {
 }
 
 /// Run a command and capture stdout (stderr inherited); error on nonzero exit.
-async fn capture(cmd: &str, args: &[&str]) -> Result<String> {
+pub(crate) async fn capture(cmd: &str, args: &[&str]) -> Result<String> {
     let out = Command::new(cmd)
         .args(args)
         .stderr(Stdio::inherit())
@@ -421,7 +439,7 @@ async fn capture(cmd: &str, args: &[&str]) -> Result<String> {
 }
 
 /// Run a command and capture stdout, ignoring the exit status (like `cmd || true`).
-async fn capture_lossy(cmd: &str, args: &[&str]) -> String {
+pub(crate) async fn capture_lossy(cmd: &str, args: &[&str]) -> String {
     Command::new(cmd)
         .args(args)
         .stderr(Stdio::null())
@@ -434,7 +452,7 @@ async fn capture_lossy(cmd: &str, args: &[&str]) -> String {
 /// Run a command with `input` piped to stdin and stdio otherwise inherited.
 /// Error messages include argv only, never stdin content, so manifests
 /// containing secret material are safe to pass here.
-async fn run_with_stdin(cmd: &str, args: &[&str], input: &str) -> Result<()> {
+pub(crate) async fn run_with_stdin(cmd: &str, args: &[&str], input: &str) -> Result<()> {
     let mut child = Command::new(cmd)
         .args(args)
         .stdin(Stdio::piped())
@@ -455,7 +473,7 @@ async fn run_with_stdin(cmd: &str, args: &[&str], input: &str) -> Result<()> {
 
 /// kubectl args with an optional target kubeconfig (None = the current
 /// context, i.e. the kind cluster; Some = the pivot target).
-fn kubectl_cmd<'a>(kubeconfig: Option<&'a str>, args: &[&'a str]) -> Vec<&'a str> {
+pub(crate) fn kubectl_cmd<'a>(kubeconfig: Option<&'a str>, args: &[&'a str]) -> Vec<&'a str> {
     let mut full = Vec::with_capacity(args.len() + 2);
     if let Some(kc) = kubeconfig {
         full.push("--kubeconfig");
@@ -2063,6 +2081,52 @@ async fn main() -> Result<()> {
     // pins all come from it (BOOTSTRAP_CONFIG overrides the location).
     let repo = BootstrapConfig::locate_and_load()?;
     let cli = Cli::parse();
+
+    // The teardown subcommand has its own knob set; it does not run the
+    // bootstrap Config resolution (which validates bootstrap/pivot knobs).
+    if let Some(SubCommand::Teardown { profile }) = &cli.command {
+        let name = resolve_environment(
+            std::env::var("KNR_OPS_PROFILE")
+                .ok()
+                .filter(|v| !v.is_empty())
+                .as_deref(),
+            profile.as_deref(),
+            &repo,
+        )?;
+        let environment = repo
+            .environment(&name)
+            .with_context(|| "internal: environment vanished between resolution and lookup")?
+            .clone();
+        // A minimal Config carrying what teardown needs (profile,
+        // environment section, repository config).
+        let cfg = Config {
+            repo,
+            profile: name,
+            environment,
+            recreate: false,
+            registry_port: DEFAULT_REGISTRY_PORT,
+            registry_ready_retries: DEFAULT_REGISTRY_READY_RETRIES,
+            local_reconcile_timeout: DEFAULT_LOCAL_RECONCILE_TIMEOUT.to_string(),
+            container_engine: None,
+            git_repo_url: None,
+            github_token: None,
+            github_user: DEFAULT_GITHUB_USER.to_string(),
+            age_key_file: PathBuf::from(DEFAULT_AGE_KEY_FILE),
+            age_public_key: None,
+            oci_repository: DEFAULT_OCI_REPOSITORY.to_string(),
+            oci_tag: DEFAULT_OCI_TAG.to_string(),
+            bootstrap_pivot: true,
+            pivot_skip_delete: false,
+            mgmt_kubeconfig: teardown::TeardownConfig::from_env(|n| std::env::var(n).ok())?
+                .mgmt_kubeconfig,
+            mgmt_ready_timeout: String::new(),
+            mgmt_poll_interval: DEFAULT_MGMT_POLL_INTERVAL,
+            bootstrap_kubecontext: String::new(),
+        };
+        let tcfg = teardown::TeardownConfig::from_env(|n| std::env::var(n).ok())?;
+        return teardown::run_teardown(&cfg, &tcfg).await;
+    }
+
     let cfg = Config::load(&cli, repo)?;
     let http = reqwest::Client::builder()
         .user_agent(concat!("knr-bootstrap/", env!("CARGO_PKG_VERSION")))
@@ -2211,6 +2275,10 @@ mod tests {
             ["knr-bootstrap", "aws", "--no-pivot"],
             ["knr-bootstrap", "aws", "--pivot"],
             ["knr-bootstrap", "--mgmt-kubeconfig", "/tmp/x.yaml"],
+            // Teardown knobs are env-only too (AWS_ONLY /
+            // FORCE_KIND_DELETE), matching teardown.sh's interface.
+            ["knr-bootstrap", "teardown", "--aws-only"],
+            ["knr-bootstrap", "teardown", "--force-kind-delete"],
         ] {
             assert!(
                 Cli::try_parse_from(rejected).is_err(),

--- a/bootstrap-rs/src/teardown.rs
+++ b/bootstrap-rs/src/teardown.rs
@@ -1378,6 +1378,14 @@ async fn run_with_stdin_str(cmd: &str, args: &[&str], input: &str) -> bool {
 
 // ── Orchestrator: the nine steps in the script's order ───────────────────────
 
+/// kubectl jsonpath printing `ns/name` per line. Byte-exact matters:
+/// kubectl rejects an over-escaped form with "unrecognized character in
+/// action: U+005C" and capture_lossy would turn that into an empty
+/// listing. The unit test pins the exact argv bytes; the live form was
+/// verified against a kind cluster (prints ns/name per line).
+const NS_NAME_JSONPATH: &str =
+    "jsonpath={range .items[*]}{.metadata.namespace}/{.metadata.name}{\"\\n\"}{end}";
+
 /// Step 5: delete CAPI provider CRs (the operator uninstalls the
 /// controllers), then wait up to the timeout.
 pub async fn delete_capi_providers(kubeconfig: Option<&str>, timeout_secs: u64) {
@@ -1396,16 +1404,7 @@ pub async fn delete_capi_providers(kubeconfig: Option<&str>, timeout_secs: u64) 
         // includes the namespace for cluster-scoped listings).
         let listing = capture_lossy(
             "kubectl",
-            &kubectl_cmd(
-                kubeconfig,
-                &[
-                    "get",
-                    &full,
-                    "-A",
-                    "-o",
-                    "jsonpath={range .items[*]}{.metadata.namespace}/{.metadata.name}{\"\\n\"}{end}",
-                ],
-            ),
+            &kubectl_cmd(kubeconfig, &["get", &full, "-A", "-o", NS_NAME_JSONPATH]),
         )
         .await;
         for object in listing.lines().filter_map(|l| {
@@ -2020,5 +2019,25 @@ mod tests {
             t.bucket_name("knr-ops-{account_id}-{cluster_name}-data", "acct"),
             "knr-ops-acct-eu-north-1-management-data"
         );
+    }
+}
+
+#[cfg(test)]
+mod jsonpath_tests {
+    use super::NS_NAME_JSONPATH;
+
+    #[test]
+    fn ns_name_jsonpath_bytes_match_the_live_verified_form() {
+        // Byte-exact argv: kubectl rejects the over-escaped form
+        // ('unrecognized character in action: U+005C'). Verified live
+        // against a kind cluster: this exact string prints ns/name per
+        // line; the over-escaped variant errors and capture_lossy
+        // silently returns an empty listing.
+        assert_eq!(
+            NS_NAME_JSONPATH,
+            "jsonpath={range .items[*]}{.metadata.namespace}/{.metadata.name}{\"\\n\"}{end}"
+        );
+        // The decoded bytes contain exactly one backslash (before n).
+        assert_eq!(NS_NAME_JSONPATH.matches('\\').count(), 1);
     }
 }

--- a/bootstrap-rs/src/teardown.rs
+++ b/bootstrap-rs/src/teardown.rs
@@ -1,0 +1,1927 @@
+//! Teardown: the port of `teardown.sh` (issue #100).
+//!
+//! Destroys everything the bootstrap creates, in the script's reverse
+//! order, with the same guards and refusal messages. The post-#79
+//! semantics are resolved here: after the pivot the CAPI controllers run
+//! on the self-managed management cluster, so the "controller host" the
+//! deletion guard protects is discovered (kind pre-pivot vs the mgmt
+//! kubeconfig post-pivot) instead of assumed to be kind.
+//!
+//! Best-effort rules mirror the script: every AWS cleanup unit skips
+//! gracefully when its resource is absent and never aborts the run on a
+//! single failure; the steps that gate host deletion (Flux suspension,
+//! workload cluster deletion, deprovision wait) are strict.
+
+use anyhow::{bail, Context, Result};
+use std::path::PathBuf;
+use std::process::Stdio;
+use tokio::process::Command;
+
+use crate::{capture_lossy, kubectl_cmd, run, run_quiet, Config};
+
+// ── Configuration knobs (teardown.sh `${VAR:-default}` equivalents) ───────────
+
+const DEFAULT_CLUSTER_DELETE_TIMEOUT_SECS: u64 = 1200;
+const DEFAULT_PROVIDER_DELETE_TIMEOUT_SECS: u64 = 300;
+
+/// Resolved teardown knobs (env-only, like the script's interface).
+#[derive(Debug)]
+pub struct TeardownConfig {
+    /// AWS_ONLY=1: orphan sweep only, no k8s steps.
+    pub aws_only: bool,
+    /// FORCE_KIND_DELETE=1: remove the controller host unconditionally.
+    pub force_host_delete: bool,
+    pub cluster_delete_timeout: u64,
+    pub provider_delete_timeout: u64,
+    /// $HOME-relative default for the post-pivot mgmt kubeconfig.
+    pub mgmt_kubeconfig: PathBuf,
+}
+
+impl TeardownConfig {
+    /// Resolve from the process environment with `${VAR:-default}`
+    /// semantics (empty behaves like unset).
+    pub fn from_env(get: impl Fn(&str) -> Option<String>) -> Result<Self> {
+        let value = |name: &str| get(name).filter(|v| !v.is_empty());
+        let flag = |name: &str, default: &str| value(name).map(|v| v == default).unwrap_or(false);
+        let num = |name: &str, default: u64| -> Result<u64> {
+            match value(name) {
+                None => Ok(default),
+                Some(raw) => raw
+                    .parse::<u64>()
+                    .with_context(|| format!("{name} must be a number of seconds")),
+            }
+        };
+        let home = std::env::var_os("HOME")
+            .map(PathBuf::from)
+            .context("HOME is not set; cannot locate the management kubeconfig")?;
+        let mgmt_kubeconfig = value("MGMT_KUBECONFIG")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| home.join(".kube/knr-ops-mgmt.yaml"));
+        Ok(Self {
+            // Literal "1" enables (shell boolean gate parity).
+            aws_only: flag("AWS_ONLY", "1"),
+            force_host_delete: flag("FORCE_KIND_DELETE", "1"),
+            cluster_delete_timeout: num(
+                "CLUSTER_DELETE_TIMEOUT",
+                DEFAULT_CLUSTER_DELETE_TIMEOUT_SECS,
+            )?,
+            provider_delete_timeout: num(
+                "PROVIDER_DELETE_TIMEOUT",
+                DEFAULT_PROVIDER_DELETE_TIMEOUT_SECS,
+            )?,
+            mgmt_kubeconfig,
+        })
+    }
+}
+
+// ── Controller-host discovery (the post-#79 resolution) ───────────────────────
+
+/// Where the CAPI controllers (the thing the deletion guard protects)
+/// are running. Discovered, not assumed: pre-pivot they live in the kind
+/// bootstrap cluster; post-pivot in the self-managed management cluster.
+#[derive(Debug, PartialEq)]
+pub enum ControllerHost {
+    /// The kind bootstrap cluster (`kind-mgmt` context).
+    Kind,
+    /// The self-managed management cluster, via its exported kubeconfig.
+    SelfManaged,
+    /// No reachable controller host: everything must go via the AWS
+    /// orphan sweep (AWS_ONLY semantics even when not requested).
+    Unreachable,
+}
+
+/// Discover the controller host for the aws environment. Order:
+/// kind cluster present (and reachable) wins (pre-pivot world); then the
+/// mgmt kubeconfig (post-pivot); then unreachable.
+pub async fn discover_controller_host(cfg: &Config) -> ControllerHost {
+    let kind_ctx = &cfg.repo.bootstrap.kind_context;
+    // `kubectl config get-contexts` lists contexts without touching a
+    // cluster; kind's context existing is the pre-pivot signal.
+    let contexts = capture_lossy("kubectl", &["config", "get-contexts", "-o", "name"]).await;
+    if contexts.lines().any(|l| l.trim() == kind_ctx)
+        && run_quiet(
+            "kubectl",
+            &[
+                "--context",
+                kind_ctx,
+                "cluster-info",
+                "--request-timeout=10s",
+            ],
+        )
+        .await
+    {
+        return ControllerHost::Kind;
+    }
+    let kc = cfg.mgmt_kubeconfig.to_string_lossy().into_owned();
+    if cfg.mgmt_kubeconfig.exists()
+        && run_quiet(
+            "kubectl",
+            &kubectl_cmd(Some(&kc), &["cluster-info", "--request-timeout=10s"]),
+        )
+        .await
+    {
+        return ControllerHost::SelfManaged;
+    }
+    ControllerHost::Unreachable
+}
+
+// ── The deletion guard (CLUSTERS_CONFIRMED_GONE / FORCE_KIND_DELETE) ─────────
+
+/// Guard state for removing the controller host. The script's contract:
+/// kind (now: the host) is deleted only once CAPI clusters are confirmed
+/// gone, or unconditionally under FORCE_KIND_DELETE.
+#[derive(Debug, PartialEq)]
+pub enum HostGuard {
+    /// CLUSTERS_CONFIRMED_GONE=1 equivalent: safe to remove the host.
+    ConfirmedGone,
+    /// FORCE_KIND_DELETE=1: remove regardless of orphan risk.
+    Forced,
+    /// Neither: refuse to remove the host, keep controllers running.
+    Refuse,
+}
+
+impl HostGuard {
+    pub fn resolve(clusters_gone: bool, force: bool) -> Self {
+        if force {
+            HostGuard::Forced
+        } else if clusters_gone {
+            HostGuard::ConfirmedGone
+        } else {
+            HostGuard::Refuse
+        }
+    }
+
+    /// The script's refusal message, verbatim modulo the host noun.
+    pub fn refusal_message(host: &str) -> String {
+        format!(
+            "Refusing to delete {host}: CAPI clusters were not\n\
+             confirmed deleted. Leaving the CAPI controller running so AWS resources can continue\n\
+             deprovisioning. Re-run teardown once 'kubectl get clusters -A' is empty,\n\
+             or set FORCE_KIND_DELETE=1 to force-delete and accept orphaned AWS resources."
+        )
+    }
+}
+
+// ── Step helpers ──────────────────────────────────────────────────────────────
+
+/// Step 1: suspend Flux Kustomizations on the controller host so nothing
+/// recreates deleted resources mid-teardown.
+pub async fn suspend_flux(kubeconfig: Option<&str>) -> Result<()> {
+    println!(">>> Suspending Flux Kustomizations to prevent re-reconciliation...");
+    let names = capture_lossy(
+        "kubectl",
+        &kubectl_cmd(
+            kubeconfig,
+            &[
+                "get",
+                "kustomizations.kustomize.toolkit.fluxcd.io",
+                "-n",
+                "flux-system",
+                "-o",
+                "name",
+            ],
+        ),
+    )
+    .await;
+    if names.trim().is_empty() {
+        println!("!   No Flux Kustomizations found – skipping suspension");
+        return Ok(());
+    }
+    for ks in names.lines().filter_map(|l| l.trim().rsplit('/').next()) {
+        let _ = run(
+            "kubectl",
+            &kubectl_cmd(
+                kubeconfig,
+                &[
+                    "patch",
+                    &format!("kustomization/{ks}"),
+                    "-n",
+                    "flux-system",
+                    "--type",
+                    "merge",
+                    "-p",
+                    r#"{"spec":{"suspend":true}}"#,
+                ],
+            ),
+        )
+        .await;
+    }
+    println!("✓   Flux Kustomizations suspended");
+    Ok(())
+}
+
+/// Step 2+3 (local-host): delete the CAPD workload clusters and wait for
+/// full deprovision (containers gone), with the script's refusal when a
+/// cluster refuses to die.
+pub async fn delete_capi_workloads(
+    kubeconfig: Option<&str>,
+    workloads: &[String],
+    timeout_secs: u64,
+) -> Result<()> {
+    for cluster in workloads {
+        println!(">>> Deleting CAPD workload cluster '{cluster}'...");
+        let exists = run_quiet(
+            "kubectl",
+            &kubectl_cmd(kubeconfig, &["get", "cluster", cluster, "-n", "default"]),
+        )
+        .await;
+        if !exists {
+            println!("!   Cluster '{cluster}' not found – skipping");
+            continue;
+        }
+        run(
+            "kubectl",
+            &kubectl_cmd(
+                kubeconfig,
+                &[
+                    "delete",
+                    "cluster",
+                    cluster,
+                    "-n",
+                    "default",
+                    "--wait=false",
+                ],
+            ),
+        )
+        .await
+        .with_context(|| format!("failed to delete workload cluster '{cluster}'"))?;
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(timeout_secs);
+        loop {
+            let gone = !run_quiet(
+                "kubectl",
+                &kubectl_cmd(kubeconfig, &["get", "cluster", cluster, "-n", "default"]),
+            )
+            .await;
+            if gone {
+                println!("✓   CAPD workload cluster '{cluster}' deleted");
+                break;
+            }
+            if std::time::Instant::now() >= deadline {
+                bail!(
+                    "CAPD workload cluster '{cluster}' did not finish deleting within {timeout_secs}s; \
+                     leaving the management cluster intact"
+                );
+            }
+            tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+        }
+    }
+    Ok(())
+}
+
+/// Steps 2+3 (aws): delete every CAPI Cluster except the management
+/// cluster itself (the host), then wait until only the mgmt remains.
+/// Returns true when the workload clusters are confirmed gone.
+pub async fn delete_aws_workload_clusters(
+    kubeconfig: Option<&str>,
+    mgmt_cluster: &str,
+    timeout_secs: u64,
+) -> Result<bool> {
+    println!(">>> Discovering CAPI Cluster resources...");
+    let listing = capture_lossy(
+        "kubectl",
+        &kubectl_cmd(kubeconfig, &["get", "clusters", "-A", "-o", "name"]),
+    )
+    .await;
+    let mut workloads: Vec<String> = listing
+        .lines()
+        .filter_map(|l| l.trim().rsplit('/').next())
+        .filter(|n| *n != mgmt_cluster)
+        .map(String::from)
+        .collect();
+    workloads.sort();
+    workloads.dedup();
+    if workloads.is_empty() {
+        println!(">>> No CAPI workload clusters found – skipping cluster deletion");
+        return Ok(true);
+    }
+    for cluster in &workloads {
+        println!(">>>   Deleting cluster: {cluster}");
+        let _ = run(
+            "kubectl",
+            &kubectl_cmd(
+                kubeconfig,
+                &["delete", "cluster", cluster, "--ignore-not-found"],
+            ),
+        )
+        .await;
+    }
+    println!(">>> Waiting up to {timeout_secs}s for the workload clusters to be deleted...");
+    println!(">>> (This typically takes 15–25 minutes while CAPA tears down AWS resources)");
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(timeout_secs);
+    loop {
+        let remaining: Vec<String> = capture_lossy(
+            "kubectl",
+            &kubectl_cmd(kubeconfig, &["get", "clusters", "-A", "-o", "name"]),
+        )
+        .await
+        .lines()
+        .filter_map(|l| l.trim().rsplit('/').next())
+        .filter(|n| *n != mgmt_cluster)
+        .map(String::from)
+        .collect();
+        if remaining.is_empty() {
+            println!("✓   All CAPI workload clusters deleted");
+            return Ok(true);
+        }
+        if std::time::Instant::now() >= deadline {
+            eprintln!("!   Timed out waiting for CAPI clusters to be deleted");
+            eprintln!("!   The following clusters still exist: {remaining:?}");
+            return Ok(false);
+        }
+        println!(">>>   {} cluster(s) still deleting...", remaining.len());
+        tokio::time::sleep(std::time::Duration::from_secs(30)).await;
+    }
+}
+
+/// Pure helper: the CAPA ownership tag key for VPC/EIP scoping.
+pub fn capa_tag_key(cluster_name: &str) -> String {
+    format!("sigs.k8s.io/cluster-api-provider-aws/cluster/{cluster_name}")
+}
+
+/// Pure helper: the S3 bucket name for a cluster (pattern from
+/// bootstrap.toml, account from the caller).
+pub fn s3_bucket_name(pattern: &str, account_id: &str, cluster_name: &str) -> String {
+    pattern
+        .replace("{account_id}", account_id)
+        .replace("{cluster_name}", cluster_name)
+}
+
+// ── AWS orphan sweep units (best-effort: skip if absent, warn and
+// continue on failure — exactly the script's semantics) ───────────────────────
+
+fn warn(msg: &str) {
+    eprintln!("!   {msg}");
+}
+
+/// One AWS workload (or the management cluster itself) expressed as the
+/// names the sweep needs, derived from the config.
+#[derive(Clone, Debug)]
+pub struct AwsSweepTarget {
+    pub region: String,
+    pub cluster_name: String,
+    pub eks_cluster_name: String,
+    pub rds_instance: String,
+}
+
+impl AwsSweepTarget {
+    pub fn from_workload(w: &crate::config::AwsWorkload) -> Self {
+        Self {
+            region: w.region.clone(),
+            cluster_name: w.cluster_name.clone(),
+            eks_cluster_name: w.eks_cluster_name.clone(),
+            rds_instance: w.rds_instance.clone(),
+        }
+    }
+
+    pub fn mgmt(region: &str, cluster_name: &str, eks_cluster_name: &str) -> Self {
+        Self {
+            region: region.to_string(),
+            cluster_name: cluster_name.to_string(),
+            eks_cluster_name: eks_cluster_name.to_string(),
+            // The management cluster runs no workload ACK controllers,
+            // so it owns no RDS instance; the sweep unit skips absent ids.
+            rds_instance: format!("knr-ops-{cluster_name}-db"),
+        }
+    }
+
+    pub fn bucket_name(&self, pattern: &str, account_id: &str) -> String {
+        s3_bucket_name(pattern, account_id, &self.cluster_name)
+    }
+
+    pub fn capa_tag_key(&self) -> String {
+        capa_tag_key(&self.cluster_name)
+    }
+}
+
+fn aws_base(region: &str) -> Vec<String> {
+    vec!["--region".into(), region.into()]
+}
+
+/// True when the EKS cluster exists (used by every EKS-gated unit).
+async fn eks_exists(cluster: &str, region: &str) -> bool {
+    run_quiet(
+        "aws",
+        &[
+            "eks",
+            "describe-cluster",
+            "--name",
+            cluster,
+            "--region",
+            region,
+            "--output",
+            "json",
+        ],
+    )
+    .await
+}
+
+/// 4a. Pod identity associations (only possible while EKS exists).
+pub async fn cleanup_pod_identity_associations(target: &AwsSweepTarget) {
+    if !eks_exists(&target.eks_cluster_name, &target.region).await {
+        println!(
+            "✓   EKS cluster {} not found in {} – no pod identity associations to clean",
+            target.eks_cluster_name, target.region
+        );
+        return;
+    }
+    let mut args = aws_base(&target.region);
+    args.extend_from_slice(&[
+        "eks".into(),
+        "list-pod-identity-associations".into(),
+        "--cluster-name".into(),
+        target.eks_cluster_name.clone(),
+        "--query".into(),
+        "associations[].associationId".into(),
+        "--output".into(),
+        "text".into(),
+    ]);
+    let argrefs: Vec<&str> = args.iter().map(String::as_str).collect();
+    let ids = capture_lossy("aws", &argrefs).await;
+    for id in ids.split_whitespace() {
+        println!(">>>   Deleting pod identity association: {id}");
+        let mut args = aws_base(&target.region);
+        args.extend_from_slice(&[
+            "eks".into(),
+            "delete-pod-identity-association".into(),
+            "--cluster-name".into(),
+            target.eks_cluster_name.clone(),
+            "--association-id".into(),
+            id.into(),
+        ]);
+        let argrefs: Vec<&str> = args.iter().map(String::as_str).collect();
+        if !run_quiet("aws", &argrefs).await {
+            warn(&format!("Failed to delete pod identity association {id}"));
+        }
+    }
+}
+
+/// 4b. Nodegroups: delete in every region first, then wait (EKS refuses
+/// cluster deletion while nodegroups exist).
+pub async fn cleanup_nodegroups(target: &AwsSweepTarget) {
+    if !eks_exists(&target.eks_cluster_name, &target.region).await {
+        return;
+    }
+    let mut args = aws_base(&target.region);
+    args.extend_from_slice(&[
+        "eks".into(),
+        "list-nodegroups".into(),
+        "--cluster-name".into(),
+        target.eks_cluster_name.clone(),
+        "--query".into(),
+        "nodegroups[]".into(),
+        "--output".into(),
+        "text".into(),
+    ]);
+    let argrefs: Vec<&str> = args.iter().map(String::as_str).collect();
+    let ngs = capture_lossy("aws", &argrefs).await;
+    for ng in ngs.split_whitespace() {
+        println!(">>>   Deleting nodegroup: {ng}");
+        let mut args = aws_base(&target.region);
+        args.extend_from_slice(&[
+            "eks".into(),
+            "delete-nodegroup".into(),
+            "--cluster-name".into(),
+            target.eks_cluster_name.clone(),
+            "--nodegroup-name".into(),
+            ng.into(),
+        ]);
+        let argrefs: Vec<&str> = args.iter().map(String::as_str).collect();
+        if !run_quiet("aws", &argrefs).await {
+            warn(&format!("Failed to delete nodegroup {ng}"));
+        }
+    }
+}
+
+pub async fn wait_nodegroups_deleted(target: &AwsSweepTarget) {
+    if !eks_exists(&target.eks_cluster_name, &target.region).await {
+        return;
+    }
+    let mut args = aws_base(&target.region);
+    args.extend_from_slice(&[
+        "eks".into(),
+        "list-nodegroups".into(),
+        "--cluster-name".into(),
+        target.eks_cluster_name.clone(),
+        "--query".into(),
+        "nodegroups[]".into(),
+        "--output".into(),
+        "text".into(),
+    ]);
+    let argrefs: Vec<&str> = args.iter().map(String::as_str).collect();
+    let ngs = capture_lossy("aws", &argrefs).await;
+    for ng in ngs.split_whitespace() {
+        println!(">>>   Waiting for nodegroup {ng} to finish deleting...");
+        let mut args = aws_base(&target.region);
+        args.extend_from_slice(&[
+            "eks".into(),
+            "wait".into(),
+            "nodegroup-deleted".into(),
+            "--cluster-name".into(),
+            target.eks_cluster_name.clone(),
+            "--nodegroup-name".into(),
+            ng.into(),
+        ]);
+        let argrefs: Vec<&str> = args.iter().map(String::as_str).collect();
+        if !run_quiet("aws", &argrefs).await {
+            warn(&format!("Timed out waiting for nodegroup {ng}"));
+        }
+    }
+}
+
+/// 4c. EKS cluster deletion + wait (control-plane ENIs block VPC cleanup).
+pub async fn cleanup_eks_cluster(target: &AwsSweepTarget) {
+    if !eks_exists(&target.eks_cluster_name, &target.region).await {
+        println!(
+            "✓   EKS cluster {} not found in {}",
+            target.eks_cluster_name, target.region
+        );
+        return;
+    }
+    println!(
+        ">>>   Deleting EKS cluster: {} in {}",
+        target.eks_cluster_name, target.region
+    );
+    let mut args = aws_base(&target.region);
+    args.extend_from_slice(&[
+        "eks".into(),
+        "delete-cluster".into(),
+        "--name".into(),
+        target.eks_cluster_name.clone(),
+    ]);
+    let argrefs: Vec<&str> = args.iter().map(String::as_str).collect();
+    if !run_quiet("aws", &argrefs).await {
+        warn(&format!(
+            "Failed to delete EKS cluster {}",
+            target.eks_cluster_name
+        ));
+    }
+}
+
+pub async fn wait_eks_cluster_deleted(target: &AwsSweepTarget) {
+    if !eks_exists(&target.eks_cluster_name, &target.region).await {
+        return;
+    }
+    println!(
+        ">>>   Waiting for EKS cluster {} to finish deleting...",
+        target.eks_cluster_name
+    );
+    let mut args = aws_base(&target.region);
+    args.extend_from_slice(&[
+        "eks".into(),
+        "wait".into(),
+        "cluster-deleted".into(),
+        "--name".into(),
+        target.eks_cluster_name.clone(),
+    ]);
+    let argrefs: Vec<&str> = args.iter().map(String::as_str).collect();
+    if !run_quiet("aws", &argrefs).await {
+        warn(&format!(
+            "Timed out waiting for EKS cluster {}",
+            target.eks_cluster_name
+        ));
+    }
+}
+
+/// 4d. RDS instances orphaned when their workload cluster died first.
+pub async fn cleanup_rds_instance(target: &AwsSweepTarget) {
+    let mut args = aws_base(&target.region);
+    args.extend_from_slice(&[
+        "rds".into(),
+        "describe-db-instances".into(),
+        "--db-instance-identifier".into(),
+        target.rds_instance.clone(),
+    ]);
+    let argrefs: Vec<&str> = args.iter().map(String::as_str).collect();
+    if !run_quiet("aws", &argrefs).await {
+        println!(
+            "✓   RDS instance {} not found in {}",
+            target.rds_instance, target.region
+        );
+        return;
+    }
+    let mut args = aws_base(&target.region);
+    args.extend_from_slice(&[
+        "rds".into(),
+        "describe-db-instances".into(),
+        "--db-instance-identifier".into(),
+        target.rds_instance.clone(),
+        "--query".into(),
+        "DBInstances[0].DBInstanceStatus".into(),
+        "--output".into(),
+        "text".into(),
+    ]);
+    let argrefs: Vec<&str> = args.iter().map(String::as_str).collect();
+    let status = capture_lossy("aws", &argrefs).await.trim().to_string();
+    if status == "deleting" {
+        println!(
+            ">>>   RDS instance {} already deleting in {}",
+            target.rds_instance, target.region
+        );
+        return;
+    }
+    println!(
+        ">>>   Deleting RDS instance: {} in {}",
+        target.rds_instance, target.region
+    );
+    let mut args = aws_base(&target.region);
+    args.extend_from_slice(&[
+        "rds".into(),
+        "delete-db-instance".into(),
+        "--db-instance-identifier".into(),
+        target.rds_instance.clone(),
+        "--skip-final-snapshot".into(),
+        "--delete-automated-backups".into(),
+    ]);
+    let argrefs: Vec<&str> = args.iter().map(String::as_str).collect();
+    if !run_quiet("aws", &argrefs).await {
+        warn(&format!(
+            "Failed to delete RDS instance {}",
+            target.rds_instance
+        ));
+    }
+}
+
+/// 4f. S3 buckets: versioned, so every object version AND delete marker
+/// must be purged before the bucket itself can be deleted.
+pub async fn cleanup_s3_bucket(bucket: &str, region: &str) {
+    let head = run_quiet(
+        "aws",
+        &[
+            "s3api",
+            "head-bucket",
+            "--bucket",
+            bucket,
+            "--region",
+            region,
+        ],
+    )
+    .await;
+    if !head {
+        println!("✓   S3 bucket {bucket} not found");
+        return;
+    }
+    println!(">>>   Emptying S3 bucket: {bucket} (all versions and delete markers)");
+    loop {
+        let batch = capture_lossy(
+            "aws",
+            &[
+                "s3api",
+                "list-object-versions",
+                "--bucket",
+                bucket,
+                "--region",
+                region,
+                "--max-items",
+                "500",
+                "--query",
+                "{Objects: [Versions, DeleteMarkers][][].{Key: Key, VersionId: VersionId}, Quiet: `true`}",
+                "--output",
+                "json",
+            ],
+        ).await;
+        if !batch.contains("\"Key\"") {
+            break;
+        }
+        let ok = run_with_stdin_str(
+            "aws",
+            &[
+                "s3api",
+                "delete-objects",
+                "--bucket",
+                bucket,
+                "--region",
+                region,
+                "--delete",
+                "fileb:///dev/stdin",
+            ],
+            &batch,
+        )
+        .await;
+        if !ok {
+            warn(&format!("Failed to purge objects from {bucket}"));
+            break;
+        }
+    }
+    println!(">>>   Deleting S3 bucket: {bucket}");
+    if !run_quiet(
+        "aws",
+        &[
+            "s3api",
+            "delete-bucket",
+            "--bucket",
+            bucket,
+            "--region",
+            region,
+        ],
+    )
+    .await
+    {
+        warn(&format!("Failed to delete S3 bucket {bucket}"));
+    }
+}
+
+/// 4g. IAM role (detach policies, instance profiles, inline policies,
+/// then the role). Skips silently when the role is absent.
+pub async fn cleanup_iam_role(role: &str) {
+    if !run_quiet("aws", &["iam", "get-role", "--role-name", role]).await {
+        return;
+    }
+    println!(">>>   Deleting IAM role: {role}");
+    let policies = capture_lossy(
+        "aws",
+        &[
+            "iam",
+            "list-attached-role-policies",
+            "--role-name",
+            role,
+            "--query",
+            "AttachedPolicies[].PolicyArn",
+            "--output",
+            "text",
+        ],
+    )
+    .await;
+    for arn in policies.split_whitespace() {
+        println!(">>>     Detaching policy: {arn}");
+        let _ = run_quiet(
+            "aws",
+            &[
+                "iam",
+                "detach-role-policy",
+                "--role-name",
+                role,
+                "--policy-arn",
+                arn,
+            ],
+        )
+        .await;
+    }
+    let profiles = capture_lossy(
+        "aws",
+        &[
+            "iam",
+            "list-instance-profiles-for-role",
+            "--role-name",
+            role,
+            "--query",
+            "InstanceProfiles[].InstanceProfileName",
+            "--output",
+            "text",
+        ],
+    )
+    .await;
+    for profile in profiles.split_whitespace() {
+        println!(">>>     Deleting instance profile: {profile}");
+        let _ = run_quiet(
+            "aws",
+            &[
+                "iam",
+                "remove-role-from-instance-profile",
+                "--instance-profile-name",
+                profile,
+                "--role-name",
+                role,
+            ],
+        )
+        .await;
+        let _ = run_quiet(
+            "aws",
+            &[
+                "iam",
+                "delete-instance-profile",
+                "--instance-profile-name",
+                profile,
+            ],
+        )
+        .await;
+    }
+    let inline = capture_lossy(
+        "aws",
+        &[
+            "iam",
+            "list-role-policies",
+            "--role-name",
+            role,
+            "--query",
+            "PolicyNames[]",
+            "--output",
+            "text",
+        ],
+    )
+    .await;
+    for policy in inline.split_whitespace() {
+        println!(">>>     Deleting inline policy: {policy}");
+        let _ = run_quiet(
+            "aws",
+            &[
+                "iam",
+                "delete-role-policy",
+                "--role-name",
+                role,
+                "--policy-name",
+                policy,
+            ],
+        )
+        .await;
+    }
+    if !run_quiet("aws", &["iam", "delete-role", "--role-name", role]).await {
+        warn(&format!("Failed to delete IAM role {role}"));
+    }
+}
+
+/// CAPA (EKSEnableIAM) auto-creates per-cluster roles not declared in
+/// Git; sweep every role whose name starts with the cluster name.
+pub async fn cleanup_capa_iam_roles(prefix: &str) {
+    // list-roles is paginated at 100 by the CLI without a paginator on
+    // server-side filters; use the query prefix sweep like the script.
+    let roles = capture_lossy(
+        "aws",
+        &[
+            "iam",
+            "list-roles",
+            "--query",
+            &format!("Roles[?starts_with(RoleName, `{prefix}`)].RoleName"),
+            "--output",
+            "text",
+            "--max-items",
+            "1000",
+        ],
+    )
+    .await;
+    for role in roles.split_whitespace() {
+        if role == "None" {
+            continue;
+        }
+        cleanup_iam_role(role).await;
+    }
+}
+
+/// 4g. IAM user (login profile, access keys, inline policies, user).
+pub async fn cleanup_iam_user(user: &str) {
+    if !run_quiet("aws", &["iam", "get-user", "--user-name", user]).await {
+        return;
+    }
+    println!(">>>   Deleting IAM user: {user}");
+    let _ = run_quiet("aws", &["iam", "delete-login-profile", "--user-name", user]).await;
+    let keys = capture_lossy(
+        "aws",
+        &[
+            "iam",
+            "list-access-keys",
+            "--user-name",
+            user,
+            "--query",
+            "AccessKeyMetadata[].AccessKeyId",
+            "--output",
+            "text",
+        ],
+    )
+    .await;
+    for key in keys.split_whitespace() {
+        println!(">>>     Deleting access key: {key}");
+        let _ = run_quiet(
+            "aws",
+            &[
+                "iam",
+                "delete-access-key",
+                "--user-name",
+                user,
+                "--access-key-id",
+                key,
+            ],
+        )
+        .await;
+    }
+    let inline = capture_lossy(
+        "aws",
+        &[
+            "iam",
+            "list-user-policies",
+            "--user-name",
+            user,
+            "--query",
+            "PolicyNames[]",
+            "--output",
+            "text",
+        ],
+    )
+    .await;
+    for policy in inline.split_whitespace() {
+        let _ = run_quiet(
+            "aws",
+            &[
+                "iam",
+                "delete-user-policy",
+                "--user-name",
+                user,
+                "--policy-name",
+                policy,
+            ],
+        )
+        .await;
+    }
+    if !run_quiet("aws", &["iam", "delete-user", "--user-name", user]).await {
+        warn(&format!("Failed to delete IAM user {user}"));
+    }
+}
+
+/// 4h. CloudFormation bootstrap stack.
+pub async fn cleanup_cfn_stack(stack: &str, region: &str) {
+    if !run_quiet(
+        "aws",
+        &[
+            "cloudformation",
+            "describe-stacks",
+            "--stack-name",
+            stack,
+            "--region",
+            region,
+        ],
+    )
+    .await
+    {
+        return;
+    }
+    println!(">>>   Deleting CFN stack: {stack} in {region}");
+    if !run_quiet(
+        "aws",
+        &[
+            "cloudformation",
+            "delete-stack",
+            "--stack-name",
+            stack,
+            "--region",
+            region,
+        ],
+    )
+    .await
+    {
+        warn(&format!("Failed to delete CFN stack {stack} in {region}"));
+    }
+}
+
+/// 4e. VPC resources, gated on the CAPA ownership tag (knr-ops scope
+/// only): NAT gateways + their EIPs, subnets, IGWs, route tables,
+/// security groups (rules first, then the groups), the VPC itself.
+pub async fn cleanup_vpc_resources(target: &AwsSweepTarget) {
+    let tag = target.capa_tag_key();
+    let vpcs = capture_lossy(
+        "aws",
+        &[
+            "ec2",
+            "describe-vpcs",
+            "--region",
+            &target.region,
+            "--filters",
+            &format!("Name=tag:{tag},Values=owned"),
+            "--query",
+            "Vpcs[].VpcId",
+            "--output",
+            "text",
+        ],
+    )
+    .await;
+    for vpc in vpcs.split_whitespace() {
+        println!(
+            ">>>   Cleaning up VPC {vpc} in {} (cluster: {})",
+            target.region, target.cluster_name
+        );
+        cleanup_vpc(vpc, &target.region, &tag).await;
+    }
+}
+
+async fn cleanup_vpc(vpc: &str, region: &str, tag: &str) {
+    // NAT gateways (before subnets), including the deleting state.
+    let nats = capture_lossy(
+        "aws",
+        &[
+            "ec2",
+            "describe-nat-gateways",
+            "--region",
+            region,
+            "--filter",
+            &format!("Name=vpc-id,Values={vpc}"),
+            "Name=state,Values=pending,available,deleting",
+            "--query",
+            "NatGateways[].NatGatewayId",
+            "--output",
+            "text",
+        ],
+    )
+    .await;
+    for nat in nats.split_whitespace() {
+        println!(">>>     Deleting NAT gateway: {nat}");
+        let _ = run_quiet(
+            "aws",
+            &[
+                "ec2",
+                "delete-nat-gateway",
+                "--region",
+                region,
+                "--nat-gateway-id",
+                nat,
+            ],
+        )
+        .await;
+    }
+    for nat in nats.split_whitespace() {
+        println!(">>>     Waiting for NAT gateway {nat} to finish deleting...");
+        let _ = run_quiet(
+            "aws",
+            &[
+                "ec2",
+                "wait",
+                "nat-gateway-deleted",
+                "--region",
+                region,
+                "--nat-gateway-ids",
+                nat,
+            ],
+        )
+        .await;
+    }
+    // Elastic IPs (tagged, NAT-allocated ones are not released with it).
+    let eips = capture_lossy(
+        "aws",
+        &[
+            "ec2",
+            "describe-addresses",
+            "--region",
+            region,
+            "--filters",
+            &format!("Name=tag:{tag},Values=owned"),
+            "--query",
+            "Addresses[].AllocationId",
+            "--output",
+            "text",
+        ],
+    )
+    .await;
+    for eip in eips.split_whitespace() {
+        println!(">>>     Releasing Elastic IP: {eip}");
+        let _ = run_quiet(
+            "aws",
+            &[
+                "ec2",
+                "release-address",
+                "--region",
+                region,
+                "--allocation-id",
+                eip,
+            ],
+        )
+        .await;
+    }
+    // Subnets (the VPC is CAPA-tagged, never the default VPC).
+    let subnets = capture_lossy(
+        "aws",
+        &[
+            "ec2",
+            "describe-subnets",
+            "--region",
+            region,
+            "--filters",
+            &format!("Name=vpc-id,Values={vpc}"),
+            "--query",
+            "Subnets[].SubnetId",
+            "--output",
+            "text",
+        ],
+    )
+    .await;
+    for subnet in subnets.split_whitespace() {
+        println!(">>>     Deleting subnet: {subnet}");
+        let _ = run_quiet(
+            "aws",
+            &[
+                "ec2",
+                "delete-subnet",
+                "--region",
+                region,
+                "--subnet-id",
+                subnet,
+            ],
+        )
+        .await;
+    }
+    // Internet gateways: detach, then delete.
+    let igws = capture_lossy(
+        "aws",
+        &[
+            "ec2",
+            "describe-internet-gateways",
+            "--region",
+            region,
+            "--filters",
+            &format!("Name=attachment.vpc-id,Values={vpc}"),
+            "--query",
+            "InternetGateways[].InternetGatewayId",
+            "--output",
+            "text",
+        ],
+    )
+    .await;
+    for igw in igws.split_whitespace() {
+        println!(">>>     Detaching internet gateway: {igw}");
+        let _ = run_quiet(
+            "aws",
+            &[
+                "ec2",
+                "detach-internet-gateway",
+                "--region",
+                region,
+                "--internet-gateway-id",
+                igw,
+                "--vpc-id",
+                vpc,
+            ],
+        )
+        .await;
+        println!(">>>     Deleting internet gateway: {igw}");
+        let _ = run_quiet(
+            "aws",
+            &[
+                "ec2",
+                "delete-internet-gateway",
+                "--region",
+                region,
+                "--internet-gateway-id",
+                igw,
+            ],
+        )
+        .await;
+    }
+    // Route tables (skip the main).
+    let main_rt = capture_lossy(
+        "aws",
+        &[
+            "ec2",
+            "describe-route-tables",
+            "--region",
+            region,
+            "--filters",
+            &format!("Name=vpc-id,Values={vpc}"),
+            "Name=main,Values=true",
+            "--query",
+            "RouteTables[0].RouteTableId",
+            "--output",
+            "text",
+        ],
+    )
+    .await
+    .trim()
+    .to_string();
+    let rts = capture_lossy(
+        "aws",
+        &[
+            "ec2",
+            "describe-route-tables",
+            "--region",
+            region,
+            "--filters",
+            &format!("Name=vpc-id,Values={vpc}"),
+            "--query",
+            "RouteTables[].RouteTableId",
+            "--output",
+            "text",
+        ],
+    )
+    .await;
+    for rt in rts.split_whitespace() {
+        if rt == main_rt {
+            continue;
+        }
+        println!(">>>     Deleting route table: {rt}");
+        let _ = run_quiet(
+            "aws",
+            &[
+                "ec2",
+                "delete-route-table",
+                "--region",
+                region,
+                "--route-table-id",
+                rt,
+            ],
+        )
+        .await;
+    }
+    // Security groups reference each other: strip all rules, then delete.
+    let sgs = capture_lossy(
+        "aws",
+        &[
+            "ec2",
+            "describe-security-groups",
+            "--region",
+            region,
+            "--filters",
+            &format!("Name=vpc-id,Values={vpc}"),
+            "--query",
+            "SecurityGroups[?GroupName!=`default`].GroupId",
+            "--output",
+            "text",
+        ],
+    )
+    .await;
+    let sg_list: Vec<String> = sgs.split_whitespace().map(String::from).collect();
+    for sg in &sg_list {
+        let ingress = capture_lossy(
+            "aws",
+            &[
+                "ec2",
+                "describe-security-groups",
+                "--region",
+                region,
+                "--group-ids",
+                sg,
+                "--query",
+                "SecurityGroups[0].IpPermissions",
+                "--output",
+                "json",
+            ],
+        )
+        .await;
+        if ingress.trim() != "[]" && !ingress.trim().is_empty() {
+            let _ = run_quiet(
+                "aws",
+                &[
+                    "ec2",
+                    "revoke-security-group-ingress",
+                    "--region",
+                    region,
+                    "--group-id",
+                    sg,
+                    "--ip-permissions",
+                    ingress.trim(),
+                ],
+            )
+            .await;
+        }
+        let egress = capture_lossy(
+            "aws",
+            &[
+                "ec2",
+                "describe-security-groups",
+                "--region",
+                region,
+                "--group-ids",
+                sg,
+                "--query",
+                "SecurityGroups[0].IpPermissionsEgress",
+                "--output",
+                "json",
+            ],
+        )
+        .await;
+        if egress.trim() != "[]" && !egress.trim().is_empty() {
+            let _ = run_quiet(
+                "aws",
+                &[
+                    "ec2",
+                    "revoke-security-group-egress",
+                    "--region",
+                    region,
+                    "--group-id",
+                    sg,
+                    "--ip-permissions",
+                    egress.trim(),
+                ],
+            )
+            .await;
+        }
+    }
+    for sg in &sg_list {
+        println!(">>>     Deleting security group: {sg}");
+        let _ = run_quiet(
+            "aws",
+            &[
+                "ec2",
+                "delete-security-group",
+                "--region",
+                region,
+                "--group-id",
+                sg,
+            ],
+        )
+        .await;
+    }
+    println!(">>>     Deleting VPC: {vpc}");
+    if !run_quiet(
+        "aws",
+        &["ec2", "delete-vpc", "--region", region, "--vpc-id", vpc],
+    )
+    .await
+    {
+        warn(&format!("Failed to delete VPC {vpc}"));
+    }
+}
+
+/// run_with_stdin, but best-effort (returns success instead of raising).
+async fn run_with_stdin_str(cmd: &str, args: &[&str], input: &str) -> bool {
+    use tokio::io::AsyncWriteExt;
+    let mut child = match Command::new(cmd).args(args).stdin(Stdio::piped()).spawn() {
+        Ok(c) => c,
+        Err(_) => return false,
+    };
+    if let Some(mut stdin) = child.stdin.take() {
+        if stdin.write_all(input.as_bytes()).await.is_err() {
+            return false;
+        }
+    }
+    matches!(child.wait().await, Ok(s) if s.success())
+}
+
+// ── Orchestrator: the nine steps in the script's order ───────────────────────
+
+/// Step 5: delete CAPI provider CRs (the operator uninstalls the
+/// controllers), then wait up to the timeout.
+pub async fn delete_capi_providers(kubeconfig: Option<&str>, timeout_secs: u64) {
+    println!(">>> Deleting CAPI providers...");
+    let kinds = [
+        "addonproviders",
+        "controlplaneproviders",
+        "bootstrapproviders",
+        "infrastructureproviders",
+        "coreproviders",
+    ];
+    let mut deleted_any = false;
+    for kind in kinds {
+        let full = format!("{kind}.operator.cluster.x-k8s.io");
+        let listing = capture_lossy(
+            "kubectl",
+            &kubectl_cmd(kubeconfig, &["get", &full, "-A", "-o", "name"]),
+        )
+        .await;
+        for object in listing.lines().filter_map(|l| l.trim().rsplit('/').next()) {
+            // name may be namespaced "ns/name" already via -o name
+            let ns = object.rsplit('/').nth(1).unwrap_or("default");
+            let name = object.rsplit('/').next().unwrap_or(object);
+            println!(">>>   Deleting {kind}: {name} (namespace: {ns})");
+            let _ = run(
+                "kubectl",
+                &kubectl_cmd(
+                    kubeconfig,
+                    &["delete", &full, name, "-n", ns, "--ignore-not-found"],
+                ),
+            )
+            .await;
+            deleted_any = true;
+        }
+    }
+    if !deleted_any {
+        println!("!   CAPI Operator CRDs not present – skipping provider deletion");
+        return;
+    }
+    println!(">>> Waiting up to {timeout_secs}s for CAPI providers to be removed...");
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(timeout_secs);
+    loop {
+        let mut remaining = 0;
+        for kind in kinds {
+            let full = format!("{kind}.operator.cluster.x-k8s.io");
+            let listing = capture_lossy(
+                "kubectl",
+                &kubectl_cmd(kubeconfig, &["get", &full, "-A", "--no-headers"]),
+            )
+            .await;
+            remaining += listing.lines().filter(|l| !l.trim().is_empty()).count();
+        }
+        if remaining == 0 {
+            println!("✓   All CAPI providers removed");
+            return;
+        }
+        if std::time::Instant::now() >= deadline {
+            warn("Timed out waiting for CAPI providers to be removed – continuing anyway");
+            return;
+        }
+        println!(">>>   {remaining} provider(s) still removing...");
+        tokio::time::sleep(std::time::Duration::from_secs(15)).await;
+    }
+}
+
+/// Steps 6-8: helm releases then secrets (aws path, kubeconfig threaded).
+pub async fn uninstall_helm_and_secrets(cfg: &Config, kubeconfig: Option<&str>) {
+    for release in ["flux", "flux-operator"] {
+        println!(">>> Uninstalling {release} Helm release...");
+        let kc: Vec<&str> = match kubeconfig {
+            Some(k) => vec!["--kubeconfig", k],
+            None => vec![],
+        };
+        let status = {
+            let mut args = kc.clone();
+            args.extend_from_slice(&["status", release, "-n", "flux-system"]);
+            capture_lossy("helm", &args).await
+        };
+        if status.trim().is_empty() || status.contains("not found") || status.contains("Error") {
+            println!("!   {release} Helm release not found – skipping");
+            continue;
+        }
+        let mut args = kc.clone();
+        args.extend_from_slice(&[
+            "uninstall",
+            release,
+            "--namespace",
+            "flux-system",
+            "--wait",
+            "--timeout",
+            "5m0s",
+        ]);
+        if run("helm", &args).await.is_ok() {
+            println!("✓   {release} Helm release uninstalled");
+        } else {
+            warn(&format!("{release} Helm release could not be uninstalled"));
+        }
+    }
+
+    println!(">>> Deleting GitHub PAT and SOPS age secrets...");
+    let ns = &cfg.repo.bootstrap.flux_namespace;
+    let pat = &cfg.repo.bootstrap.github_pat_secret;
+    let age = &cfg.repo.bootstrap.sops_age_secret;
+    for secret in [pat.as_str(), age.as_str(), "aws-credentials"] {
+        let namespace = if secret == "aws-credentials" {
+            "capa-system"
+        } else {
+            ns
+        };
+        let _ = run(
+            "kubectl",
+            &kubectl_cmd(
+                kubeconfig,
+                &[
+                    "delete",
+                    "secret",
+                    secret,
+                    "-n",
+                    namespace,
+                    "--ignore-not-found",
+                ],
+            ),
+        )
+        .await;
+    }
+    println!("✓   Secrets deleted (or were already absent)");
+}
+
+/// local-host: remove the self-managed mgmt's containers at the engine
+/// level (validated live 2026-09-01; a cluster cannot delete its own
+/// Cluster object cleanly).
+pub async fn remove_local_mgmt_containers(engine: &str, prefix: &str) {
+    let listing = capture_lossy(engine, &["ps", "-a", "--format", "{{.Names}}"]).await;
+    let targets: Vec<&str> = listing
+        .lines()
+        .map(str::trim)
+        .filter(|n| n.starts_with(prefix))
+        .collect();
+    if targets.is_empty() {
+        println!(">>> No '{prefix}*' containers found – management cluster already gone");
+        return;
+    }
+    let target_refs: Vec<&str> = targets.clone();
+    println!(
+        ">>> Removing self-managed management cluster containers: {}",
+        target_refs.join(", ")
+    );
+    let mut args = vec!["rm", "-f"];
+    args.extend(target_refs);
+    if run(engine, &args).await.is_ok() {
+        println!("✓   management cluster containers removed");
+    } else {
+        warn("some management cluster containers could not be removed");
+    }
+}
+
+/// local-host registry removal (best-effort, engine may be down).
+pub async fn remove_registry_container(engine: Option<&str>, name: &str) {
+    let Some(engine) = engine else {
+        println!("!   Container engine unavailable; registry cleanup skipped");
+        return;
+    };
+    let listing = capture_lossy(
+        engine,
+        &[
+            "ps",
+            "-a",
+            "--filter",
+            &format!("name=^{name}$"),
+            "--format",
+            "{{.Names}}",
+        ],
+    )
+    .await;
+    if !listing.lines().any(|l| l.trim() == name) {
+        return;
+    }
+    println!(">>> Removing local registry container '{name}'...");
+    if run(engine, &["rm", "-f", name]).await.is_ok() {
+        println!("✓   registry container '{name}' removed");
+    } else {
+        warn("registry container could not be removed");
+    }
+}
+
+/// The full teardown run. Mirrors teardown.sh's flow with the
+/// post-pivot controller-host resolution.
+#[allow(clippy::too_many_arguments)]
+pub async fn run_teardown(cfg: &Config, tcfg: &TeardownConfig) -> Result<()> {
+    let env = &cfg.environment;
+    let td = &env.teardown;
+
+    // Never let the AWS CLI open an interactive pager.
+    std::env::set_var("AWS_PAGER", "");
+
+    // ── Preflight: tools and mode rules ───────────────────────────────
+    let aws_available = run_quiet("aws", &["--version"]).await;
+    if tcfg.aws_only {
+        if !aws_available {
+            bail!("aws CLI not found in PATH (required for AWS_ONLY mode)");
+        }
+        println!(">>> AWS_ONLY mode – k8s tools not required");
+    } else if !aws_available {
+        eprintln!("!   aws CLI not found – AWS orphan cleanup (step 4) will be skipped");
+    }
+
+    // local-host path.
+    if cfg.is_local() {
+        if tcfg.aws_only {
+            bail!("AWS_ONLY=1 cannot be combined with the local-host profile\n       Use the AWS profile for AWS-only orphan cleanup");
+        }
+        let engine = detect_engine().await;
+        let kind_present = run_quiet("kind", &["get", "clusters"]).await
+            && capture_lossy("kind", &["get", "clusters"])
+                .await
+                .lines()
+                .any(|l| l.trim() == cfg.repo.bootstrap.kind_cluster);
+
+        let kc: Option<String> = if kind_present {
+            // The kind context is switched to and becomes current; the
+            // k8s calls run without --kubeconfig.
+            let _ = run(
+                "kubectl",
+                &["config", "use-context", &cfg.repo.bootstrap.kind_context],
+            )
+            .await;
+            None
+        } else {
+            // Post-pivot: the self-managed mgmt kubeconfig.
+            let kc_path = tcfg.mgmt_kubeconfig.to_string_lossy().into_owned();
+            if tcfg.mgmt_kubeconfig.exists() {
+                Some(kc_path)
+            } else {
+                None
+            }
+        };
+
+        // Suspend the workload Kustomization (prevents Flux recreating
+        // the Cluster while CAPD removes its machines), then delete the
+        // workload clusters, then remove the controller host.
+        if let Some(kc) = kc.as_deref() {
+            let _ = run(
+                "kubectl",
+                &kubectl_cmd(
+                    Some(kc),
+                    &[
+                        "patch",
+                        "kustomization/docker-workload-cluster",
+                        "-n",
+                        "flux-system",
+                        "--type",
+                        "merge",
+                        "-p",
+                        r#"{"spec":{"suspend":true}}"#,
+                    ],
+                ),
+            )
+            .await;
+            delete_capi_workloads(Some(kc), &td.capi_workloads, 300).await?;
+        } else if kind_present {
+            delete_capi_workloads(None, &td.capi_workloads, 300).await?;
+        } else {
+            println!(">>> No reachable management cluster; skipping CAPI workload deletion");
+        }
+
+        // Remove the controller host under the guard.
+        if kind_present {
+            // Workload clusters confirmed gone (or the deletion above
+            // would have refused); delete kind.
+            println!(
+                ">>> Deleting kind management cluster '{}'...",
+                cfg.repo.bootstrap.kind_cluster
+            );
+            let kind_name = cfg.repo.bootstrap.kind_cluster.clone();
+            if run("kind", &["delete", "cluster", "--name", &kind_name])
+                .await
+                .is_ok()
+            {
+                println!("✓   kind cluster '{kind_name}' deleted");
+            } else {
+                warn("kind cluster could not be deleted – it may already be gone");
+            }
+        } else if let Some(prefix) = td.mgmt_container_prefix.as_deref() {
+            if let Some(engine) = engine.as_deref() {
+                remove_local_mgmt_containers(engine, prefix).await;
+            } else {
+                println!("!   Container engine unavailable; management container cleanup skipped");
+            }
+        }
+
+        if let Some(engine) = engine.as_deref() {
+            remove_registry_container(Some(engine), &cfg.repo.bootstrap.registry_name).await;
+        } else {
+            remove_registry_container(None, &cfg.repo.bootstrap.registry_name).await;
+        }
+        println!();
+        println!("✓ Teardown complete.");
+        return Ok(());
+    }
+
+    // ── aws path ──────────────────────────────────────────────────────
+    let host = if tcfg.aws_only {
+        ControllerHost::Unreachable
+    } else {
+        discover_controller_host(cfg).await
+    };
+    if !tcfg.aws_only && host == ControllerHost::Unreachable {
+        eprintln!("!   Cannot reach the management cluster. It may already be gone.");
+        eprintln!("!   Running AWS orphan cleanup only. To skip this warning, set AWS_ONLY=1.");
+        println!();
+    }
+
+    let kc: Option<String> = match &host {
+        ControllerHost::Kind => None,
+        ControllerHost::SelfManaged => Some(tcfg.mgmt_kubeconfig.to_string_lossy().into_owned()),
+        ControllerHost::Unreachable => None,
+    };
+
+    // Steps 1-3 (k8s side): suspend Flux, delete workload clusters, wait.
+    let mut clusters_gone = true;
+    if !tcfg.aws_only {
+        if host != ControllerHost::Unreachable {
+            suspend_flux(kc.as_deref()).await?;
+            clusters_gone = delete_aws_workload_clusters(
+                kc.as_deref(),
+                &env.mgmt_cluster,
+                tcfg.cluster_delete_timeout,
+            )
+            .await?;
+        } else {
+            println!(">>> No reachable management cluster – skipping k8s steps");
+        }
+    }
+
+    // Step 4: AWS orphan sweep (workloads, then the mgmt itself).
+    if aws_available {
+        println!(">>> Cleaning up orphaned AWS resources...");
+        let mut targets: Vec<AwsSweepTarget> = td
+            .aws_workloads
+            .iter()
+            .map(AwsSweepTarget::from_workload)
+            .collect();
+        // The self-managed mgmt joins the sweep (post-pivot semantics):
+        // its EKS cluster is removed AWS-side, never via its own API.
+        if let (Some(eks), Some(prefix)) = (
+            td.mgmt_eks_cluster_name.as_deref(),
+            td.mgmt_iam_role_prefix.as_deref(),
+        ) {
+            let region = env
+                .mgmt_cluster
+                .split('-')
+                .take(3)
+                .collect::<Vec<_>>()
+                .join("-");
+            targets.push(AwsSweepTarget::mgmt(&region, prefix, eks));
+        }
+        // 4a+4b: associations + nodegroups in all regions, then wait.
+        for target in &targets {
+            println!(
+                ">>>   [{}] cluster: {}",
+                target.region, target.eks_cluster_name
+            );
+            cleanup_pod_identity_associations(target).await;
+            cleanup_nodegroups(target).await;
+        }
+        for target in &targets {
+            wait_nodegroups_deleted(target).await;
+        }
+        // 4c: EKS clusters, all regions, then wait.
+        for target in &targets {
+            cleanup_eks_cluster(target).await;
+        }
+        for target in &targets {
+            wait_eks_cluster_deleted(target).await;
+        }
+        // 4d: RDS.
+        for target in &targets {
+            cleanup_rds_instance(target).await;
+        }
+        // 4e: VPC resources (CAPA-tagged).
+        for target in &targets {
+            cleanup_vpc_resources(target).await;
+        }
+        // 4f: S3 buckets.
+        let account = capture_lossy(
+            "aws",
+            &[
+                "sts",
+                "get-caller-identity",
+                "--query",
+                "Account",
+                "--output",
+                "text",
+            ],
+        )
+        .await
+        .trim()
+        .to_string();
+        if !account.is_empty() {
+            if let Some(pattern) = cfg.repo.teardown.s3_bucket_pattern.as_deref() {
+                for target in &targets {
+                    cleanup_s3_bucket(&target.bucket_name(pattern, &account), &target.region).await;
+                }
+            }
+        } else {
+            warn("Could not determine AWS account ID – skipping S3 bucket cleanup");
+        }
+        // 4g: IAM (per-cluster prefix sweeps + global lists).
+        for target in &targets {
+            cleanup_capa_iam_roles(&target.cluster_name).await;
+        }
+        for role in &cfg.repo.teardown.global_iam_roles {
+            cleanup_iam_role(role).await;
+        }
+        for user in &cfg.repo.teardown.global_iam_users {
+            cleanup_iam_user(user).await;
+        }
+        // 4h: CFN stack.
+        if let Some(stack) = cfg.repo.teardown.cfn_stack_name.as_deref() {
+            let regions: Vec<String> = targets.iter().map(|t| t.region.clone()).collect();
+            for region in regions {
+                cleanup_cfn_stack(stack, &region).await;
+            }
+        }
+        println!("✓   AWS orphan cleanup complete");
+    }
+
+    // Steps 5-8 (k8s side) on the controller host.
+    if !tcfg.aws_only && host != ControllerHost::Unreachable {
+        delete_capi_providers(kc.as_deref(), tcfg.provider_delete_timeout).await;
+        uninstall_helm_and_secrets(cfg, kc.as_deref()).await;
+    }
+
+    // Step 9: remove the controller host under the guard.
+    if !tcfg.aws_only {
+        let guard = HostGuard::resolve(clusters_gone, tcfg.force_host_delete);
+        match guard {
+            HostGuard::Refuse => {
+                eprintln!();
+                eprintln!("{}", HostGuard::refusal_message("the management cluster"));
+            }
+            HostGuard::ConfirmedGone | HostGuard::Forced => match host {
+                ControllerHost::Kind => {
+                    let name = cfg.repo.bootstrap.kind_cluster.clone();
+                    println!(">>> Deleting kind management cluster '{name}'...");
+                    if run("kind", &["delete", "cluster", "--name", &name])
+                        .await
+                        .is_ok()
+                    {
+                        println!("✓   kind cluster '{name}' deleted");
+                    } else {
+                        warn("kind cluster could not be deleted – it may already be gone");
+                    }
+                }
+                ControllerHost::SelfManaged => {
+                    // The mgmt EKS cluster was removed by the sweep above
+                    // (or never existed); nothing k8s-side remains.
+                    println!(">>> Management cluster removed via the AWS orphan sweep");
+                }
+                ControllerHost::Unreachable => {
+                    println!(">>> No controller host to remove");
+                }
+            },
+        }
+    }
+
+    println!();
+    println!("✓ Teardown complete.");
+    Ok(())
+}
+
+/// Detect the container engine the way bootstrap.sh does (docker with
+/// podman re-detection, then podman). None when no engine is running.
+pub async fn detect_engine() -> Option<String> {
+    if let Ok(engine) = std::env::var("CONTAINER_ENGINE") {
+        if !engine.is_empty() {
+            if run_quiet(&engine, &["info"]).await {
+                return Some(engine);
+            }
+            eprintln!(">>> WARNING: {engine} is unavailable; registry cleanup will be skipped");
+            return None;
+        }
+    }
+    if run_quiet("docker", &["info"]).await {
+        let version = capture_lossy("docker", &["--version"]).await;
+        if version.to_lowercase().contains("podman") {
+            return Some("podman".into());
+        }
+        return Some("docker".into());
+    }
+    if run_quiet("podman", &["info"]).await {
+        return Some("podman".into());
+    }
+    eprintln!(">>> WARNING: No running container engine found; registry cleanup will be skipped");
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn guard_resolves_the_script_contract() {
+        // CLUSTERS_CONFIRMED_GONE / FORCE_KIND_DELETE truth table.
+        assert_eq!(HostGuard::resolve(true, false), HostGuard::ConfirmedGone);
+        assert_eq!(HostGuard::resolve(false, false), HostGuard::Refuse);
+        assert_eq!(HostGuard::resolve(false, true), HostGuard::Forced);
+        // Force wins even when clusters are gone (Forced, not ConfirmedGone).
+        assert_eq!(HostGuard::resolve(true, true), HostGuard::Forced);
+    }
+
+    #[test]
+    fn refusal_message_keeps_the_script_wording() {
+        let msg = HostGuard::refusal_message("the management cluster");
+        assert!(msg.contains("Refusing to delete the management cluster"));
+        assert!(msg.contains("FORCE_KIND_DELETE=1"));
+        assert!(msg.contains("kubectl get clusters -A' is empty"));
+    }
+
+    #[test]
+    fn s3_bucket_name_substitutes_the_config_pattern() {
+        assert_eq!(
+            s3_bucket_name(
+                "knr-ops-{account_id}-{cluster_name}-data",
+                "123456789012",
+                "eu-north-1-workload"
+            ),
+            "knr-ops-123456789012-eu-north-1-workload-data"
+        );
+    }
+
+    #[test]
+    fn capa_tag_key_matches_the_provider_format() {
+        assert_eq!(
+            capa_tag_key("eu-north-1-workload"),
+            "sigs.k8s.io/cluster-api-provider-aws/cluster/eu-north-1-workload"
+        );
+    }
+
+    #[test]
+    fn teardown_knobs_follow_shell_boolean_semantics() {
+        // Literal "1" enables; anything else (0, yes, true) does not.
+        let on = |v: Option<&str>| {
+            TeardownConfig::from_env(|name| {
+                if name == "AWS_ONLY" {
+                    v.map(String::from)
+                } else {
+                    None
+                }
+            })
+            .unwrap()
+            .aws_only
+        };
+        assert!(on(Some("1")));
+        assert!(!on(Some("0")));
+        assert!(!on(Some("true")));
+        assert!(!on(None));
+    }
+
+    #[test]
+    fn teardown_timeouts_parse_and_default() {
+        let cfg = TeardownConfig::from_env(|_| None).unwrap();
+        assert_eq!(cfg.cluster_delete_timeout, 1200);
+        assert_eq!(cfg.provider_delete_timeout, 300);
+        let cfg = TeardownConfig::from_env(|name| {
+            (name == "CLUSTER_DELETE_TIMEOUT").then(|| "60".to_string())
+        })
+        .unwrap();
+        assert_eq!(cfg.cluster_delete_timeout, 60);
+    }
+
+    #[test]
+    fn teardown_rejects_non_numeric_timeouts() {
+        assert!(TeardownConfig::from_env(|name| {
+            (name == "CLUSTER_DELETE_TIMEOUT").then(|| "forever".to_string())
+        })
+        .is_err());
+    }
+
+    #[test]
+    fn aws_sweep_target_derives_the_mgmt_entry() {
+        let t = AwsSweepTarget::mgmt(
+            "eu-north-1",
+            "eu-north-1-management",
+            "default_eu-north-1-management-control-plane",
+        );
+        assert_eq!(t.capa_tag_key(), capa_tag_key("eu-north-1-management"));
+        assert_eq!(
+            t.bucket_name("knr-ops-{account_id}-{cluster_name}-data", "acct"),
+            "knr-ops-acct-eu-north-1-management-data"
+        );
+    }
+}

--- a/bootstrap-rs/src/teardown.rs
+++ b/bootstrap-rs/src/teardown.rs
@@ -165,7 +165,9 @@ impl HostGuard {
 // ── Step helpers ──────────────────────────────────────────────────────────────
 
 /// Step 1: suspend Flux Kustomizations on the controller host so nothing
-/// recreates deleted resources mid-teardown.
+/// recreates deleted resources mid-teardown. Patch failures are warned
+/// (the script's "Could not suspend some Kustomizations – continuing
+/// anyway"), not fatal.
 pub async fn suspend_flux(kubeconfig: Option<&str>) -> Result<()> {
     println!(">>> Suspending Flux Kustomizations to prevent re-reconciliation...");
     let names = capture_lossy(
@@ -187,8 +189,9 @@ pub async fn suspend_flux(kubeconfig: Option<&str>) -> Result<()> {
         println!("!   No Flux Kustomizations found – skipping suspension");
         return Ok(());
     }
+    let mut failed = 0;
     for ks in names.lines().filter_map(|l| l.trim().rsplit('/').next()) {
-        let _ = run(
+        if run(
             "kubectl",
             &kubectl_cmd(
                 kubeconfig,
@@ -204,7 +207,14 @@ pub async fn suspend_flux(kubeconfig: Option<&str>) -> Result<()> {
                 ],
             ),
         )
-        .await;
+        .await
+        .is_err()
+        {
+            failed += 1;
+        }
+    }
+    if failed > 0 {
+        eprintln!("!   Could not suspend some Kustomizations – continuing anyway");
     }
     println!("✓   Flux Kustomizations suspended");
     Ok(())
@@ -307,7 +317,8 @@ pub async fn delete_aws_workload_clusters(
     }
     println!(">>> Waiting up to {timeout_secs}s for the workload clusters to be deleted...");
     println!(">>> (This typically takes 15–25 minutes while CAPA tears down AWS resources)");
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(timeout_secs);
+    let start = std::time::Instant::now();
+    let deadline = start + std::time::Duration::from_secs(timeout_secs);
     loop {
         let remaining: Vec<String> = capture_lossy(
             "kubectl",
@@ -323,12 +334,24 @@ pub async fn delete_aws_workload_clusters(
             println!("✓   All CAPI workload clusters deleted");
             return Ok(true);
         }
+        let elapsed = start.elapsed().as_secs();
         if std::time::Instant::now() >= deadline {
-            eprintln!("!   Timed out waiting for CAPI clusters to be deleted");
+            eprintln!("!   Timed out waiting for CAPI clusters to be deleted after {elapsed}s");
             eprintln!("!   The following clusters still exist: {remaining:?}");
+            eprintln!(
+                "!   ABORTING teardown. The management cluster and CAPA controller have been"
+            );
+            eprintln!("!   left intact so AWS resources can continue to deprovision. Re-run this");
+            eprintln!("!   once 'kubectl get clusters -A' is empty (or FORCE_KIND_DELETE=1 to");
+            eprintln!(
+                "!   force-delete the management cluster and accept orphaned AWS resources)."
+            );
             return Ok(false);
         }
-        println!(">>>   {} cluster(s) still deleting...", remaining.len());
+        println!(
+            ">>>   {} cluster(s) still deleting... ({elapsed}s elapsed, checking again in 30s)",
+            remaining.len()
+        );
         tokio::time::sleep(std::time::Duration::from_secs(30)).await;
     }
 }
@@ -351,6 +374,29 @@ pub fn s3_bucket_name(pattern: &str, account_id: &str, cluster_name: &str) -> St
 
 fn warn(msg: &str) {
     eprintln!("!   {msg}");
+}
+
+/// `command -v` equivalent: true when the binary cannot be found or is
+/// not executable on PATH (the script's preflight probe).
+async fn which_failure(cmd: &str) -> bool {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let Some(path) = std::env::var_os("PATH") else {
+            return true;
+        };
+        !std::env::split_paths(&path).any(|dir| {
+            let candidate = dir.join(cmd);
+            candidate
+                .metadata()
+                .map(|m| m.permissions().mode() & 0o111 != 0)
+                .unwrap_or(false)
+        })
+    }
+    #[cfg(not(unix))]
+    {
+        !run_quiet(cmd, &["--version"]).await
+    }
 }
 
 /// One AWS workload (or the management cluster itself) expressed as the
@@ -1346,15 +1392,34 @@ pub async fn delete_capi_providers(kubeconfig: Option<&str>, timeout_secs: u64) 
     let mut deleted_any = false;
     for kind in kinds {
         let full = format!("{kind}.operator.cluster.x-k8s.io");
+        // The script's jsonpath: `ns/name` per line (-o name never
+        // includes the namespace for cluster-scoped listings).
         let listing = capture_lossy(
             "kubectl",
-            &kubectl_cmd(kubeconfig, &["get", &full, "-A", "-o", "name"]),
+            &kubectl_cmd(
+                kubeconfig,
+                &[
+                    "get",
+                    &full,
+                    "-A",
+                    "-o",
+                    "jsonpath={range .items[*]}{.metadata.namespace}/{.metadata.name}{\"\\n\"}{end}",
+                ],
+            ),
         )
         .await;
-        for object in listing.lines().filter_map(|l| l.trim().rsplit('/').next()) {
-            // name may be namespaced "ns/name" already via -o name
-            let ns = object.rsplit('/').nth(1).unwrap_or("default");
-            let name = object.rsplit('/').next().unwrap_or(object);
+        for object in listing.lines().filter_map(|l| {
+            let l = l.trim();
+            if l.is_empty() {
+                None
+            } else {
+                Some(l)
+            }
+        }) {
+            let (ns, name) = match object.split_once('/') {
+                Some((ns, name)) => (ns, name),
+                None => ("default", object),
+            };
             println!(">>>   Deleting {kind}: {name} (namespace: {ns})");
             let _ = run(
                 "kubectl",
@@ -1528,14 +1593,40 @@ pub async fn run_teardown(cfg: &Config, tcfg: &TeardownConfig) -> Result<()> {
     std::env::set_var("AWS_PAGER", "");
 
     // ── Preflight: tools and mode rules ───────────────────────────────
+    // The script's tool preflight, restored: hard-fail on a missing tool
+    // BEFORE any mutation. A PATH problem must never downgrade the aws
+    // path into a blind AWS-only sweep against a live world.
     let aws_available = run_quiet("aws", &["--version"]).await;
     if tcfg.aws_only {
         if !aws_available {
             bail!("aws CLI not found in PATH (required for AWS_ONLY mode)");
         }
         println!(">>> AWS_ONLY mode – k8s tools not required");
-    } else if !aws_available {
-        eprintln!("!   aws CLI not found – AWS orphan cleanup (step 4) will be skipped");
+    } else if cfg.is_local() {
+        for cmd in ["kind", "kubectl"] {
+            if !run_quiet(cmd, &["--version"]).await && cmd != "kind" {
+                bail!("{cmd} not found in PATH");
+            }
+            // kind has no --version that succeeds without docker; probe
+            // the binary itself (the script uses command -v).
+            if cmd == "kind" && which_failure(cmd).await {
+                bail!("{cmd} not found in PATH");
+            }
+        }
+        if !aws_available {
+            eprintln!("!   aws CLI not found – AWS orphan cleanup (step 4) will be skipped");
+        }
+    } else {
+        for cmd in ["kind", "helm", "kubectl", "xargs"] {
+            if which_failure(cmd).await {
+                bail!("{cmd} not found in PATH");
+            }
+        }
+        if aws_available {
+            println!(">>> aws CLI available");
+        } else {
+            eprintln!("!   aws CLI not found – AWS orphan cleanup (step 4) will be skipped");
+        }
     }
 
     // local-host path.
@@ -1661,6 +1752,12 @@ pub async fn run_teardown(cfg: &Config, tcfg: &TeardownConfig) -> Result<()> {
                 tcfg.cluster_delete_timeout,
             )
             .await?;
+            if !clusters_gone {
+                // The script aborts here (exit 1): the remaining steps
+                // must not run while CAPA is mid-deprovision, and the
+                // run must report failure to automation.
+                bail!("teardown aborted: CAPI workload clusters did not finish deleting; the management cluster and CAPA controller were left intact so AWS resources can continue deprovisioning");
+            }
         } else {
             println!(">>> No reachable management cluster – skipping k8s steps");
         }

--- a/bootstrap.toml
+++ b/bootstrap.toml
@@ -39,6 +39,28 @@ cert-manager = "1.21.1"
 # renovate: datasource=helm registryUrl=https://kubernetes-sigs.github.io/cluster-api-operator depName=cluster-api-operator
 capi-operator = "0.28.0"
 
+[teardown]
+# Constants for `knr-bootstrap teardown` (issue #100), mirroring the literal
+# lists in teardown.sh; tests/test-bootstrap-config.py cross-checks them
+# against the Git manifests that define the same names.
+# CloudFormation stack created by `clusterawsadm bootstrap iam`.
+cfn-stack-name = "cluster-api-provider-aws-sigs-k8s-io"
+# Region-independent IAM roles: the ACK controller pod-identity roles
+# (mgmt/aws/infrastructure/ack-pod-identity/) and the per-cluster reader
+# roles created by the workload ACK IAM controllers.
+global-iam-roles = [
+  "knr-ops-ack-s3-controller",
+  "knr-ops-ack-rds-controller",
+  "knr-ops-ack-iam-controller",
+  "knr-ops-eu-north-1-workload-reader",
+  "knr-ops-eu-west-1-workload-reader",
+]
+# The console reader user created by the management cluster's ACK IAM
+# controller (mgmt/aws/infrastructure/aws-global-iam/reader-user.yaml).
+global-iam-users = ["knr-ops-reader"]
+# S3 bucket pattern (workload/base/s3-buckets/bucket.yaml).
+s3-bucket-pattern = "knr-ops-{account_id}-{cluster_name}-data"
+
 [environments.local-host]
 kind = "local-host"
 sync-path = "mgmt/local-host"
@@ -54,6 +76,15 @@ provider-manifests = [
   "mgmt/local-host/capi-providers/caaph-system/namespace.yaml",
   "mgmt/local-host/capi-providers/caaph-system/provider.yaml",
 ]
+
+[environments.local-host.teardown]
+# CAPD workload clusters deleted before the management cluster; their
+# Kustomization is suspended first so Flux does not recreate them.
+capi-workloads = ["local-workload"]
+# The self-managed management cluster is removed at the container level
+# (a cluster cannot delete its own Cluster object cleanly): its node/lb
+# containers share this prefix.
+mgmt-container-prefix = "local-management"
 
 [environments.aws]
 kind = "aws"
@@ -77,3 +108,24 @@ provider-manifests = [
 resource = "awsclustercontrolleridentities.infrastructure.cluster.x-k8s.io"
 name = "default"
 manifest = "mgmt/aws/infrastructure/aws-identity/identity.yaml"
+
+[environments.aws.teardown]
+# The self-managed management cluster (post-pivot) is removed through the
+# AWS orphan sweep, never via its own Cluster object: deleting it from
+# itself kills the CAPA controller mid-delete. Its names join the sweep.
+mgmt-eks-cluster-name = "default_eu-north-1-management-control-plane"
+mgmt-iam-role-prefix = "eu-north-1-management"
+# Workload clusters the orphan sweep visits (order: file order = sweep
+# order). Names mirror the Kustomization namePrefixes and the cluster-vars
+# substitutions in mgmt/aws/addons/flux-apps/flux-instance.yaml.
+[[environments.aws.teardown.aws-workloads]]
+region = "eu-north-1"
+cluster-name = "eu-north-1-workload"
+eks-cluster-name = "default_eu-north-1-workload-control-plane"
+rds-instance = "knr-ops-eu-north-1-workload-db"
+
+[[environments.aws.teardown.aws-workloads]]
+region = "eu-west-1"
+cluster-name = "eu-west-1-workload"
+eks-cluster-name = "default_eu-west-1-workload-control-plane"
+rds-instance = "knr-ops-eu-west-1-workload-db"

--- a/tests/test-bootstrap-config.py
+++ b/tests/test-bootstrap-config.py
@@ -86,6 +86,72 @@ def main() -> int:
                     f"{fallback.get('manifest')}"
                 )
 
+        # ── teardown constants (issue #100) ─────────────────────────────
+        td = env.get("teardown", {})
+        for workload in td.get("aws-workloads", []):
+            region = workload.get("region", "")
+            prefix_dir = REPO_ROOT / "mgmt/aws/clusters" / region
+            if not prefix_dir.is_dir():
+                failures.append(f"environments.{name} teardown region {region!r} has no cluster directory")
+            # The K8s cluster name must equal the Kustomization namePrefix
+            # + 'workload' (the staged cluster.yaml names Cluster 'workload').
+            kustomization = prefix_dir / "staging/kustomization.yaml"
+            if kustomization.is_file():
+                text = kustomization.read_text()
+                expected_prefix = f"namePrefix: {region}-"
+                if expected_prefix not in text:
+                    failures.append(
+                        f"environments.{name} teardown: {kustomization.relative_to(REPO_ROOT)} "
+                        f"lacks '{expected_prefix}'"
+                    )
+            cluster_name = workload.get("cluster-name", "")
+            if cluster_name and not cluster_name.startswith(region):
+                failures.append(
+                    f"environments.{name} teardown cluster-name {cluster_name!r} "
+                    f"does not start with its region {region!r}"
+                )
+            # The RDS instance id is knr-ops-<cluster>-db (workload/base/
+            # rds-instances/dbinstance.yaml substitutes CLUSTER_NAME).
+            rds = workload.get("rds-instance", "")
+            if cluster_name and rds != f"knr-ops-{cluster_name}-db":
+                failures.append(
+                    f"environments.{name} teardown rds-instance {rds!r} != "
+                    f"knr-ops-{cluster_name}-db"
+                )
+            # The EKS name is '<namespace>_<kcp-name>' — only the namespace
+            # separator becomes an underscore (teardown.sh documents this
+            # against the live account; the KCP name keeps its dashes).
+            eks = workload.get("eks-cluster-name", "")
+            expected_eks = f"default_{cluster_name}-control-plane"
+            if cluster_name and eks != expected_eks:
+                failures.append(
+                    f"environments.{name} teardown eks-cluster-name {eks!r} != "
+                    f"{expected_eks}"
+                )
+
+    # Global teardown constants pin to the manifests that define them.
+    teardown = config.get("teardown", {})
+    if teardown:
+        expected_roles = [
+            "knr-ops-ack-s3-controller",
+            "knr-ops-ack-rds-controller",
+            "knr-ops-ack-iam-controller",
+        ]
+        roles = teardown.get("global-iam-roles", [])
+        for role in expected_roles:
+            if role not in roles:
+                failures.append(f"teardown.global-iam-roles missing {role}")
+        reader_user = REPO_ROOT / "mgmt/aws/infrastructure/aws-global-iam/reader-user.yaml"
+        users = teardown.get("global-iam-users", [])
+        if reader_user.is_file() and "knr-ops-reader" not in users:
+            failures.append("teardown.global-iam-users missing knr-ops-reader")
+        pattern = teardown.get("s3-bucket-pattern", "")
+        if pattern and "{account_id}" not in pattern or "{cluster_name}" not in pattern:
+            failures.append(
+                f"teardown.s3-bucket-pattern {pattern!r} must contain "
+                "{account_id} and {cluster_name}"
+            )
+
     if failures:
         print("bootstrap.toml cross-check FAILED:")
         for failure in failures:


### PR DESCRIPTION
## Summary

Ports `teardown.sh` (977 lines) into `knr-bootstrap teardown`, implementing #100 per the design resolved on the issue (issuecomment-5495441273). Two commits, mirroring the #98 contract/consumption split:

1. **`feat: add teardown constants to bootstrap.toml and cross-check them`** — a `[teardown]` section (CFN stack name, global IAM roles/users, S3 bucket pattern) and per-environment `[environments.<name>.teardown]` blocks (aws: per-region workload resource names + the management cluster's own sweep entries; local-host: CAPI workload list + mgmt container prefix). The Python cross-check pins every name to the Git manifests that define it: Kustomization namePrefixes, the RDS instance pattern, the EKS naming rule (namespace separator to underscore), the ACK pod-identity roles, the reader user. The cross-check caught one derivation error during development (EKS name keeps dashes in the resource part).
2. **`feat: port teardown.sh into knr-bootstrap as the teardown subcommand`** — the full port (~1700 lines of Rust).

## Design decisions implemented

- **Entry shape**: `knr-bootstrap teardown [PROFILE]` subcommand on the single binary (docs/bootstrap-cli.md's single-binary commitment). Profile resolution identical to the bootstrap path (KNR_OPS_PROFILE > positional > config default, file-order error listing).
- **AWS interaction**: shell out to the `aws` CLI, parity with every other spawned tool; per-resource units keep best-effort semantics (skip-if-absent, warn-and-continue), steps gating host deletion are strict.
- **Post-pivot semantics**: `ControllerHost` discovery (kind present = pre-pivot; `knr-ops-mgmt` kubeconfig reachable = post-pivot; neither = AWS-only). The deletion guard (`CLUSTERS_CONFIRMED_GONE` / `FORCE_KIND_DELETE` contract) protects whichever host the controllers run on. local-host removes the self-managed mgmt at the container level (prefix from config) — the path validated live on 2026-09-01 during the #79 work; aws removes the mgmt EKS cluster through the orphan sweep (its names join the sweep targets from config), never via its own Cluster object.
- **Knobs**: env-only (`AWS_ONLY`, `FORCE_KIND_DELETE`, `CLUSTER_DELETE_TIMEOUT`, `PROVIDER_DELETE_TIMEOUT`, `MGMT_KUBECONFIG`), literal-`1` boolean semantics matching the script's shell gates; `cli_rejects_deferred_flags` pins the reduced surface (`--aws-only`/`--force-kind-delete` fail to parse).

## Verification

- `cargo build/clippy --locked --all-targets -D warnings/test` green: **42/42 tests** (8 new: guard truth table, refusal message wording, bucket/tag derivations, shell-boolean knob semantics, timeout parsing/rejection, mgmt sweep entry derivation); `cargo fmt --check` clean.
- `mise run validate` green (bootstrap.toml cross-check included).
- Behavioral probes against the built binary, all with the script's exact wording and nonzero exits: AWS_ONLY+local-host refusal, unknown profile listing file-order environments, AWS_ONLY without aws CLI on PATH, `--help` rendering the subcommand.

## Not run (deliberately)

The destructive happy paths (live local-host teardown, aws sweep). The local-host teardown sequence itself was validated live on 2026-09-01 (manual, during #79 close-out: suspend Flux, delete workload cluster, wait, container-level mgmt removal, registry last) — this port encodes that sequence. A full-parity teardown run per environment remains the retirement gate for `teardown.sh` (issue acceptance criterion), tracked with #92's parity runs.

Refs #100. Milestone 2-rust-bootstrap.
