### PR TITLE
fix: probe tool existence, not execution, in the local-host teardown preflight

### DIFF
--- a/bootstrap-rs/src/teardown.rs
+++ b/bootstrap-rs/src/teardown.rs
@@ -1595,20 +1595,18 @@ pub async fn run_teardown(cfg: &Config, tcfg: &TeardownConfig) -> Result<()> {
     // The script's tool preflight, restored: hard-fail on a missing tool
     // BEFORE any mutation. A PATH problem must never downgrade the aws
     // path into a blind AWS-only sweep against a live world.
-    let aws_available = run_quiet("aws", &["--version"]).await;
+    let aws_available = !which_failure("aws").await;
     if tcfg.aws_only {
         if !aws_available {
             bail!("aws CLI not found in PATH (required for AWS_ONLY mode)");
         }
         println!(">>> AWS_ONLY mode – k8s tools not required");
     } else if cfg.is_local() {
+        // The script probes existence (command -v) for both tools; probing
+        // execution instead breaks on kubectl, which rejects --version as
+        // an unknown flag and would fail preflight on every host.
         for cmd in ["kind", "kubectl"] {
-            if !run_quiet(cmd, &["--version"]).await && cmd != "kind" {
-                bail!("{cmd} not found in PATH");
-            }
-            // kind has no --version that succeeds without docker; probe
-            // the binary itself (the script uses command -v).
-            if cmd == "kind" && which_failure(cmd).await {
+            if which_failure(cmd).await {
                 bail!("{cmd} not found in PATH");
             }
         }


### PR DESCRIPTION
## Summary

The local-host teardown preflight merged in #145 probed tool liveness with `kubectl --version`, which kubectl rejects as an unknown flag. `run_quiet` therefore returned false and the binary bailed `kubectl not found in PATH` on every host with kubectl present: the local-host teardown path was unrunnable as merged.

The script's probe is `command -v` (existence). This PR switches the local-host loop to the same `which_failure` existence check the aws path already uses, and moves the aws-availability probe to existence as well (parity with the script's `command -v aws`).

## How it was found

The first #100 local-host parity run: the binary refused to start against a live world with all tools present. #145's own probes never caught it because they exercised the aws path (`which_failure`) and the refusal wording, never a real local-host tool loop.

## Verification

- [x] `cargo fmt --check`, `clippy --locked --all-targets -D warnings`, `cargo test --locked` 43/43 green
- [x] Live: `knr-bootstrap teardown local-host` now passes preflight and completed the full local-host teardown run (evidence comment on #100 follows)
- [x] The `--version` probe remains only in the `#[cfg(not(unix))]` fallback where it is the only option

Refs #100. Milestone 2-rust-bootstrap.
