### PR TITLE
feat: add the knr-ops toolbox image (Dockerfile, CI build, tag release, Renovate surfaces)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+# Keep the toolbox image context (docker build -f bootstrap-rs/Dockerfile .)
+# to what the image actually needs: bootstrap-rs sources + mise configs.
+*
+!bootstrap-rs/
+!bootstrap-rs/src/
+!bootstrap-rs/Cargo.toml
+!bootstrap-rs/Cargo.lock
+!bootstrap-rs/rust-toolchain.toml
+!mise.toml
+!mise.aws.toml
+# Never ship build artifacts, secrets, or git history in the context.
+bootstrap-rs/target/
+.env
+age.agekey
+.git

--- a/.github/workflows/bootstrap-rs.yml
+++ b/.github/workflows/bootstrap-rs.yml
@@ -85,7 +85,10 @@ jobs:
 
       - name: Smoke the image (binary + tools on PATH)
         run: |
-          docker run --rm --entrypoint sh knr-ops-toolbox:ci -c '
+          # /workspace has no bootstrap.toml in CI (the repo is mounted
+          # there at runtime); --help must be probed from the checkout.
+          docker run --rm --entrypoint sh -v "$PWD:/workspace:ro" \
+            -w /workspace knr-ops-toolbox:ci -c '
             for t in kind kubectl helm clusterctl flux sops age aws docker xargs git curl; do
               command -v "$t" >/dev/null || { echo "::error::$t missing on PATH"; exit 1; }
             done

--- a/.github/workflows/bootstrap-rs.yml
+++ b/.github/workflows/bootstrap-rs.yml
@@ -6,10 +6,16 @@ on:
     branches: [main]
     paths:
       - "bootstrap-rs/**"
+      - "mise.toml"
+      - "mise.aws.toml"
+      - ".dockerignore"
       - ".github/workflows/bootstrap-rs.yml"
   pull_request:
     paths:
       - "bootstrap-rs/**"
+      - "mise.toml"
+      - "mise.aws.toml"
+      - ".dockerignore"
       - ".github/workflows/bootstrap-rs.yml"
 
 permissions:

--- a/.github/workflows/bootstrap-rs.yml
+++ b/.github/workflows/bootstrap-rs.yml
@@ -56,3 +56,37 @@ jobs:
 
       - name: Test
         run: cargo test --locked
+
+  docker:
+    name: Docker image build
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7.0.1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4.3.0
+
+      # Rot protection for the toolbox image (issue #104): the image
+      # cannot silently break between releases. Loads only; the release
+      # workflow (toolbox-release.yml) pushes.
+      - name: Build the toolbox image (load only)
+        uses: docker/build-push-action@v7.3.0
+        with:
+          context: .
+          file: bootstrap-rs/Dockerfile
+          platforms: linux/arm64
+          push: false
+          load: true
+          tags: knr-ops-toolbox:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Smoke the image (binary + tools on PATH)
+        run: |
+          docker run --rm --entrypoint sh knr-ops-toolbox:ci -c '
+            for t in kind kubectl helm clusterctl flux sops age aws docker xargs git curl; do
+              command -v "$t" >/dev/null || { echo "::error::$t missing on PATH"; exit 1; }
+            done
+            knr-bootstrap --help >/dev/null'

--- a/.github/workflows/toolbox-release.yml
+++ b/.github/workflows/toolbox-release.yml
@@ -1,0 +1,133 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: toolbox-release
+
+# Publishes ghcr.io/polarsquad/knr-ops-toolbox on semver tags (issue #104).
+# The tag must equal the version in bootstrap-rs/Cargo.toml; the gate job
+# fails the release when they disagree. Signing is cosign keyless via the
+# workflow's GitHub OIDC identity (same identity model as the air-gapped
+# workflow's keyless-signed Zarf packages); the SBOM is Syft, matching the
+# Zarf bundle's per-component SBOMs.
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: toolbox-release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  gate:
+    name: Tag matches Cargo.toml version
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7.0.1
+
+      - name: Fail if tag and Cargo.toml disagree
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          cargo_version=$(sed -n 's/^version = "\(.*\)"$/\1/p' bootstrap-rs/Cargo.toml | head -1)
+          if [ "$tag" != "$cargo_version" ]; then
+            echo "::error::tag v${tag} does not match bootstrap-rs/Cargo.toml version ${cargo_version}"
+            exit 1
+          fi
+          echo "tag v${tag} matches Cargo.toml ${cargo_version}"
+
+  publish:
+    name: Build, push, sign, attest
+    needs: gate
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7.0.1
+
+      - name: Docker login to GHCR
+        uses: docker/login-action@v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Docker metadata (X.Y.Z, X.Y, latest)
+        id: meta
+        uses: docker/metadata-action@v6.2.0
+        with:
+          images: ghcr.io/polarsquad/knr-ops-toolbox
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern=latest
+
+      - name: Set up QEMU (linux/amd64 cross-build)
+        uses: docker/setup-qemu-action@v4.3.0
+        with:
+          platforms: amd64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4.3.0
+
+      - name: Build and push multi-arch
+        id: build
+        uses: docker/build-push-action@v7.3.0
+        with:
+          context: .
+          file: bootstrap-rs/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v4.1.2
+
+      - name: Install syft
+        uses: anchore/sbom-action/download-syft@v0.24.2
+
+      - name: Sign the image (keyless, workflow identity)
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          # Sign each tag's digest; verification is against the workflow
+          # identity (certificate issuer/subject per cosign docs):
+          #   cosign verify ghcr.io/polarsquad/knr-ops-toolbox:X.Y.Z \
+          #     --certificate-identity-regexp \
+          #       '^https://github.com/polarsquad/knr-ops/.github/workflows/toolbox-release.yml@refs/tags/vX.Y.Z$' \
+          #     --certificate-oidc-issuer https://token.actions.githubusercontent.com
+          digest="${{ steps.build.outputs.digest }}"
+          IFS=',' read -ra tag_list <<< "$TAGS"
+          for tag in "${tag_list[@]}"; do
+            ref="${tag}@${digest}"
+            echo "signing ${ref}"
+            cosign sign --yes "${ref}"
+          done
+
+      - name: Attach SBOM (Syft) to each tag
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          digest="${{ steps.build.outputs.digest }}"
+          IFS=',' read -ra tag_list <<< "$TAGS"
+          for tag in "${tag_list[@]}"; do
+            ref="${tag}@${digest}"
+            syft "${ref}" -o spdx-json > sbom.json
+            cosign attest --yes --predicate sbom.json --type spdxjson "${ref}"
+            echo "SBOM attested to ${ref}"
+          done
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: toolbox-sbom-spdx
+          path: sbom.json
+          retention-days: 30

--- a/.github/workflows/toolbox-release.yml
+++ b/.github/workflows/toolbox-release.yml
@@ -62,10 +62,11 @@ jobs:
         uses: docker/metadata-action@v6.2.0
         with:
           images: ghcr.io/polarsquad/knr-ops-toolbox
+          # The default latest=auto flavor adds latest for stable semver
+          # tags without moving it for prereleases.
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern=latest
 
       - name: Set up QEMU (linux/amd64 cross-build)
         uses: docker/setup-qemu-action@v4.3.0

--- a/bootstrap-rs/Dockerfile
+++ b/bootstrap-rs/Dockerfile
@@ -1,0 +1,80 @@
+# knr-ops toolbox image (issue #104).
+#
+# Ships knr-bootstrap plus the full pinned tool layer so a host needs only
+# a container engine to run the whole bootstrap lifecycle. Tool versions
+# are single-sourced from the committed mise configs (Renovate-managed
+# there, never duplicated into this file); the CLI is compiled with the
+# toolchain pinned in bootstrap-rs/rust-toolchain.toml.
+#
+# Build (from the repository root; the context is the repo root):
+#   docker build -f bootstrap-rs/Dockerfile -t knr-ops-toolbox:dev .
+#
+# Base image digests and the mise CLI pin are Renovate-managed
+# (dockerfile manager with pinDigests, and the jdx/mise custom manager
+# extended to this file's ARG MISE_VERSION line).
+
+# ── Stage 1: compile knr-bootstrap with the pinned toolchain ──────────────
+# slim-bookworm matches the runtime stage's glibc (bookworm, 2.36): a
+# binary built on the default rust image (trixie, glibc 2.39) fails on
+# bookworm with "GLIBC_2.39 not found".
+FROM rust:1.98.0-slim-bookworm@sha256:1469a27c125cb5a3aebfa4f4e4665d935b02fb72cc093b2c974b3d740e43f157 AS build
+
+WORKDIR /build
+COPY bootstrap-rs/ ./bootstrap-rs/
+RUN cd bootstrap-rs && cargo build --locked --release \
+    && cp target/release/knr-bootstrap /usr/local/bin/knr-bootstrap
+
+# ── Stage 2: runtime with the pinned tool layer ───────────────────────────
+FROM debian:bookworm-slim@sha256:88200866dfff7ea7f5cbcb6ec7c8a701889efe6fe859fe64d6990e4b07ea4171
+
+# renovate: datasource=github-releases depName=jdx/mise extractVersion=^v(?<version>.+) versioning=semver
+ARG MISE_VERSION=2026.8.10
+# Set by BuildKit: "amd64" or "arm64".
+ARG TARGETARCH
+
+# docker-ce-cli (client only) comes from Docker's apt repo: bookworm has no
+# standalone docker-cli package, and docker.io would drag in the whole
+# engine. The client floats with the repo (client/server API is backward
+# compatible; the daemon always runs on the host).
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates curl git jq findutils gnupg \
+    && install -d -m 0755 /etc/apt/keyrings \
+    && curl -fsSL https://download.docker.com/linux/debian/gpg \
+         -o /etc/apt/keyrings/docker.asc \
+    && chmod a+r /etc/apt/keyrings/docker.asc \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian bookworm stable" \
+         > /etc/apt/sources.list.d/docker.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends docker-ce-cli \
+    && rm -rf /var/lib/apt/lists/* \
+    && case "${TARGETARCH}" in \
+         amd64) MISE_ASSET=mise-v${MISE_VERSION}-linux-x64 ;; \
+         arm64) MISE_ASSET=mise-v${MISE_VERSION}-linux-arm64 ;; \
+         *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+       esac \
+    && curl -fsSL "https://github.com/jdx/mise/releases/download/v${MISE_VERSION}/${MISE_ASSET}" \
+         -o /usr/local/bin/mise \
+    && chmod +x /usr/local/bin/mise
+
+# The repository is mounted at /workspace at run time; mise runs from the
+# working directory with both env layers available (aws tools per the #104
+# decision: one image, credentials arrive at runtime).
+ENV MISE_DATA_DIR=/usr/local/share/mise \
+    MISE_YES=1 \
+    PATH=/usr/local/share/mise/shims:/usr/local/bin:/usr/bin:/sbin:/bin
+
+COPY --from=build /usr/local/bin/knr-bootstrap /usr/local/bin/knr-bootstrap
+COPY mise.toml mise.aws.toml /opt/knr-ops/
+
+# Install every tool the configs pin except the dev-only toolchains the
+# lifecycle never invokes (go, python, zarf: airgap builds run on the
+# host, not inside the toolbox). The aws layer (aws-cli, clusterawsadm)
+# installs too; credentials arrive at runtime.
+RUN cd /opt/knr-ops \
+    && mise install -y kind helm kubectl clusterctl flux2 sops age \
+    && mise -E aws install -y aws-cli clusterawsadm \
+    && mise reshim
+
+WORKDIR /workspace
+ENTRYPOINT ["/usr/local/bin/knr-bootstrap"]

--- a/renovate.json5
+++ b/renovate.json5
@@ -158,6 +158,16 @@
     },
     {
       "customType": "regex",
+      "description": "toolbox image: mise CLI pin (issue #104)",
+      "managerFilePatterns": ["bootstrap-rs/Dockerfile"],
+      "matchStrings": ["ARG MISE_VERSION=(?<currentValue>[0-9][^\\s]*)"],
+      "depNameTemplate": "jdx/mise",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.+)",
+      "autoReplaceStringTemplate": "ARG MISE_VERSION={{newValue}}"
+    },
+    {
+      "customType": "regex",
       "description": "mise: aws-cli pin (floating latest tag)",
       "managerFilePatterns": ["/(^|/)mise\\.aws\\.toml$/"],
       "matchStrings": ["aws-cli = \"(?<currentValue>[^\"]+)\""],
@@ -307,6 +317,12 @@
       "description": "Pin air-gap container images by digest while retaining readable tags",
       "matchDatasources": ["docker"],
       "matchFileNames": ["airgap/images.txt", "airgap/zarf.yaml"],
+      "pinDigests": true
+    },
+    {
+      "description": "Pin toolbox image base images by digest (issue #104)",
+      "matchDatasources": ["docker"],
+      "matchFileNames": ["bootstrap-rs/Dockerfile"],
       "pinDigests": true
     },
     {


### PR DESCRIPTION
## Summary

First PR of #104: the toolbox image definition, its CI rot protection, the tag-driven release workflow, and the Renovate surfaces.

Multi-stage `bootstrap-rs/Dockerfile`:

- **Build stage**: `rust:1.98.0-slim-bookworm` (digest-pinned), matching the runtime glibc. The default `rust` image targets trixie/glibc 2.39 and the produced binary fails on bookworm with `GLIBC_2.39 not found` (found by actually running the image). Compiles `knr-bootstrap --locked --release` under the toolchain pinned in `rust-toolchain.toml`.
- **Runtime stage**: `debian:bookworm-slim` (digest-pinned) with the pinned tool layer installed via mise from the committed configs: single-sourced, Renovate-managed there, never duplicated into the Dockerfile. Both env layers per the #104 decision (aws-cli, clusterawsadm baked in; credentials arrive at runtime). `docker-ce-cli` included: kind talks to the host engine through the mounted socket. Dev-only toolchains (go, python, zarf) are excluded; the lifecycle never invokes them.
- `.dockerignore` keeps the repo-root context to the sources + mise configs.

**CI** (bootstrap-rs workflow): a Docker image build job (linux/arm64, load only) with a PATH smoke test covering all twelve lifecycle tools, so the image cannot silently break between releases.

**Release** (toolbox-release workflow): semver tag push -> gate job (tag must equal `bootstrap-rs/Cargo.toml` version) -> multi-arch (amd64 via QEMU, arm64 native) build and push to `ghcr.io/polarsquad/knr-ops-toolbox` (X.Y.Z, X.Y, latest), cosign keyless signing via the workflow's GitHub OIDC identity, Syft SPDX SBOM attested per tag and uploaded as an artifact.

**Renovate surfaces** (dry-run proven):

- dockerfile manager extracts both FROM pins with `pinDigests` (new packageRule for `bootstrap-rs/Dockerfile`).
- New regex manager for `ARG MISE_VERSION=` (jdx/mise, github-releases) alongside the existing `min_version` self-pin.

Proof (renovate 44.50.1, node 24, `--platform=local --dry-run=full`): `packageFiles` shows `dockerfile → bootstrap-rs/Dockerfile` with both deps (rust 1.98.0-slim-bookworm@sha256:1469a…, debian bookworm-slim@sha256:88200…) and the regex manager extracting `ARG MISE_VERSION=2026.8.10` → jdx/mise; zero "Failed to look up".

## Verification

- [x] `docker build` green locally (linux/arm64), image 1.15 GB
- [x] All twelve lifecycle tools resolve on PATH inside the image (kind kubectl helm clusterctl flux sops age aws docker xargs git curl)
- [x] `knr-bootstrap --help` runs against the image (correctly demands bootstrap.toml in the mounted workspace)
- [x] `renovate-config-validator` green; Renovate dry-run proof above
- [x] CI green (including the new Docker image build job)

Follow-up PRs (stacked on this): docs and mise-task wiring.

Refs #104. Milestone 2-rust-bootstrap.
