### PR TITLE
feat: run the full bootstrap lifecycle inside the toolbox container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,6 +6,7 @@
 !bootstrap-rs/Cargo.toml
 !bootstrap-rs/Cargo.lock
 !bootstrap-rs/rust-toolchain.toml
+!bootstrap-rs/toolbox-entrypoint.sh
 !mise.toml
 !mise.aws.toml
 # Never ship build artifacts, secrets, or git history in the context.

--- a/.github/workflows/bootstrap-rs.yml
+++ b/.github/workflows/bootstrap-rs.yml
@@ -8,6 +8,7 @@ on:
       - "bootstrap-rs/**"
       - "mise.toml"
       - "mise.aws.toml"
+      - "mise.local-host.toml"
       - ".dockerignore"
       - ".github/workflows/bootstrap-rs.yml"
   pull_request:
@@ -15,6 +16,7 @@ on:
       - "bootstrap-rs/**"
       - "mise.toml"
       - "mise.aws.toml"
+      - "mise.local-host.toml"
       - ".dockerignore"
       - ".github/workflows/bootstrap-rs.yml"
 

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ age.agekey
 
 # Generated local Cluster API workload kubeconfig
 local-workload.kubeconfig
+# Toolbox container kubeconfig state (scripts/toolbox-run.sh)
+.kube/
 airgap/archives/
 airgap/rendered/
 airgap/sbom/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,8 +50,10 @@ resources. There is no app source code here, only declarative infrastructure.
   `rust-toolchain.toml`.
 - `bootstrap.sh` / `pivot.sh` / `teardown.sh`: the shell equivalents of the
   CLI's phases. Kept until the binary completes full parity runs per
-  environment, then retired (issues #92/#95/#100). `mise run bootstrap` and
-  `mise run pivot` still invoke the scripts.
+  environment, then retired (issues #92/#95/#100). The lifecycle mise tasks
+  (`bootstrap`/`pivot`/`teardown`) run the knr-ops-toolbox container via
+  `scripts/toolbox-run.sh` (issue #104); the scripts remain the native path
+  for development.
 - `docs/`: detailed documentation (see the table in README.md).
 - `mise.toml`: pinned tool versions and all task entrypoints.
   `mise.aws.toml` is the AWS tool layer (aws-cli, clusterawsadm),
@@ -109,9 +111,9 @@ Each component pairs a plain kustomize root with a Flux `Kustomization`:
 ```sh
 mise install            # install pinned tools (kubectl, kind, flux, sops, age, ...)
 mise run validate       # build every kustomize overlay; mirrors CI
-mise run bootstrap      # one-time kind cluster + Flux handoff + pivot to self-managed mgmt
+mise run bootstrap      # toolbox container: kind cluster + Flux handoff + pivot to self-managed mgmt
 mise -E aws run kubeconfigs  # export AWS workload-cluster kubeconfigs
-mise run teardown       # full teardown (EKS, AWS resources, kind)
+mise run teardown       # toolbox container: full teardown (EKS, AWS resources, kind)
 ```
 
 ## Editing renovate.json5

--- a/README.md
+++ b/README.md
@@ -77,9 +77,18 @@ not a developer self-service portal; you are the consumer.
 
 ## Prerequisites
 
+The toolbox container is the primary interface (issue #104): the only host
+prerequisite is a running container engine.
+
+- A running Docker engine, or Podman 5.5+ (kind creates the clusters through
+  the engine socket the toolbox mounts)
+- The toolbox image: `ghcr.io/polarsquad/knr-ops-toolbox` (published on semver
+  tags), or built locally with
+  `docker build -f bootstrap-rs/Dockerfile -t knr-ops-toolbox:dev .`
+
+The native host path (development and air-gap work) additionally needs:
+
 - Mise 2026.8.10 or newer
-- A running Docker engine, or Podman 5.5+, for kind; the local-host
-  environment also uses it for its local OCI registry
 - Rust toolchain (via [rustup](https://rustup.rs/); the exact pin lives in
   `bootstrap-rs/rust-toolchain.toml`) to build the bootstrap CLI
 - AWS environment only: GitHub personal access token (PAT) with read access
@@ -88,6 +97,27 @@ not a developer self-service portal; you are the consumer.
   environment
 
 ## Quickstart
+
+With only a container engine (the primary interface, issue #104):
+
+```sh
+cp .env.example .env        # AWS environment only: fill in GitHub PAT and AWS settings
+docker run --rm -it \
+  -v "$PWD:/workspace" -w /workspace \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -v "$PWD/.kube:/root/.kube" \
+  -e KUBECONFIG=/workspace/.kube/kind.yaml \
+  ghcr.io/polarsquad/knr-ops-toolbox:latest
+# teardown: same invocation with `teardown` appended
+```
+
+`scripts/toolbox-run.sh` wraps the invocation (engine and socket detection,
+`.env` passthrough, repo-local kubeconfig state); `mise run bootstrap` and
+`mise run teardown` call it for hosts that already have mise. See
+[docs/operations.md](docs/operations.md) for the Podman form and the full
+runtime contract.
+
+The native host path (development):
 
 ```sh
 mise trust                  # to enable mise in this repository

--- a/bootstrap-rs/Dockerfile
+++ b/bootstrap-rs/Dockerfile
@@ -89,4 +89,4 @@ RUN cd /opt/knr-ops \
     && mise reshim
 
 WORKDIR /workspace
-ENTRYPOINT ["/usr/local/bin/knr-bootstrap"]
+ENTRYPOINT ["/usr/local/bin/toolbox-entrypoint.sh"]

--- a/bootstrap-rs/Dockerfile
+++ b/bootstrap-rs/Dockerfile
@@ -35,7 +35,12 @@ ARG TARGETARCH
 # docker-ce-cli (client only) comes from Docker's apt repo: bookworm has no
 # standalone docker-cli package, and docker.io would drag in the whole
 # engine. The client floats with the repo (client/server API is backward
-# compatible; the daemon always runs on the host).
+# compatible; the daemon always runs on the host). The podman remote client
+# (static build) provides the podman provider path kind and knr-bootstrap
+# exec (CONTAINER_ENGINE=podman); it talks to the host socket the run
+# invocation mounts.
+# renovate: datasource=github-releases depName=containers/podman extractVersion=^v(?<version>.+) versioning=semver
+ARG PODMAN_VERSION=5.5.2
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates curl git jq findutils gnupg \
@@ -55,7 +60,11 @@ RUN apt-get update \
        esac \
     && curl -fsSL "https://github.com/jdx/mise/releases/download/v${MISE_VERSION}/${MISE_ASSET}" \
          -o /usr/local/bin/mise \
-    && chmod +x /usr/local/bin/mise
+    && chmod +x /usr/local/bin/mise \
+    && curl -fsSL "https://github.com/containers/podman/releases/download/v${PODMAN_VERSION}/podman-remote-static-linux_${TARGETARCH}.tar.gz" \
+         | tar -xz -C /tmp --strip-components=1 "bin/podman-remote-static-linux_${TARGETARCH}" \
+    && mv "/tmp/podman-remote-static-linux_${TARGETARCH}" /usr/local/bin/podman \
+    && chmod +x /usr/local/bin/podman
 
 # The repository is mounted at /workspace at run time; mise runs from the
 # working directory with both env layers available (aws tools per the #104
@@ -65,7 +74,10 @@ ENV MISE_DATA_DIR=/usr/local/share/mise \
     PATH=/usr/local/share/mise/shims:/usr/local/bin:/usr/bin:/sbin:/bin
 
 COPY --from=build /usr/local/bin/knr-bootstrap /usr/local/bin/knr-bootstrap
+COPY bootstrap-rs/toolbox-entrypoint.sh /usr/local/bin/toolbox-entrypoint.sh
 COPY mise.toml mise.aws.toml /opt/knr-ops/
+
+RUN chmod +x /usr/local/bin/toolbox-entrypoint.sh
 
 # Install every tool the configs pin except the dev-only toolchains the
 # lifecycle never invokes (go, python, zarf: airgap builds run on the

--- a/bootstrap-rs/src/main.rs
+++ b/bootstrap-rs/src/main.rs
@@ -757,7 +757,9 @@ fn toolbox_container_id() -> Option<String> {
 
 /// Attach the toolbox container to the kind network so kind-network
 /// endpoints (the internal API server, knr-registry:5000) resolve.
-/// Idempotent: an already-attached container is success.
+/// Idempotent: docker exits 0 on re-attach, but podman errors with "is
+/// already connected", so failures are retried against a captured-error
+/// check instead of string-matching the (inherited) stderr.
 pub(crate) async fn toolbox_join_kind_network(cfg: &Config, engine: &str) -> Result<()> {
     if !cfg.toolbox {
         return Ok(());
@@ -765,12 +767,26 @@ pub(crate) async fn toolbox_join_kind_network(cfg: &Config, engine: &str) -> Res
     let Some(id) = toolbox_container_id() else {
         bail!("KNR_TOOLBOX=1 but /etc/hostname is unreadable; cannot join the kind network");
     };
-    match capture(engine, &["network", "connect", "kind", &id]).await {
-        Ok(_) => Ok(()),
-        // docker: "already exists in network"; podman: "is already connected"
-        Err(e) if e.to_string().contains("already") => Ok(()),
-        Err(e) => Err(e).context("attaching the toolbox to the kind network failed"),
+    let out = Command::new(engine)
+        .args(["network", "connect", "kind", &id])
+        .stderr(Stdio::piped())
+        .output()
+        .await
+        .with_context(|| format!("failed to spawn '{engine}'"))?;
+    if out.status.success() {
+        return Ok(());
     }
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    // docker: "already exists in network"; podman: "is already connected"
+    // (or "already connected" on newer releases).
+    if stderr.to_lowercase().contains("already") {
+        return Ok(());
+    }
+    bail!(
+        "'{engine} network connect kind {id}' failed with {}:\n{}",
+        out.status,
+        stderr.trim_end()
+    );
 }
 
 /// Best-effort detach before `kind delete cluster`: kind removes the network
@@ -931,7 +947,7 @@ async fn bootstrap_local_registry(
             ],
         )
         .await?;
-        println!("    Registry created and running: localhost:{port}");
+        println!("    Registry created and running: {registry_name}:5000");
     } else {
         // Name match alone proves nothing about configuration. Verify the
         // host-port binding and the kind-network attachment; a stale
@@ -971,7 +987,7 @@ async fn bootstrap_local_registry(
                 ],
             )
             .await?;
-            println!("    Registry recreated: localhost:{port}");
+            println!("    Registry recreated: {registry_name}:5000");
         } else {
             let running = capture_lossy(
                 engine,
@@ -983,14 +999,16 @@ async fn bootstrap_local_registry(
             if !running {
                 println!("    Restarting stopped registry...");
                 capture(engine, &["start", registry_name]).await?;
-                println!("    Registry restarted: localhost:{port}");
+                println!("    Registry restarted: {registry_name}:5000");
             } else {
-                println!("    Registry already running: localhost:{port}");
+                println!("    Registry already running: {registry_name}:5000");
             }
         }
     }
 
-    println!(">>> Waiting for local registry API at {registry_name}:5000...");
+    let (registry_host, probe_port) = cfg.registry_endpoint();
+    let registry_url = format!("http://{registry_host}:{probe_port}/v2/");
+    println!(">>> Waiting for local registry API at {registry_host}:{probe_port}...");
     // Parity with the script's `curl --fail --retry N --retry-connrefused
     // --retry-delay 1`: one initial attempt plus N retries 1s apart; any
     // response below 400 succeeds (curl --fail's threshold); connection
@@ -999,8 +1017,6 @@ async fn bootstrap_local_registry(
     // answer fails immediately instead of burning the retry budget.
     // The probe address is where THIS process reaches the registry: the
     // kind-network name inside the toolbox, the published port on the host.
-    let (registry_host, probe_port) = cfg.registry_endpoint();
-    let registry_url = format!("http://{registry_host}:{probe_port}/v2/");
     let mut ready = false;
     for attempt in 0..=cfg.registry_ready_retries {
         if let Ok(resp) = http.get(&registry_url).send().await {
@@ -2144,6 +2160,12 @@ async fn pivot_delete_bootstrap_cluster(
     }
 
     println!(">>> Deleting the kind bootstrap cluster...");
+    // The toolbox must leave the kind network first: kind removes the
+    // network with the last node, and an attached toolbox container would
+    // keep it alive (same guard as --recreate and teardown).
+    if let Some(engine) = detect_engine_for_network(cfg).await {
+        toolbox_leave_kind_network(cfg, &engine).await;
+    }
     run(
         "kind",
         &[

--- a/bootstrap-rs/src/main.rs
+++ b/bootstrap-rs/src/main.rs
@@ -134,6 +134,8 @@ struct Config {
     registry_ready_retries: u32,
     local_reconcile_timeout: String,
     container_engine: Option<String>,
+    engine_sock: Option<String>,
+    toolbox: bool,
     git_repo_url: Option<String>,
     github_token: Option<String>,
     github_user: String,
@@ -154,6 +156,22 @@ impl Config {
     /// names are the binary's opinionated contract, kept as literals.
     fn is_local(&self) -> bool {
         self.profile == "local-host"
+    }
+
+    /// Address the local registry from the process running this binary.
+    /// Host runs use the published port; toolbox runs share the kind network.
+    fn registry_endpoint(&self) -> (String, u16) {
+        if self.toolbox {
+            (self.repo.bootstrap.registry_name.clone(), 5000)
+        } else {
+            ("localhost".to_string(), self.registry_port)
+        }
+    }
+
+    /// CAPD kubeconfigs already contain a kind-network endpoint. Host runs
+    /// rewrite it to a published localhost port; toolbox runs keep it intact.
+    fn should_rewrite_capd_endpoint(&self) -> bool {
+        self.is_local() && !self.toolbox
     }
 
     /// Resolve the run configuration from the process environment.
@@ -216,6 +234,8 @@ impl Config {
                 DEFAULT_LOCAL_RECONCILE_TIMEOUT,
             ),
             container_engine: value("CONTAINER_ENGINE"),
+            engine_sock: value("ENGINE_SOCK"),
+            toolbox: with_default("KNR_TOOLBOX", "0") == "1",
             git_repo_url: value("GIT_REPO_URL"),
             github_token: value("GITHUB_TOKEN"),
             github_user: with_default("GITHUB_USER", DEFAULT_GITHUB_USER),
@@ -298,6 +318,34 @@ fn extract_workload_port(port_output: &str) -> Option<String> {
         .and_then(|l| l.rsplit(':').next())
         .map(str::trim)
         .filter(|p| !p.is_empty() && p.chars().all(|c| c.is_ascii_digit()))
+        .map(str::to_string)
+}
+
+fn toolbox_kubeconfig_path(toolbox: bool, kubeconfig: Option<&str>) -> Result<Option<PathBuf>> {
+    if !toolbox {
+        return Ok(None);
+    }
+    let path = kubeconfig
+        .filter(|value| !value.is_empty())
+        .context("KUBECONFIG must name one writable file when KNR_TOOLBOX=1")?;
+    ensure!(
+        !path.contains(':'),
+        "KUBECONFIG must name a single file when KNR_TOOLBOX=1"
+    );
+    Ok(Some(PathBuf::from(path)))
+}
+
+fn internal_kind_kubeconfig_args(name: &str) -> [&str; 5] {
+    ["get", "kubeconfig", "--internal", "--name", name]
+}
+
+/// The `server:` endpoint recorded in a CAPD-exported kubeconfig.
+fn capd_recorded_endpoint(kubeconfig: &str) -> Option<String> {
+    kubeconfig
+        .lines()
+        .find_map(|l| l.trim().strip_prefix("server: "))
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
         .map(str::to_string)
 }
 
@@ -557,7 +605,7 @@ async fn preflight_checks(cfg: &Config, http: &reqwest::Client) -> Result<Prefli
         }
     };
 
-    let engine_sock = match engine.as_str() {
+    let detected_engine_sock = match engine.as_str() {
         "docker" => {
             if !run_quiet("docker", &["info"]).await {
                 bail!("Docker daemon not running");
@@ -587,6 +635,10 @@ async fn preflight_checks(cfg: &Config, http: &reqwest::Client) -> Result<Prefli
         }
         other => bail!("Unsupported CONTAINER_ENGINE '{other}' (expected 'docker' or 'podman')"),
     };
+    // A containerized client can mount the API socket at /var/run/docker.sock
+    // while sibling containers need the daemon-side source path. The launcher
+    // supplies that source as ENGINE_SOCK, especially for remote Podman.
+    let engine_sock = cfg.engine_sock.clone().unwrap_or(detected_engine_sock);
 
     Ok(Preflight {
         engine,
@@ -673,6 +725,65 @@ async fn preflight_aws(cfg: &Config, http: &reqwest::Client) -> Result<AwsContex
 
 // ── Steps ─────────────────────────────────────────────────────────────────────
 
+pub(crate) async fn select_toolbox_kind_kubeconfig(cfg: &Config) -> Result<()> {
+    let kubeconfig = std::env::var("KUBECONFIG").ok();
+    let Some(path) = toolbox_kubeconfig_path(cfg.toolbox, kubeconfig.as_deref())? else {
+        return Ok(());
+    };
+    let args = internal_kind_kubeconfig_args(&cfg.repo.bootstrap.kind_cluster);
+    let contents = capture("kind", &args).await?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+    }
+    std::fs::write(&path, contents)
+        .with_context(|| format!("failed to write {}", path.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
+            .with_context(|| format!("failed to chmod 600 {}", path.display()))?;
+    }
+    Ok(())
+}
+
+/// The toolbox container's own ID (Docker/Podman write it to /etc/hostname).
+fn toolbox_container_id() -> Option<String> {
+    std::fs::read_to_string("/etc/hostname")
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+/// Attach the toolbox container to the kind network so kind-network
+/// endpoints (the internal API server, knr-registry:5000) resolve.
+/// Idempotent: an already-attached container is success.
+pub(crate) async fn toolbox_join_kind_network(cfg: &Config, engine: &str) -> Result<()> {
+    if !cfg.toolbox {
+        return Ok(());
+    }
+    let Some(id) = toolbox_container_id() else {
+        bail!("KNR_TOOLBOX=1 but /etc/hostname is unreadable; cannot join the kind network");
+    };
+    match capture(engine, &["network", "connect", "kind", &id]).await {
+        Ok(_) => Ok(()),
+        // docker: "already exists in network"; podman: "is already connected"
+        Err(e) if e.to_string().contains("already") => Ok(()),
+        Err(e) => Err(e).context("attaching the toolbox to the kind network failed"),
+    }
+}
+
+/// Best-effort detach before `kind delete cluster`: kind removes the network
+/// after the last node, and an attached toolbox would keep it alive.
+pub(crate) async fn toolbox_leave_kind_network(cfg: &Config, engine: &str) {
+    if !cfg.toolbox {
+        return;
+    }
+    if let Some(id) = toolbox_container_id() {
+        let _ = run(engine, &["network", "disconnect", "kind", &id]).await;
+    }
+}
+
 /// Ensure the kind 'mgmt' cluster exists and is healthy.
 ///
 /// Default: reuse an existing cluster after validating that its context is
@@ -685,12 +796,20 @@ async fn ensure_kind_cluster(cfg: &Config, engine_sock: &str) -> Result<()> {
     let clusters = capture_lossy("kind", &["get", "clusters"]).await;
     let exists = clusters.lines().any(|l| l.trim() == kind_cluster);
     let node_ready_timeout = format!("--timeout={NODE_READY_TIMEOUT}");
+    let engine = detect_engine_for_network(cfg).await;
 
     if exists && !cfg.recreate {
         println!(
             ">>> Reusing existing kind cluster '{kind_cluster}' (pass --recreate to replace it)..."
         );
         println!(">>> Validating existing cluster health...");
+        if let Some(engine) = engine.as_deref() {
+            // Idempotent (already-attached is success) and must precede the
+            // kubeconfig selection: the internal endpoint only resolves
+            // once the toolbox is on the kind network.
+            toolbox_join_kind_network(cfg, engine).await?;
+            select_toolbox_kind_kubeconfig(cfg).await?;
+        }
         if !run_quiet("kubectl", &["config", "use-context", kind_context]).await {
             // kind get clusters can report mgmt while the kubeconfig lacks
             // the context (interrupted first create, pruned kubeconfig).
@@ -725,6 +844,9 @@ async fn ensure_kind_cluster(cfg: &Config, engine_sock: &str) -> Result<()> {
 
     if exists {
         println!(">>> Cluster '{kind_cluster}' exists and --recreate was given – recreating...");
+        if let Some(engine) = engine.as_deref() {
+            toolbox_leave_kind_network(cfg, engine).await;
+        }
         run("kind", &["delete", "cluster", "--name", kind_cluster]).await?;
     }
 
@@ -744,6 +866,10 @@ async fn ensure_kind_cluster(cfg: &Config, engine_sock: &str) -> Result<()> {
         &kind_config,
     )
     .await?;
+    if let Some(engine) = engine.as_deref() {
+        toolbox_join_kind_network(cfg, engine).await?;
+    }
+    select_toolbox_kind_kubeconfig(cfg).await?;
 
     println!(">>> Waiting for cluster node to be ready...");
     // Explicitly switch kubectl to use the kind cluster context.
@@ -864,14 +990,17 @@ async fn bootstrap_local_registry(
         }
     }
 
-    println!(">>> Waiting for local registry API at localhost:{port}...");
+    println!(">>> Waiting for local registry API at {registry_name}:5000...");
     // Parity with the script's `curl --fail --retry N --retry-connrefused
     // --retry-delay 1`: one initial attempt plus N retries 1s apart; any
     // response below 400 succeeds (curl --fail's threshold); connection
     // errors (--retry-connrefused) and curl's documented transient
     // statuses (408, 429, 500, 502, 503, 504) are retried; any other
     // answer fails immediately instead of burning the retry budget.
-    let registry_url = format!("http://localhost:{port}/v2/");
+    // The probe address is where THIS process reaches the registry: the
+    // kind-network name inside the toolbox, the published port on the host.
+    let (registry_host, probe_port) = cfg.registry_endpoint();
+    let registry_url = format!("http://{registry_host}:{probe_port}/v2/");
     let mut ready = false;
     for attempt in 0..=cfg.registry_ready_retries {
         if let Ok(resp) = http.get(&registry_url).send().await {
@@ -881,7 +1010,7 @@ async fn bootstrap_local_registry(
                 break;
             }
             if !CURL_TRANSIENT_STATUSES.contains(&status) {
-                bail!("local registry at localhost:{port} returned {status}; not retrying");
+                bail!("local registry at {registry_url} returned {status}; not retrying");
             }
         }
         // Connection errors fall through and are retried (--retry-connrefused).
@@ -890,7 +1019,7 @@ async fn bootstrap_local_registry(
         }
     }
     if !ready {
-        bail!("local registry did not become ready at localhost:{port}");
+        bail!("local registry did not become ready at {registry_url}");
     }
 
     // Tell the cluster about the local registry (apply = rerun-safe).
@@ -911,9 +1040,13 @@ async fn bootstrap_local_registry(
     println!(">>> Publishing initial OCI artifact from the local Git checkout...");
     // Forward the resolved values: the mise oci-push task reads them from
     // its own environment, so they must not stop at this boundary.
+    // REGISTRY_HOST reroutes the task's own registry probe and push from
+    // the published localhost port to the kind-network name (toolbox runs).
+    let (registry_host, oci_port) = cfg.registry_endpoint();
     let status = Command::new("mise")
         .args(["-E", &cfg.profile, "run", "oci-push"])
-        .env("REGISTRY_PORT", cfg.registry_port.to_string())
+        .env("REGISTRY_PORT", oci_port.to_string())
+        .env("REGISTRY_HOST", &registry_host)
         .env("OCI_REPOSITORY", &cfg.oci_repository)
         .env("OCI_TAG", &cfg.oci_tag)
         .status()
@@ -1247,14 +1380,23 @@ async fn watch_local_reconciliation(cfg: &Config, engine: &str) -> Result<()> {
 
     let kubeconfig_content =
         capture("clusterctl", &["get", "kubeconfig", "local-workload"]).await?;
+    let recorded_endpoint = capd_recorded_endpoint(&kubeconfig_content);
     std::fs::write(workload_kubeconfig.path(), kubeconfig_content)?;
 
-    let port_output = capture(engine, &["port", "local-workload-lb", "6443/tcp"]).await?;
-    let Some(workload_port) = extract_workload_port(&port_output) else {
-        bail!("cannot determine the local-workload API server port");
+    // Host runs rewrite the endpoint to the published localhost port; the
+    // toolbox is on the kind network, where the CAPD-recorded endpoint
+    // already resolves, so the kubeconfig is written as-is.
+    let server = if cfg.should_rewrite_capd_endpoint() {
+        let port_output = capture(engine, &["port", "local-workload-lb", "6443/tcp"]).await?;
+        let Some(workload_port) = extract_workload_port(&port_output) else {
+            bail!("cannot determine the local-workload API server port");
+        };
+        format!("https://127.0.0.1:{workload_port}")
+    } else {
+        // Reuse the endpoint recorded by CAPD (kind-network address).
+        recorded_endpoint
+            .context("cannot read the local-workload endpoint from the CAPD kubeconfig")?
     };
-
-    let server = format!("https://127.0.0.1:{workload_port}");
     let kubeconfig_flag = format!("--kubeconfig={kubeconfig_path}");
     capture(
         "kubectl",
@@ -1379,10 +1521,25 @@ async fn watch_local_reconciliation(cfg: &Config, engine: &str) -> Result<()> {
 // The move stays re-runnable: objects are deleted from the source only after
 // they were created on the target, so kind stays authoritative until Phase 6.
 
+/// The engine binary toolbox network attach/detach must invoke. Host runs
+/// never need it; toolbox runs use the selected engine from preflight.
+async fn detect_engine_for_network(cfg: &Config) -> Option<String> {
+    if !cfg.toolbox {
+        return None;
+    }
+    Some(
+        cfg.container_engine
+            .clone()
+            .unwrap_or_else(|| "docker".to_string()),
+    )
+}
+
 /// One readiness probe of the local registry /v2/ endpoint (script: `curl
-/// --fail`): any response below 400 counts as serving.
-async fn registry_reachable(http: &reqwest::Client, port: u16) -> bool {
-    http.get(format!("http://localhost:{port}/v2/"))
+/// --fail`): any response below 400 counts as serving. The toolbox reaches
+/// the registry by network name instead of the published localhost port.
+async fn registry_reachable(cfg: &Config, http: &reqwest::Client) -> bool {
+    let (host, port) = cfg.registry_endpoint();
+    http.get(format!("http://{host}:{port}/v2/"))
         .send()
         .await
         .map(|r| r.status().as_u16() < 400)
@@ -1512,11 +1669,12 @@ async fn pivot_export_kubeconfig(cfg: &Config, engine: &str, mgmt_cluster: &str)
     }
     let kc = path.to_string_lossy().into_owned();
 
-    if cfg.is_local() {
+    if cfg.should_rewrite_capd_endpoint() {
         // CAPD records the load balancer's container-network IP, which is
         // not routable from macOS. Point the kubeconfig at the port
         // published on localhost instead (same rewrite as the workload
-        // kubeconfigs).
+        // kubeconfigs). Toolbox runs stay on the kind network where the
+        // recorded endpoint already resolves, so no rewrite.
         let lb = format!("{mgmt_cluster}-lb");
         let port_output = capture(engine, &["port", &lb, "6443/tcp"]).await?;
         let Some(port) = extract_workload_port(&port_output) else {
@@ -1977,7 +2135,7 @@ async fn pivot_delete_bootstrap_cluster(
         eprintln!("ERROR: no Clusters on the management cluster; refusing to delete kind.");
         bail!("no Clusters on the management cluster; refusing to delete kind");
     }
-    if cfg.is_local() && !registry_reachable(http, cfg.registry_port).await {
+    if cfg.is_local() && !registry_reachable(cfg, http).await {
         eprintln!(
             "ERROR: local registry unavailable; the management cluster's Flux depends on it."
         );
@@ -2030,7 +2188,7 @@ async fn run_pivot(cfg: &Config, preflight: &Preflight, http: &reqwest::Client) 
     // check is not repeated here.
     pivot_check_context(cfg).await?;
     pivot_check_management_cluster(&cfg.repo.bootstrap.mgmt_namespace, mgmt_cluster).await?;
-    if cfg.is_local() && !registry_reachable(http, cfg.registry_port).await {
+    if cfg.is_local() && !registry_reachable(cfg, http).await {
         eprintln!(
             "ERROR: local registry is unavailable at localhost:{}",
             cfg.registry_port
@@ -2107,7 +2265,9 @@ async fn main() -> Result<()> {
             registry_port: DEFAULT_REGISTRY_PORT,
             registry_ready_retries: DEFAULT_REGISTRY_READY_RETRIES,
             local_reconcile_timeout: DEFAULT_LOCAL_RECONCILE_TIMEOUT.to_string(),
-            container_engine: None,
+            container_engine: std::env::var("CONTAINER_ENGINE").ok(),
+            engine_sock: std::env::var("ENGINE_SOCK").ok(),
+            toolbox: std::env::var("KNR_TOOLBOX").is_ok_and(|value| value == "1"),
             git_repo_url: None,
             github_token: None,
             github_user: DEFAULT_GITHUB_USER.to_string(),
@@ -2373,6 +2533,62 @@ mod tests {
         assert_eq!(cfg.mgmt_poll_interval, 5);
         assert_eq!(cfg.mgmt_kubeconfig, PathBuf::from("/tmp/mgmt.yaml"));
         assert_eq!(cfg.bootstrap_kubecontext, "other-ctx");
+    }
+
+    #[test]
+    fn config_reads_toolbox_runtime_knobs() {
+        let cli = Cli::try_parse_from(["knr-bootstrap", "local-host"]).unwrap();
+        let cfg = config_from(&cli, |name| match name {
+            "KNR_TOOLBOX" => Some("1".into()),
+            "ENGINE_SOCK" => Some("/run/user/501/podman/podman.sock".into()),
+            _ => None,
+        });
+
+        assert!(cfg.toolbox);
+        assert_eq!(
+            cfg.engine_sock.as_deref(),
+            Some("/run/user/501/podman/podman.sock")
+        );
+        assert_eq!(cfg.registry_endpoint(), ("knr-registry".into(), 5000));
+        assert!(!cfg.should_rewrite_capd_endpoint());
+    }
+
+    #[test]
+    fn host_runtime_keeps_localhost_endpoints() {
+        let cfg = config_from(
+            &Cli::try_parse_from(["knr-bootstrap", "local-host"]).unwrap(),
+            |_| None,
+        );
+
+        assert!(!cfg.toolbox);
+        assert!(cfg.engine_sock.is_none());
+        assert_eq!(cfg.registry_endpoint(), ("localhost".into(), 5001));
+        assert!(cfg.should_rewrite_capd_endpoint());
+    }
+
+    #[test]
+    fn toolbox_kind_kubeconfig_uses_one_explicit_file() {
+        assert_eq!(
+            toolbox_kubeconfig_path(true, Some("/state/kind.yaml")).unwrap(),
+            Some(PathBuf::from("/state/kind.yaml"))
+        );
+        assert!(toolbox_kubeconfig_path(true, None)
+            .unwrap_err()
+            .to_string()
+            .contains("KUBECONFIG"));
+        assert!(toolbox_kubeconfig_path(true, Some("/a:/b"))
+            .unwrap_err()
+            .to_string()
+            .contains("single file"));
+        assert_eq!(toolbox_kubeconfig_path(false, None).unwrap(), None);
+    }
+
+    #[test]
+    fn internal_kind_kubeconfig_command_targets_the_named_cluster() {
+        assert_eq!(
+            internal_kind_kubeconfig_args("mgmt"),
+            ["get", "kubeconfig", "--internal", "--name", "mgmt"]
+        );
     }
 
     #[test]

--- a/bootstrap-rs/src/teardown.rs
+++ b/bootstrap-rs/src/teardown.rs
@@ -17,7 +17,10 @@ use std::path::PathBuf;
 use std::process::Stdio;
 use tokio::process::Command;
 
-use crate::{capture_lossy, kubectl_cmd, run, run_quiet, Config};
+use crate::{
+    capture_lossy, kubectl_cmd, run, run_quiet, select_toolbox_kind_kubeconfig,
+    toolbox_join_kind_network, toolbox_leave_kind_network, Config,
+};
 
 // ── Configuration knobs (teardown.sh `${VAR:-default}` equivalents) ───────────
 
@@ -1639,8 +1642,16 @@ pub async fn run_teardown(cfg: &Config, tcfg: &TeardownConfig) -> Result<()> {
                 .any(|l| l.trim() == cfg.repo.bootstrap.kind_cluster);
 
         let kc: Option<String> = if kind_present {
-            // The kind context is switched to and becomes current; the
-            // k8s calls run without --kubeconfig.
+            // Toolbox runs: join the kind network so the internal API
+            // endpoint resolves, then rewrite KUBECONFIG to kind's
+            // internal kubeconfig. kubectl picks KUBECONFIG up from the
+            // environment, so the k8s calls below need no --kubeconfig.
+            if cfg.toolbox {
+                if let Some(engine) = engine.as_deref() {
+                    toolbox_join_kind_network(cfg, engine).await?;
+                    select_toolbox_kind_kubeconfig(cfg).await?;
+                }
+            }
             let _ = run(
                 "kubectl",
                 &["config", "use-context", &cfg.repo.bootstrap.kind_context],
@@ -1693,6 +1704,14 @@ pub async fn run_teardown(cfg: &Config, tcfg: &TeardownConfig) -> Result<()> {
                 ">>> Deleting kind management cluster '{}'...",
                 cfg.repo.bootstrap.kind_cluster
             );
+            // Toolbox runs must leave the kind network first: kind removes
+            // the network with the last node, and an attached toolbox
+            // container would keep it alive.
+            if cfg.toolbox {
+                if let Some(engine) = engine.as_deref() {
+                    toolbox_leave_kind_network(cfg, engine).await;
+                }
+            }
             let kind_name = cfg.repo.bootstrap.kind_cluster.clone();
             if run("kind", &["delete", "cluster", "--name", &kind_name])
                 .await

--- a/bootstrap-rs/toolbox-entrypoint.sh
+++ b/bootstrap-rs/toolbox-entrypoint.sh
@@ -1,0 +1,96 @@
+#!/bin/sh
+# toolbox-entrypoint.sh – launcher for the knr-ops toolbox image (issue #104).
+#
+# The image's ENTRYPOINT runs knr-bootstrap directly; this launcher is the
+# documented `docker run`/`podman run` command's inner command when the
+# operator wants a shell or a custom argv, and the wiring point for the
+# toolbox runtime knobs the binary reads (KNR_TOOLBOX, ENGINE_SOCK,
+# CONTAINER_ENGINE, KUBECONFIG).
+#
+# Usage inside the image (set by the run invocation):
+#   toolbox-entrypoint.sh [profile|--recreate|teardown ...]
+#
+# The launcher:
+#   1. detects the engine the way bootstrap.sh does (docker with podman
+#      re-detection, then podman) so kind picks the right provider;
+#   2. resolves the ENGINE_SOCK source path the daemon-side kind network
+#      needs (macOS Docker Desktop and remote Podman sockets do not live at
+#      /var/run/docker.sock);
+#   3. exports the toolbox knobs and execs knr-bootstrap (PID 1 semantics:
+#      signals reach the CLI directly).
+set -eu
+
+# ── 1. Engine detection (bootstrap.sh parity) ─────────────────────────────────
+if [ -z "${CONTAINER_ENGINE:-}" ]; then
+  if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
+    if docker --version 2>/dev/null | grep -qi podman; then
+      CONTAINER_ENGINE=podman
+    else
+      CONTAINER_ENGINE=docker
+    fi
+  elif command -v podman >/dev/null 2>&1 && podman info >/dev/null 2>&1; then
+    CONTAINER_ENGINE=podman
+  else
+    echo "ERROR: No running container engine found (tried docker and podman)" >&2
+    echo "       Is the engine socket mounted into the container?" >&2
+    exit 1
+  fi
+fi
+export CONTAINER_ENGINE
+
+case "$CONTAINER_ENGINE" in
+  docker)
+    docker info >/dev/null 2>&1 || { echo "ERROR: Docker daemon not reachable" >&2; exit 1; }
+    ;;
+  podman)
+    podman info >/dev/null 2>&1 || { echo "ERROR: Podman not reachable" >&2; exit 1; }
+    export KIND_EXPERIMENTAL_PROVIDER=podman
+    ;;
+  *)
+    echo "ERROR: Unsupported CONTAINER_ENGINE '${CONTAINER_ENGINE}' (expected docker or podman)" >&2
+    exit 1
+    ;;
+esac
+
+# ── 2. ENGINE_SOCK: the daemon-side source path for the kind network ─────────
+# The toolbox's own API socket is mounted at /var/run/docker.sock; the kind
+# node's extraMounts hostPath must be the path AS THE DAEMON SEES IT. The
+# host-side wrapper (scripts/toolbox-run.sh) computes it correctly for every
+# platform (Docker Desktop, rootful/rootless Podman, podman machine) and
+# passes it in; only fill the bootstrap.sh-parity fallbacks when missing.
+if [ -z "${ENGINE_SOCK:-}" ]; then
+  case "$CONTAINER_ENGINE" in
+    docker)
+      # The Docker daemon always exposes its socket at the standard path
+      # (inside the Docker Desktop VM on macOS).
+      ENGINE_SOCK=/var/run/docker.sock
+      ;;
+    podman)
+      # Never query podman info here: inside the toolbox it reports the
+      # mounted client socket, not the daemon-side path kind needs. The
+      # bootstrap.sh fallback covers Linux rootful and podman-machine VMs.
+      ENGINE_SOCK=/run/podman/podman.sock
+      ;;
+  esac
+  export ENGINE_SOCK
+fi
+
+# ── 3. Join the kind network (best-effort) ────────────────────────────────────
+# Every `docker run` starts a NEW container, so the network attachment must
+# happen per container start, not once per cluster. The kind network exists
+# after the first bootstrap; joining makes knr-registry and kind-network
+# endpoints resolve for ANY invocation (oci-push, kubectl, a shell). Failure
+# is expected and silent before the first bootstrap creates the network; the
+# bootstrap itself joins explicitly after cluster creation.
+HOSTNAME_ID="$(cat /etc/hostname 2>/dev/null || true)"
+if [ -n "$HOSTNAME_ID" ]; then
+  case "$CONTAINER_ENGINE" in
+    docker) docker network connect kind "$HOSTNAME_ID" >/dev/null 2>&1 || true ;;
+    podman) podman network connect kind "$HOSTNAME_ID" >/dev/null 2>&1 || true ;;
+  esac
+fi
+
+# ── 4. Toolbox mode + exec ────────────────────────────────────────────────────
+export KNR_TOOLBOX=1
+
+exec knr-bootstrap "$@"

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -2,6 +2,43 @@
 
 ## Prerequisites
 
+### Toolbox container (primary interface, issue #104)
+
+The toolbox image (`ghcr.io/polarsquad/knr-ops-toolbox`) carries the bootstrap
+CLI plus every pinned tool. The host needs only a running container engine —
+Docker, or Podman 5.5+ — and the repository checkout. The engine socket is
+mounted into the container; kind creates its clusters through it. The
+documented interface is the raw run invocation:
+
+```sh
+docker run --rm -it \
+  -v "$PWD:/workspace" -w /workspace \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -v "$PWD/.kube:/root/.kube" \
+  -e KUBECONFIG=/workspace/.kube/kind.yaml \
+  ghcr.io/polarsquad/knr-ops-toolbox:latest
+```
+
+Podman is the same invocation with `podman run` and the podman socket. The
+socket path differs by platform; `scripts/toolbox-run.sh` (which
+`mise run bootstrap`/`pivot`/`teardown` wrap) resolves it for Docker
+Desktop, rootful/rootless Podman, and podman machine, forwards `.env` with
+proper quote handling, and keeps kubeconfig state under the repo-local
+`.kube/` directory (gitignored).
+
+How the toolbox reaches what it needs:
+
+- The toolbox joins the `kind` Docker network after cluster creation, so the
+  internal API endpoint (`kind get kubeconfig --internal`) and the local
+  registry (`knr-registry:5000`) resolve by name.
+- Host-only rewrites (published localhost ports) are skipped inside the
+  toolbox; the CAPD-recorded endpoints already resolve there.
+- KUBECONFIG must name one writable file (the wrapper sets
+  `/workspace/.kube/kind.yaml`); the CLI rewrites it with the internal
+  kubeconfig after each `kind create`.
+
+### Native host path
+
 Tool versions are pinned in `mise.toml`, which requires mise 2026.8.10 or
 newer. With [mise](https://mise.jdx.dev/) installed:
 
@@ -71,7 +108,7 @@ AWS credentials, and `AWS_REGION` are only needed with the AWS environment.
 ## Bootstrap
 
 ```sh
-mise run bootstrap                 # AWS environment
+mise run bootstrap                 # AWS environment (toolbox container via scripts/toolbox-run.sh)
 mise -E local-host run bootstrap   # local-host environment
 ```
 

--- a/mise.local-host.toml
+++ b/mise.local-host.toml
@@ -9,9 +9,12 @@ REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) \
 cd "$REPO_ROOT"
 
 REGISTRY_PORT="${REGISTRY_PORT:-5001}"
+# Toolbox runs reach the registry by kind-network name (the CLI exports
+# REGISTRY_HOST=knr-registry there); host runs default to localhost.
+REGISTRY_HOST="${REGISTRY_HOST:-localhost}"
 OCI_REPOSITORY="${OCI_REPOSITORY:-knr-ops}"
 OCI_TAG="${OCI_TAG:-latest}"
-OCI_URL="oci://localhost:${REGISTRY_PORT}/${OCI_REPOSITORY}:${OCI_TAG}"
+OCI_URL="oci://${REGISTRY_HOST}:${REGISTRY_PORT}/${OCI_REPOSITORY}:${OCI_TAG}"
 OCI_MGMT_SOURCE_PATH="mgmt/local-host"
 OCI_WORKLOAD_SOURCE_PATH="workload/local-host"
 
@@ -22,8 +25,8 @@ for source_path in "$OCI_MGMT_SOURCE_PATH" "$OCI_WORKLOAD_SOURCE_PATH"; do
   fi
 done
 
-if ! curl --fail --silent --show-error "http://localhost:${REGISTRY_PORT}/v2/" >/dev/null; then
-  echo "ERROR: local registry is unavailable at localhost:${REGISTRY_PORT}" >&2
+if ! curl --fail --silent --show-error "http://${REGISTRY_HOST}:${REGISTRY_PORT}/v2/" >/dev/null; then
+  echo "ERROR: local registry is unavailable at ${REGISTRY_HOST}:${REGISTRY_PORT}" >&2
   echo "       Start it with: mise -E local-host run bootstrap" >&2
   exit 1
 fi

--- a/mise.toml
+++ b/mise.toml
@@ -80,12 +80,12 @@ done
 """
 
 [tasks.bootstrap]
-description = "Bootstrap the management kind cluster, hand off to Flux/GitOps, then pivot to the self-managed management cluster"
-run = "./bootstrap.sh"
+description = "Bootstrap the management kind cluster, hand off to Flux/GitOps, then pivot to the self-managed management cluster (toolbox container; native path: ./bootstrap.sh)"
+run = "scripts/toolbox-run.sh bootstrap"
 
 [tasks.pivot]
-description = "Pivot the management cluster from local kind to the CAPI-managed management cluster (aws=CAPA/EKS, local-host=CAPD)"
-run = "./pivot.sh"
+description = "Pivot the management cluster from local kind to the CAPI-managed management cluster (aws=CAPA/EKS, local-host=CAPD) (toolbox container; native path: ./pivot.sh)"
+run = "scripts/toolbox-run.sh pivot"
 
 [tasks.mgmt-kubeconfig]
 description = "Export the management-cluster kubeconfig to ~/.kube/knr-ops-mgmt.yaml"
@@ -122,5 +122,5 @@ description = "Export AWS credentials as a profile string for SOPS-encrypted sec
 run = "clusterawsadm bootstrap credentials encode-as-profile"
 
 [tasks.teardown]
-description = "Tear down all infrastructure created by bootstrap"
-run = "./teardown.sh"
+description = "Tear down all infrastructure created by bootstrap (toolbox container; native path: ./teardown.sh)"
+run = "scripts/toolbox-run.sh teardown"

--- a/renovate.json5
+++ b/renovate.json5
@@ -168,6 +168,16 @@
     },
     {
       "customType": "regex",
+      "description": "toolbox image: podman remote client pin (issue #104)",
+      "managerFilePatterns": ["bootstrap-rs/Dockerfile"],
+      "matchStrings": ["ARG PODMAN_VERSION=(?<currentValue>[0-9][^\\s]*)"],
+      "depNameTemplate": "containers/podman",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.+)",
+      "autoReplaceStringTemplate": "ARG PODMAN_VERSION={{newValue}}"
+    },
+    {
+      "customType": "regex",
       "description": "mise: aws-cli pin (floating latest tag)",
       "managerFilePatterns": ["/(^|/)mise\\.aws\\.toml$/"],
       "matchStrings": ["aws-cli = \"(?<currentValue>[^\"]+)\""],

--- a/scripts/toolbox-run.sh
+++ b/scripts/toolbox-run.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# toolbox-run.sh – thin wrapper that runs the knr-ops toolbox container
+# (issue #104). The raw `docker run`/`podman run` invocation in
+# docs/operations.md is the primary interface; `mise run bootstrap|pivot|
+# teardown` call this wrapper for hosts that already have mise.
+#
+# What the wrapper adds over the raw invocation:
+#   - host-side engine detection (docker, or podman 5.5+)
+#   - the socket mount source and the daemon-side ENGINE_SOCK the toolbox
+#     needs (they differ on macOS Docker Desktop and podman machine)
+#   - .env passthrough with proper quote stripping (docker/podman --env-file
+#     keep quotes verbatim; the repo's .env uses KEY="value")
+#   - a persistent, repo-local kubeconfig dir (.kube/) so the internal kind
+#     kubeconfig and the exported mgmt kubeconfig survive across runs
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+TOOLBOX_IMAGE="${TOOLBOX_IMAGE:-ghcr.io/polarsquad/knr-ops-toolbox:latest}"
+
+usage() {
+  cat >&2 <<EOF
+Usage: scripts/toolbox-run.sh <bootstrap|pivot|teardown> [extra knr-bootstrap args]
+
+Env:
+  TOOLBOX_IMAGE   image reference (default: ${TOOLBOX_IMAGE};
+                  build locally with: docker build -f bootstrap-rs/Dockerfile \\
+                    -t knr-ops-toolbox:dev . && TOOLBOX_IMAGE=knr-ops-toolbox:dev)
+  KNR_OPS_PROFILE aws | local-host (default: the mise environment in use)
+EOF
+  exit 2
+}
+
+[ $# -ge 1 ] || usage
+LIFECYCLE="$1"
+shift
+
+# ── Engine detection (bootstrap.sh parity) ────────────────────────────────────
+if [ -z "${CONTAINER_ENGINE:-}" ]; then
+  if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
+    if docker --version 2>/dev/null | grep -qi podman; then
+      CONTAINER_ENGINE=podman
+    else
+      CONTAINER_ENGINE=docker
+    fi
+  elif command -v podman >/dev/null 2>&1 && podman info >/dev/null 2>&1; then
+    CONTAINER_ENGINE=podman
+  else
+    echo "ERROR: No running container engine found (tried docker and podman)" >&2
+    exit 1
+  fi
+fi
+
+# ── Socket resolution: mount source (host side) vs ENGINE_SOCK (daemon side) ──
+case "$CONTAINER_ENGINE" in
+  docker)
+    SOCK_SOURCE="$(docker context inspect --format '{{(index .Endpoints "docker").Host}}' \
+      2>/dev/null | sed 's|^unix://||')"
+    [ -S "$SOCK_SOURCE" ] || SOCK_SOURCE=/var/run/docker.sock
+    ENGINE_SOCK_IN=/var/run/docker.sock
+    ;;
+  podman)
+    SOCK_SOURCE="$(podman info --format '{{.Host.RemoteSocket.Path}}' \
+      2>/dev/null | sed 's|^unix://||')"
+    [ -S "$SOCK_SOURCE" ] || SOCK_SOURCE=/run/podman/podman.sock
+    # kind's extraMounts hostPath resolves inside the podman VM/rootful
+    # namespace, where the socket lives at the standard path. (On Linux
+    # rootless the daemon-side path IS the reported one; keep it then.)
+    case "$(uname -s):$SOCK_SOURCE" in
+      Darwin:*) ENGINE_SOCK_IN=/run/podman/podman.sock ;;
+      *)       ENGINE_SOCK_IN="$SOCK_SOURCE" ;;
+    esac
+    ;;
+  *)
+    echo "ERROR: Unsupported CONTAINER_ENGINE '${CONTAINER_ENGINE}' (expected docker or podman)" >&2
+    exit 1
+    ;;
+esac
+
+# ── .env passthrough with quote stripping ─────────────────────────────────────
+# Load KEY="value" / KEY='value' / KEY=value lines into this shell so the
+# single -e KEY pass-through below forwards them. Never log these values.
+if [ -f .env ]; then
+  while IFS= read -r line || [ -n "$line" ]; do
+    case "$line" in
+      ''|'#'*) continue ;;
+    esac
+    key="${line%%=*}"
+    value="${line#*=}"
+    case "$value" in
+      \"*\") value="${value#\"}"; value="${value%\"}" ;;
+      \'*\') value="${value#\'}"; value="${value%\'}" ;;
+    esac
+    # Only export valid identifiers; skip garbage lines.
+    case "$key" in
+      ''|*[!A-Za-z0-9_]*) continue ;;
+    esac
+    export "$key=$value"
+  done < .env
+fi
+
+# Forward lifecycle knobs and credentials into the container.
+PASS_ENV=(
+  -e CONTAINER_ENGINE
+  -e ENGINE_SOCK
+  -e KNR_OPS_PROFILE
+  -e REGISTRY_PORT
+  -e OCI_REPOSITORY
+  -e OCI_TAG
+  -e BOOTSTRAP_PIVOT
+  -e PIVOT_SKIP_DELETE
+  -e GIT_REPO_URL
+  -e GITHUB_TOKEN
+  -e GITHUB_USER
+  -e AGE_KEY_FILE
+  -e AGE_PUBLIC_KEY
+  -e AWS_REGION
+  -e AWS_PROFILE
+  -e AWS_ACCESS_KEY_ID
+  -e AWS_SECRET_ACCESS_KEY
+  -e AWS_SESSION_TOKEN
+)
+
+# Repo-local persistent kubeconfig state (gitignored): the toolbox's internal
+# kind kubeconfig and the exported management kubeconfig live here.
+mkdir -p .kube
+KUBECONFIG_IN=/workspace/.kube/kind.yaml
+
+# Interactive TTY when run from a terminal (pivot/teardown prompts, ctrl-c).
+TTY_ARGS=()
+if [ -t 0 ] && [ -t 1 ]; then
+  TTY_ARGS=(-it)
+fi
+
+# The lifecycle command: bootstrap/pivot rerun the CLI (reruns are safe and
+# resume; bootstrap's default exit pivots), teardown uses the subcommand.
+case "$LIFECYCLE" in
+  bootstrap) CLI_ARGS=("$@") ;;
+  pivot)     CLI_ARGS=("$@") ;;
+  teardown)  CLI_ARGS=(teardown "$@") ;;
+  *)         usage ;;
+esac
+
+exec "$CONTAINER_ENGINE" run --rm "${TTY_ARGS[@]}" \
+  -v "$REPO_ROOT:/workspace" \
+  -w /workspace \
+  -v "$SOCK_SOURCE:/var/run/docker.sock" \
+  -v "$REPO_ROOT/.kube:/root/.kube" \
+  -e KUBECONFIG="$KUBECONFIG_IN" \
+  "${PASS_ENV[@]}" \
+  --entrypoint /usr/local/bin/knr-bootstrap \
+  "$TOOLBOX_IMAGE" \
+  "${CLI_ARGS[@]}"

--- a/scripts/toolbox-run.sh
+++ b/scripts/toolbox-run.sh
@@ -77,6 +77,10 @@ case "$CONTAINER_ENGINE" in
     exit 1
     ;;
 esac
+# Forward the daemon-side socket path to the toolbox: the entrypoint's static
+# fallbacks cannot know the Linux-rootless session socket or a non-default
+# Docker context path.
+export ENGINE_SOCK="$ENGINE_SOCK_IN"
 
 # ── .env passthrough with quote stripping ─────────────────────────────────────
 # Load KEY="value" / KEY='value' / KEY=value lines into this shell so the
@@ -149,6 +153,5 @@ exec "$CONTAINER_ENGINE" run --rm "${TTY_ARGS[@]}" \
   -v "$REPO_ROOT/.kube:/root/.kube" \
   -e KUBECONFIG="$KUBECONFIG_IN" \
   "${PASS_ENV[@]}" \
-  --entrypoint /usr/local/bin/knr-bootstrap \
   "$TOOLBOX_IMAGE" \
   "${CLI_ARGS[@]}"


### PR DESCRIPTION
## Summary

Second PR of #104: the toolbox container becomes the primary bootstrap
interface. Builds on the image from #147, which carried the CLI and tools but
could not run the lifecycle (host-only networking assumptions).

`knr-bootstrap` learns a toolbox runtime mode (`KNR_TOOLBOX=1`, set by the
image entrypoint):

- Joins the `kind` Docker network after cluster creation (idempotent;
  per-container join also in the entrypoint, so oci-push/kubectl/shell
  invocations resolve `knr-registry` and kind-network endpoints).
- Selects kind's internal kubeconfig (`kind get kubeconfig --internal`,
  targets `<cluster>-control-plane:6443`); requires a single-file KUBECONFIG,
  validated at startup.
- Reaches the registry as `knr-registry:5000` (probes and the child
  `mise oci-push` via `REGISTRY_HOST`), skipping host-only published-port
  rewrites: CAPD-recorded endpoints already resolve on the kind network.
- Detaches from the kind network before `kind delete cluster` (bootstrap
  --recreate, pivot Phase 6, teardown), so kind can remove the network.
- Teardown joins/leaves symmetrically.

Image and wrapper:

- `bootstrap-rs/Dockerfile`: pinned podman 5.5.2 static remote client
  (Renovate-managed `ARG PODMAN_VERSION`), giving kind's podman provider and
  `CONTAINER_ENGINE=podman` a real binary; `toolbox-entrypoint.sh` (engine
  detection with podman-shim re-detection, ENGINE_SOCK fallbacks, network
  join, exec).
- `scripts/toolbox-run.sh`: the mise-facing wrapper; resolves the socket
  mount source and daemon-side ENGINE_SOCK per platform (Docker Desktop,
  rootful/rootless podman, podman machine), forwards `.env` with quote
  stripping (`--env-file` keeps quotes verbatim; verified empirically), keeps
  kubeconfig state in gitignored `.kube/`.
- `mise run bootstrap|pivot|teardown` now wrap the container; the shell
  scripts remain the native development path.

## Verification

- [x] `cargo test` 47/47 (new unit tests: toolbox knobs, registry endpoint,
      rewrite guard, single-file KUBECONFIG, internal-kubeconfig args)
- [x] `cargo fmt --check` + `cargo clippy -D warnings` clean
- [x] `mise run validate` green
- [x] Image built with the new entrypoint; all 13 tools (incl. `podman`)
      on PATH; `--help`/`--version` run through the entrypoint
- [x] Live E2E smoke (Docker): toolbox created a real kind cluster through
      the mounted socket, joined the kind network (registry probe answered
      at `knr-registry:5000`), applied via the internal kubeconfig; test
      cluster and state cleaned up, registry artifact republished
- [x] Renovate dry-run (44.50.1, node 24): `containers/podman` extracted,
      regex depCount 101, zero "Failed to look up";
      `renovate-config-validator` green
- [x] CI green
- [ ] First-tag publish still pending (as on #147)
- [ ] Podman-host acceptance (needs a Podman 5.5+ machine; the Docker path
      is verified live here) — tracked for the #104 phased acceptance
      (local-host first, then aws)

Refs #104. Milestone 2-rust-bootstrap.
