### PR TITLE
docs: refresh lifecycle and toolbox documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,63 +77,79 @@ not a developer self-service portal; you are the consumer.
 
 ## Prerequisites
 
-The toolbox container is the primary interface (issue #104): the only host
-prerequisite is a running container engine.
+The toolbox container is the primary lifecycle interface. A container user
+needs only the repository checkout and a running engine:
 
-- A running Docker engine, or Podman 5.5+ (kind creates the clusters through
-  the engine socket the toolbox mounts)
-- The toolbox image: `ghcr.io/polarsquad/knr-ops-toolbox` (published on semver
-  tags), or built locally with
+- Docker, or Podman 5.5+; kind creates clusters through the mounted engine
+  socket
+- The toolbox image. No semver release has been published yet, so build the
+  current checkout with
   `docker build -f bootstrap-rs/Dockerfile -t knr-ops-toolbox:dev .`
 
-The native host path (development and air-gap work) additionally needs:
+A future matching `v*` tag publishes
+`ghcr.io/polarsquad/knr-ops-toolbox` for Linux amd64 and arm64 as `X.Y.Z`,
+`X.Y`, and stable `latest`, with a keyless signature and SPDX SBOM
+attestation. The `aws` environment additionally requires a GitHub PAT with
+read access, AWS credentials and service quotas, and an age private key.
+
+Native development and air-gap work additionally need:
 
 - Mise 2026.8.10 or newer
-- Rust toolchain (via [rustup](https://rustup.rs/); the exact pin lives in
-  `bootstrap-rs/rust-toolchain.toml`) to build the bootstrap CLI
-- AWS environment only: GitHub personal access token (PAT) with read access
-  to this repo
-- AWS environment only: AWS credentials and quotas established for the
-  environment
+- Rust via [rustup](https://rustup.rs/) when building the CLI outside the
+  image; the pin lives in `bootstrap-rs/rust-toolchain.toml`
 
 ## Quickstart
 
-With only a container engine (the primary interface, issue #104):
+Build the current checkout and run the complete local-host lifecycle with only
+Docker installed:
 
 ```sh
-cp .env.example .env        # AWS environment only: fill in GitHub PAT and AWS settings
+docker build -f bootstrap-rs/Dockerfile -t knr-ops-toolbox:dev .
+mkdir -p .kube
 docker run --rm -it \
   -v "$PWD:/workspace" -w /workspace \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v "$PWD/.kube:/root/.kube" \
   -e KUBECONFIG=/workspace/.kube/kind.yaml \
-  ghcr.io/polarsquad/knr-ops-toolbox:latest
-# teardown: same invocation with `teardown` appended
+  knr-ops-toolbox:dev local-host
+
+# Teardown uses the same mounts and the teardown subcommand:
+docker run --rm -it \
+  -v "$PWD:/workspace" -w /workspace \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -v "$PWD/.kube:/root/.kube" \
+  -e KUBECONFIG=/workspace/.kube/kind.yaml \
+  knr-ops-toolbox:dev teardown local-host
 ```
 
-`scripts/toolbox-run.sh` wraps the invocation (engine and socket detection,
-`.env` passthrough, repo-local kubeconfig state); `mise run bootstrap` and
-`mise run teardown` call it for hosts that already have mise. See
-[docs/operations.md](docs/operations.md) for the Podman form and the full
-runtime contract.
+Use `ghcr.io/polarsquad/knr-ops-toolbox:<version>` instead of the local image
+for a published release. The AWS form must also pass the Git source, PAT, age
+key path, and any AWS credential variables. Podman socket paths vary by host.
+`scripts/toolbox-run.sh` handles those mounts, loads `.env` without preserving
+quote characters, and persists kubeconfigs under `.kube/`; see
+[Operations](docs/operations.md) for both forms.
 
-The native host path (development):
+For hosts with mise, the lifecycle tasks call that wrapper. Installing the
+pinned native tools also enables key generation, validation, and inspection:
 
 ```sh
-mise trust                  # to enable mise in this repository
-mise install                # installs tools pinned in mise.toml (kubectl, kind, flux, ...)
-cp .env.example .env        # AWS environment only: fill in GitHub PAT and AWS settings
-mise run sops-keygen        # first time only: age key for SOPS
-mise run bootstrap          # disposable kind cluster + Flux + pivot; then it is all GitOps
+docker build -f bootstrap-rs/Dockerfile -t knr-ops-toolbox:dev .
+export TOOLBOX_IMAGE=knr-ops-toolbox:dev
+mise trust
+mise install
+cp .env.example .env        # AWS only: fill in the Git source and PAT
+mise run sops-keygen         # first time only: age key for SOPS
+mise run bootstrap           # toolbox: bootstrap, Flux handoff, then pivot
+export KUBECONFIG="$PWD/.kube/knr-ops-mgmt.yaml"
 flux get kustomizations --watch
-mise run validate           # bash -n, unit tests, build every kustomize overlay (mirrors CI)
-mise run teardown           # full teardown (EKS, AWS resources, kind)
+mise run validate            # shell syntax, bootstrap.toml cross-check, overlays
+mise run teardown            # toolbox: reverse-order lifecycle cleanup
 ```
 
 Dependency versions are managed by Renovate
-([renovate.json5](renovate.json5)) running as the hosted GitHub App: they
-live in the native files that consume them and Renovate opens update PRs
-weekly; see [docs/dependencies.md](docs/dependencies.md).
+([renovate.json5](renovate.json5)) running as the hosted GitHub App; they live
+in their native consumer files and update PRs open weekly. See
+[Dependencies](docs/dependencies.md).
 
 ### Environments (formerly profiles)
 
@@ -150,8 +166,11 @@ workload delivery and application access. This covers the complete GitOps and
 CAPI lifecycle without provisioning AWS resources:
 
 ```sh
+docker build -f bootstrap-rs/Dockerfile -t knr-ops-toolbox:dev .
+export TOOLBOX_IMAGE=knr-ops-toolbox:dev
 mise -E local-host install
 mise -E local-host run bootstrap
+export KUBECONFIG="$PWD/.kube/knr-ops-mgmt.yaml"
 mise -E local-host run oci-push  # republish local management and workload paths
 mise -E local-host run kubeconfigs
 mise -E local-host run podinfo-port-forward  # http://localhost:9898
@@ -167,49 +186,59 @@ Flux reconciliation chains and surfaces workload reconciliation errors. A
 successful bootstrap, followed by the Podinfo port-forward, verifies the
 end-to-end local-host flow.
 
-The local-host teardown deletes the CAPD workload cluster before deleting the
-`mgmt` kind cluster and local registry container. The default teardown path
-suspends Flux and removes the AWS-managed infrastructure.
+Local-host teardown deletes the CAPD workload cluster first, then removes the
+pre-pivot kind cluster or the post-pivot self-managed management containers,
+and removes the local registry last. AWS teardown discovers the active
+controller host, deletes the workload clusters, sweeps orphaned resources in
+both workload regions plus the self-managed management cluster, and removes
+the `clusterawsadm` CloudFormation stack.
 
 ## The bootstrap CLI
 
-The imperative lifecycle steps run through a single Rust binary,
-`knr-bootstrap` ([docs/bootstrap-cli.md](docs/bootstrap-cli.md)): it creates
-the disposable kind cluster, hands off to Flux, and (by default) pivots the
-CAPI inventory into the self-managed management cluster before deleting kind.
-Reruns are safe by default (a healthy cluster is reused, every step is
-idempotent), so a failed run resumes by rerunning. The shell scripts
-(`bootstrap.sh`, `pivot.sh`, `teardown.sh`) remain the `mise` entrypoints
-until the binary completes full parity runs per environment; the teardown port
-([#100](https://github.com/polarsquad/knr-ops/issues/100)) and the
-externalization of repo-specific constants into `bootstrap.toml`
-([#98](https://github.com/polarsquad/knr-ops/issues/98)) are tracked issues.
+The single `knr-bootstrap` binary implements bootstrap, the default pivot, and
+`knr-bootstrap teardown`. Repository-owned cluster names, paths, chart
+versions, provider manifests, and teardown targets come from
+[`bootstrap.toml`](bootstrap.toml); `mise run validate` cross-checks that file
+against the Git manifests. Sequence-level behavior and generic fallback
+defaults remain in the binary.
+
+`mise run bootstrap`, `pivot`, and `teardown` now run the CLI through the
+toolbox wrapper. The shell scripts remain native reference and fallback paths
+until both environments complete parity runs; local-host has passed the full
+lifecycle, while AWS parity still gates retirement. See
+[The bootstrap CLI](docs/bootstrap-cli.md) for the interface, configuration,
+teardown controls, toolbox release, and current parity status.
 
 ## Documentation
 
 | Page | Contents |
 |---|---|
-| [docs/bootstrap-cli.md](docs/bootstrap-cli.md) | The `knr-bootstrap` Rust CLI: build, interface, env knobs, pivot, parity status, roadmap |
+| [docs/bootstrap-cli.md](docs/bootstrap-cli.md) | The `knr-bootstrap` lifecycle CLI: toolbox distribution, interface, `bootstrap.toml`, pivot, teardown, parity status |
 | [docs/dependencies.md](docs/dependencies.md) | Renovate-managed dependency updates: covered surfaces, update procedure, intentional differences |
 | [docs/architecture.md](docs/architecture.md) | Architecture diagram, reconciliation order, how workload apps are delivered |
 | [docs/aws-iam.md](docs/aws-iam.md) | EKS Pod Identity, ACK controller IAM roles, per-cluster reader roles, the `knr-ops-reader` console user |
 | [docs/workload-resources.md](docs/workload-resources.md) | S3 bucket security posture, RDS instances, known limitations |
 | [docs/konflate.md](docs/konflate.md) | Rendered Flux PR review: GitHub Actions gate, in-cluster instance, write-back to PRs, tokens |
 | [docs/secrets.md](docs/secrets.md) | SOPS + age secret management, key setup, credential rotation |
-| [docs/operations.md](docs/operations.md) | Prerequisites, AWS service quotas, configuration, bootstrap, pivot recovery, teardown, validation |
+| [docs/operations.md](docs/operations.md) | Toolbox runtime, prerequisites, quotas, bootstrap, pivot recovery, teardown, validation |
 | [docs/extending.md](docs/extending.md) | Adding a workload cluster, adding apps to the workload clusters, adding other providers (Azure, Talos, k0smotron) |
 | [docs/airgap.md](docs/airgap.md) | Zarf air-gap bundle: package build, offline deploy, verification checklist, update drill |
 
 ## Repository layout
 
 ```
-├── airgap/                       Zarf air-gap bundle, image inventory, scripts
-├── bootstrap-rs/                 knr-bootstrap: the Rust bootstrap/pivot CLI
-├── bootstrap.sh / pivot.sh /     Shell equivalents; kept until the binary
-│   teardown.sh                   completes full parity runs, then retired
-├── docs/                         Detailed documentation (see table above)
-├── mise.toml / mise.*.toml       Pinned toolchain and AWS/local-host tasks
-├── mgmt/aws/                     Synced by the MANAGEMENT cluster's Flux
+├── .github/workflows/             Validation, Rust/toolbox CI, signed releases
+├── airgap/                        Zarf air-gap bundle, image inventory, scripts
+├── bootstrap-rs/                  Lifecycle CLI, toolbox Dockerfile, Rust tests
+├── bootstrap.toml                 Repository-owned lifecycle configuration
+├── bootstrap.sh / pivot.sh /      Native shell references and fallback paths;
+│   teardown.sh                    retained until both parity gates pass
+├── scripts/toolbox-run.sh         Docker/Podman wrapper used by lifecycle tasks
+├── tests/                         Config and Renovate coverage cross-checks
+├── docs/                          Detailed documentation (see table above)
+├── mise.toml / mise.*.toml        Pinned toolchain and AWS/local-host tasks
+├── renovate.json5                 Hosted Renovate discovery and grouping rules
+├── mgmt/aws/                      Synced by the MANAGEMENT cluster's Flux
 │   ├── infrastructure/           cert-manager, CAPI operator, CAPA identity,
 │   │                              ACK controllers, pod-identity roles,
 │   │                              account-global IAM (reader console user),

--- a/docs/air-gap-infra.svg
+++ b/docs/air-gap-infra.svg
@@ -19,7 +19,7 @@
 
   <!-- ===== title block ===== -->
   <text x="800" y="60" text-anchor="middle" font-family="DejaVu Sans" font-size="40" font-weight="bold" fill="#ff78c9">knr-ops &#183; Zarf Air-Gap Bundle &#183; Radio Off, Chain Intact</text>
-  <text x="800" y="96" text-anchor="middle" font-family="DejaVu Sans" font-size="19" fill="#8f8f8f">Zarf packages the local-host profile &#183; build connected, deploy with no internet &#183; two registries, one package</text>
+  <text x="800" y="96" text-anchor="middle" font-family="DejaVu Sans" font-size="19" fill="#8f8f8f">Zarf packages the local-host environment &#183; build connected, deploy with no internet &#183; two registries, one package</text>
 
   <!-- ===== section headers ===== -->
   <text x="64" y="138" font-family="DejaVu Sans" font-size="20" font-weight="bold" fill="#fafafa">CONNECTED SIDE (build)</text>
@@ -66,8 +66,8 @@
   <!-- zarf substrate chip -->
   <rect x="88" y="576" width="452" height="128" rx="10" fill="#cfa07e" fill-opacity="0.10" stroke="#cfa07e" stroke-opacity="0.55" stroke-width="1.2"/>
   <text x="314" y="604" text-anchor="middle" font-family="DejaVu Sans" font-size="16.5" font-weight="bold" fill="#cfa07e">Zarf owns the substrate</text>
-  <text x="106" y="632" font-family="DejaVu Sans" font-size="15" fill="#d6d6d6">&#8226; internal registry <tspan font-family="DejaVu Sans Mono" font-size="14" fill="#cfa07e">127.0.0.1:31999</tspan> + agent (image rewrite)</text>
-  <text x="106" y="658" font-family="DejaVu Sans" font-size="15" fill="#d6d6d6">&#8226; cert-manager &#183; flux-operator &#183; CAPI core + CAPD + CAAPH</text>
+  <text x="106" y="632" font-family="DejaVu Sans" font-size="15" fill="#d6d6d6">&#8226; registry 127.0.0.1:31999 + rewrite agent</text>
+  <text x="106" y="658" font-family="DejaVu Sans" font-size="15" fill="#d6d6d6">&#8226; cert-manager &#183; Flux &#183; CAPI/CAPD/CAAPH</text>
   <text x="106" y="684" font-family="DejaVu Sans" font-size="15" fill="#d6d6d6">&#8226; publishes config artifact into the internal registry</text>
   <!-- flux glyph -->
   <g transform="translate(130,760)">
@@ -139,14 +139,14 @@
   <circle cx="1140" cy="338" r="15" fill="#ab9fd6"/>
   <text x="1140" y="344" text-anchor="middle" font-family="DejaVu Sans" font-size="15" font-weight="bold" fill="#0f0f0f">2</text>
   <text x="1168" y="334" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">The bundle crosses the gap. Offline:</text>
-  <text x="1168" y="360" font-family="DejaVu Sans Mono" font-size="15.5" fill="#ab9fd6">docker load<tspan font-family="DejaVu Sans" font-size="17" fill="#d6d6d6"> archives, create kind</tspan></text>
+  <text x="1168" y="360" font-family="DejaVu Sans Mono" font-size="15.5" fill="#ab9fd6">docker load archives; create kind</text>
   <text x="1168" y="386" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">mgmt cluster, seed knr-registry.</text>
   <line x1="1122" y1="420" x2="1504" y2="420" stroke="#34344a" stroke-width="1.2"/>
 
   <!-- step 3 -->
   <circle cx="1140" cy="468" r="15" fill="#cfa07e"/>
   <text x="1140" y="474" text-anchor="middle" font-family="DejaVu Sans" font-size="15" font-weight="bold" fill="#0f0f0f">3</text>
-  <text x="1168" y="464" font-family="DejaVu Sans Mono" font-size="16" fill="#cfa07e">zarf init<tspan font-family="DejaVu Sans" font-size="17" fill="#d6d6d6"> + </tspan>zarf package deploy<tspan font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">:</tspan></text>
+  <text x="1168" y="464" font-family="DejaVu Sans Mono" font-size="16" fill="#cfa07e">zarf init + zarf package deploy:</text>
   <text x="1168" y="490" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">internal registry + agent, substrate</text>
   <text x="1168" y="516" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">components; agent rewrites every</text>
   <text x="1168" y="542" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">image ref to the internal registry.</text>
@@ -165,7 +165,7 @@
   <circle cx="1140" cy="780" r="15" fill="#d693b1"/>
   <text x="1140" y="786" text-anchor="middle" font-family="DejaVu Sans" font-size="15" font-weight="bold" fill="#0f0f0f">5</text>
   <text x="1168" y="776" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">Workload Flux pulls config + charts</text>
-  <text x="1168" y="802" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">from <tspan font-family="DejaVu Sans Mono" font-size="16" fill="#d693b1">knr-registry</tspan>; <tspan font-family="DejaVu Sans Mono" font-size="16" fill="#fafafa">podinfo</tspan> runs</text>
+  <text x="1168" y="802" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">from knr-registry; podinfo runs</text>
   <text x="1168" y="828" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">from pre-loaded images. Zero pulls,</text>
   <text x="1168" y="854" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">zero public packets.</text>
   <line x1="1122" y1="888" x2="1504" y2="888" stroke="#34344a" stroke-width="1.2"/>

--- a/docs/airgap.md
+++ b/docs/airgap.md
@@ -214,6 +214,10 @@ daemon): `CLUSTER_NAME`, `AIRGAP_CLUSTER_NAME`, `WORKLOAD_REGISTRY_HOST`,
 
 ## Known limitations / follow-ups
 
+- The `knr-ops-toolbox` image is not included in `airgap/images.txt` or the
+  current Zarf package. Offline deployment still uses the dedicated
+  `airgap/scripts/` flow and its pinned tool and image inventory; the connected
+  toolbox lifecycle does not replace that flow yet.
 - **capi-operator is omitted** in the gap. Provider upgrades ride package
   rebuilds. Acceptable for the prototype.
 - **kind stays** (macOS host). On Linux targets `zarf init --components=k3s`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,6 +12,12 @@ delivered through CAPI addons, and application workloads (the
 managing secure S3 buckets, PostgreSQL instances, and read-only IAM roles)
 running on each workload cluster.
 
+The operator normally runs the imperative lifecycle through the
+`knr-ops-toolbox` container. It mounts the host engine socket, joins the kind
+network while the bootstrap cluster exists, and leaves no toolbox workload in
+the managed clusters. This packaging changes the host tool boundary, not the
+Flux or CAPI reconciliation architecture.
+
 ```mermaid
 flowchart TD
     subgraph bootstrap["Bootstrap (one-time, knr-bootstrap CLI)"]

--- a/docs/aws-infra.svg
+++ b/docs/aws-infra.svg
@@ -31,7 +31,7 @@
   <rect x="64" y="150" width="440" height="330" rx="14" fill="#131320" stroke="#3d3d55" stroke-width="1.5"/>
   <rect x="80" y="158" width="408" height="5" rx="2.5" fill="#85c7bb"/>
   <text x="284" y="198" text-anchor="middle" font-family="DejaVu Sans" font-size="25" font-weight="bold" fill="#85c7bb">Management Cluster</text>
-  <text x="284" y="222" text-anchor="middle" font-family="DejaVu Sans" font-size="16" fill="#8f8f8f">(local kind cluster)</text>
+  <text x="284" y="222" text-anchor="middle" font-family="DejaVu Sans" font-size="16" fill="#8f8f8f">(self-managed EKS &#183; post-pivot)</text>
   <!-- flux glyph -->
   <g transform="translate(122,262)">
     <path d="M0,-18 L15,0 L0,18 L-15,0 Z" fill="#85c7bb"/>

--- a/docs/bootstrap-cli.md
+++ b/docs/bootstrap-cli.md
@@ -1,122 +1,207 @@
-# The bootstrap CLI (knr-bootstrap)
+# The bootstrap CLI (`knr-bootstrap`)
 
-The imperative part of knr-ops (the one-time bootstrap, the CAPI pivot into
-the self-managed management cluster, and, once its port lands, the teardown)
-lives in a single Rust binary, `knr-bootstrap`, in [`bootstrap-rs/`](../bootstrap-rs/).
-Everything the binary runs is a one-time imperative step; after it finishes,
-Flux owns the world and the binary is not needed again until teardown.
+The imperative part of knr-ops lives in one Rust binary under
+[`bootstrap-rs/`](../bootstrap-rs/). It implements the initial bootstrap, the
+default CAPI pivot into the self-managed management cluster, and teardown.
+After bootstrap and pivot finish, Flux owns the declared state until teardown.
 
-The binary is a behavioral port of the shell scripts it replaces
-(`bootstrap.sh` + `pivot.sh`; `teardown.sh` is being ported under
-[#100](https://github.com/polarsquad/knr-ops/issues/100)). It preserves the
-scripts' step order, `>>>` progress messages, error text, and environment
-interface, with two deliberate upgrades over the scripts:
+The binary is a behavioral port of `bootstrap.sh`, `pivot.sh`, and
+`teardown.sh`. It preserves their step order, progress messages, environment
+interface, and safety guards, with two deliberate upgrades:
 
 - **Reruns are safe by default.** An existing healthy `mgmt` kind cluster is
-  reused and every step is idempotent, so a partially failed bootstrap or
-  pivot can be resumed by rerunning. Pass `--recreate` to delete and rebuild
-  the kind cluster instead.
-- **No shell, no quoting.** Tool invocations pass typed argv entries, secrets
-  travel through stdin and the environment (never argv), and the HTTP checks
-  (GitHub branch availability, registry readiness) run through reqwest with
-  explicit timeouts instead of `curl`.
+  reused and each bootstrap or pivot step is idempotent. Pass `--recreate` to
+  delete and rebuild the kind cluster instead.
+- **Typed process execution.** Tool arguments are passed as argv entries,
+  secrets travel through stdin or the environment, and the GitHub and registry
+  HTTP checks use reqwest with explicit timeouts.
 
-## Build
+## Distribution and build
+
+The primary distribution is the toolbox image,
+`ghcr.io/polarsquad/knr-ops-toolbox`. It contains `knr-bootstrap` and the
+pinned tools required by the lifecycle. See [Operations](./operations.md) for
+the container invocation and host runtime contract.
+
+The `toolbox-release` workflow runs on `v*` tags. It requires the tag to match
+`bootstrap-rs/Cargo.toml`, builds Linux amd64 and arm64 images, publishes
+`X.Y.Z`, `X.Y`, and stable `latest` tags, signs the image with GitHub OIDC, and
+attaches a Syft SPDX JSON SBOM attestation. The `bootstrap-rs` CI workflow also
+builds and smokes the arm64 image when its inputs change.
+
+No semver release has been published yet. Build the current checkout as shown
+in [Operations](./operations.md) until the first tag completes the workflow.
+
+Build the CLI directly for native development:
 
 ```sh
 cd bootstrap-rs
-cargo build            # debug; add --release for an optimized binary
-./target/debug/knr-bootstrap --help
+cargo build --locked
+cd ..
+./bootstrap-rs/target/debug/knr-bootstrap --help
+./bootstrap-rs/target/debug/knr-bootstrap teardown --help
 ```
 
-CI builds, lints (fmt, clippy `-D warnings`), and tests the crate on every
-change under `bootstrap-rs/` (`.github/workflows/bootstrap-rs.yml`). The
-toolchain is pinned in `bootstrap-rs/rust-toolchain.toml`; dependencies are
-locked in `Cargo.lock`.
+Run the binary from the repository root so its default `./bootstrap.toml` path
+resolves. Set `BOOTSTRAP_CONFIG` when running from another directory.
+
+CI runs `cargo fmt --check`, clippy with warnings denied, a locked build, and
+the test suite. The toolchain is pinned in `bootstrap-rs/rust-toolchain.toml`;
+crate dependencies are locked in `Cargo.lock`.
 
 ## Interface
 
-The CLI surface is the scripts' surface: a positional profile, `--recreate`,
-and the environment. The expanded flag interface is intentionally deferred
-(follow the [#92](https://github.com/polarsquad/knr-ops/issues/92) and
-[#95](https://github.com/polarsquad/knr-ops/issues/95) issue threads).
-
-```sh
-knr-bootstrap [PROFILE] [--recreate]
+```text
+knr-bootstrap [OPTIONS] [PROFILE] [COMMAND]
+knr-bootstrap teardown [PROFILE]
 ```
 
-- `PROFILE`: `aws` (default) or `local-host`. A non-empty `KNR_OPS_PROFILE`
-  takes precedence over the positional argument, matching `bootstrap.sh`.
-- `--recreate`: delete and recreate an existing `mgmt` kind cluster instead of
-  reusing it. Required when the profile or the kind/registry configuration
-  changed since the cluster was created; the reuse path does not detect drift.
+Common examples:
 
-Every `${VAR:-default}` knob the scripts read is read the same way: unset and
-empty both fall back to the default. Where a knob configures both the binary
-and a delegated `mise` child (for example `oci-push`), the resolved value is
-forwarded to the child explicitly.
+```sh
+knr-bootstrap                         # aws bootstrap, then pivot
+knr-bootstrap local-host              # local-host bootstrap, then pivot
+knr-bootstrap --recreate local-host   # rebuild the bootstrap kind cluster
+knr-bootstrap teardown                # aws teardown
+knr-bootstrap teardown local-host     # local-host teardown
+```
 
-| Knob | Default | Used by |
+- `PROFILE` is the CLI's retained positional name. Its value names a section
+  under `[environments.*]` in
+  [`bootstrap.toml`](../bootstrap.toml). The checked-in environments are `aws`
+  and `local-host`.
+- A non-empty `KNR_OPS_PROFILE` overrides the positional profile. If
+  neither is set, `bootstrap.default-environment` from `bootstrap.toml` is
+  used.
+- `--recreate` applies to bootstrap only. Teardown is a subcommand and keeps
+  its script-compatible controls in environment variables.
+- There is no pivot subcommand. Pivot is the default exit from bootstrap, and
+  rerunning the normal command resumes an interrupted bootstrap or pivot.
+
+## Repository configuration
+
+Repository-owned cluster names, paths, chart versions, provider manifests, and
+teardown targets live in [`bootstrap.toml`](../bootstrap.toml). The binary
+retains generic fallback defaults and sequence-level contracts. It reads
+`./bootstrap.toml` by default; `BOOTSTRAP_CONFIG` selects another path.
+
+Runtime environment variables take precedence where an override exists.
+`mise run validate` parses the file and cross-checks its chart pins and
+teardown names against the Git manifests. Renovate updates the annotated chart
+pins together with their declarative counterparts. See
+[Dependencies](./dependencies.md).
+
+## Bootstrap and pivot controls
+
+| Variable | Default | Used by |
 |---|---|---|
-| `KNR_OPS_PROFILE` | positional arg, then `aws` | profile selection |
-| `REGISTRY_PORT` | `5001` | local-host: host port of the local OCI registry |
-| `REGISTRY_READY_RETRIES` | `120` | local-host: registry readiness poll attempts |
-| `LOCAL_RECONCILE_TIMEOUT` | `15m` | local-host: management/workload reconciliation waits |
-| `CONTAINER_ENGINE` | auto (`docker`, else `podman`) | kind/container engine selection |
-| `GIT_REPO_URL` | — (required, aws) | Flux Git source for the management cluster |
-| `GITHUB_TOKEN` | — (required, aws) | PAT with read access to the repo |
-| `GITHUB_USER` | `git` | Git clone user for the Flux secret |
-| `AGE_KEY_FILE` | `age.agekey` | SOPS age private key loaded into the `sops-age` secret |
-| `AGE_PUBLIC_KEY` | derived from `AGE_KEY_FILE` | `create`-mode public key override |
-| `OCI_REPOSITORY` / `OCI_TAG` | `knr-ops` / `latest` | local-host: OCI artifact name |
-| `BOOTSTRAP_PIVOT` | `1` | `0` skips the pivot; kind stays the management cluster |
-| `MGMT_KUBECONFIG` | `~/.kube/knr-ops-mgmt.yaml` | exported management kubeconfig |
-| `MGMT_READY_TIMEOUT` | `40m` aws / `15m` local-host | management cluster provisioning wait |
-| `MGMT_POLL_INTERVAL` | `10` (seconds) | management cluster provisioning poll |
-| `BOOTSTRAP_KUBECONTEXT` | `kind-mgmt` | context the pivot runs from |
-| `PIVOT_SKIP_DELETE` | `0` | `1` keeps the kind bootstrap cluster for inspection |
+| `BOOTSTRAP_CONFIG` | `./bootstrap.toml` | Repository configuration path |
+| `KNR_OPS_PROFILE` | positional profile, then `bootstrap.default-environment` (`aws` checked in) | Environment selection |
+| `REGISTRY_PORT` | `5001` | Local-host registry host port |
+| `REGISTRY_READY_RETRIES` | `120` | Local-host registry readiness attempts |
+| `LOCAL_RECONCILE_TIMEOUT` | `15m` | Local-host management and workload reconciliation waits |
+| `CONTAINER_ENGINE` | auto-detect Docker, then Podman | kind and registry engine |
+| `GIT_REPO_URL` | required for `aws` | Management Flux Git source |
+| `GITHUB_TOKEN` | required for `aws` | PAT with read access to the repository |
+| `GITHUB_USER` | `git` | Basic-auth username paired with the PAT |
+| `AGE_KEY_FILE` | `age.agekey` | SOPS age private key loaded into `sops-age` |
+| `AGE_PUBLIC_KEY` | derived from `AGE_KEY_FILE` | Public key override during secret creation |
+| `OCI_REPOSITORY` / `OCI_TAG` | `knr-ops` / `latest` | Local-host OCI artifact name |
+| `BOOTSTRAP_PIVOT` | `1` | Any value other than literal `1` skips pivot |
+| `MGMT_KUBECONFIG` | `~/.kube/knr-ops-mgmt.yaml` | Exported management kubeconfig for native runs |
+| `MGMT_READY_TIMEOUT` | `40m` for aws, `15m` for local-host | Management cluster provisioning wait |
+| `MGMT_POLL_INTERVAL` | `10` seconds | Management cluster provisioning poll |
+| `BOOTSTRAP_KUBECONTEXT` | config value `kind-mgmt` | Source context required by pivot |
+| `PIVOT_SKIP_DELETE` | `0` | Literal `1` keeps kind after a successful pivot |
 
-## What a run does
+The toolbox runtime adds three contracts:
 
-1. **Preflight**: profile validation, required tools (`kind`, `helm`,
-   `kubectl`, `clusterctl`, `mise` on both profiles; `flux` and `curl`
-   additionally on local-host), container engine detection, and (aws) the
-   GitHub repo/branch/token checks and age key file validation.
-2. **Bootstrap** the `mgmt` kind cluster: local registry (local-host), Flux
-   Operator install, `flux-github-pat` + `sops-age` secrets (aws) or the
-   initial OCI artifact publish (local-host), `FluxInstance` sync handoff,
-   and the reconciliation watch.
-3. **Pivot** (default; `BOOTSTRAP_PIVOT=0` opts out): wait for the
-   self-managed management cluster (provisioned by CAPI from
-   `mgmt/<env>/clusters/management/`), export its kubeconfig, imperatively
-   install cert-manager + the CAPI operator + provider CRs on the target at
-   the same versions as the Git HelmReleases, suspend Flux in kind,
-   `clusterctl move`, unpause the moved Clusters, seed Flux on the target,
-   and delete the kind bootstrap cluster.
+- `KNR_TOOLBOX=1` enables internal kind networking and disables host-only CAPD
+  endpoint rewrites.
+- `ENGINE_SOCK` names the engine socket path as seen by the daemon. The wrapper
+  resolves it for Docker Desktop, Docker contexts, rootful or rootless Podman,
+  and `podman machine`.
+- `KUBECONFIG` must name one writable file, not a colon-separated list. The
+  wrapper uses `/workspace/.kube/kind.yaml`.
 
-If any phase fails, fix the cause and rerun: the bootstrap steps are
-rerun-safe, an existing healthy kind cluster is reused (a cluster whose
-kubeconfig context is gone can be recovered with
-`kind export kubeconfig --name mgmt` before rerunning), and
-`clusterctl move` is re-runnable. Recovery details and the never-delete-moved-objects
-warning are in [Operations: pivot recovery](./operations.md#pivot-recovery).
+The container reaches the local registry at `knr-registry:5000`. Its
+`/root/.kube` mount makes the management kubeconfig persist on the host as
+`./.kube/knr-ops-mgmt.yaml`. The wrapper's environment allowlist and override
+limitations are documented in [Operations](./operations.md#toolbox-container-primary-interface).
 
-## Parity status and script retirement
+## What bootstrap and pivot do
 
-The shell scripts stay in the repository until the binary has completed full
-real runs per profile; they are removed in a follow-up once both parity gates
-pass. `mise run bootstrap` and `mise run pivot` still invoke the scripts;
-run the binary from `bootstrap-rs/` until the switchover. Chart versions the
-binary installs imperatively are pinned as Renovate-annotated constants in
-`bootstrap-rs/src/main.rs` and grouped with their manifest counterparts (see
-[Dependencies](./dependencies.md)).
+1. **Preflight:** validate the environment and required tools, select a running
+   container engine, and perform the AWS GitHub/token/age-key checks when
+   needed. Native runs require `kind`, `helm`, `kubectl`, `clusterctl`, and
+   `mise`; local-host also requires `flux` and `curl`.
+2. **Bootstrap kind:** create or reuse `mgmt`, start the local registry for
+   local-host, install the Flux Operator, create the AWS Git and SOPS secrets
+   or publish the local OCI artifact, install the `FluxInstance`, and watch
+   reconciliation.
+3. **Pivot by default:** wait for the CAPI-managed management cluster, export
+   its kubeconfig, install cert-manager, the CAPI operator, and provider CRs at
+   the versions declared in `bootstrap.toml`, suspend Flux in kind, run
+   `clusterctl move`, unpause the moved clusters, seed Flux on the target, and
+   delete kind after the safety checks pass.
 
-## Roadmap
+If a phase fails, fix the cause and rerun the same command. `clusterctl move`
+is re-runnable, and kind remains authoritative until the final deletion.
+Recovery details and the warning against deleting moved CAPI objects are in
+[Pivot recovery](./operations.md#pivot-recovery).
 
-- [#100](https://github.com/polarsquad/knr-ops/issues/100): port `teardown.sh`
-  into the CLI (post-pivot teardown semantics resolved as part of it).
-- [#98](https://github.com/polasquad/knr-ops/issues/98): externalize
-  knr-ops-specific constants (cluster names, sync paths, chart pins) from
-  compiled-in values into a `bootstrap.toml` owned by the repository, so the
-  binary becomes a generic bootstrap engine with knr-ops as its first
-  consumer.
+## Teardown controls and behavior
+
+```sh
+knr-bootstrap teardown [PROFILE]
+```
+
+| Variable | Default | Effect |
+|---|---|---|
+| `AWS_ONLY` | `0` | Literal `1` skips Kubernetes steps and runs only the AWS orphan sweep; invalid with `local-host` |
+| `FORCE_KIND_DELETE` | `0` | Literal `1` removes the controller host even when CAPI cluster deletion was not confirmed |
+| `CLUSTER_DELETE_TIMEOUT` | `1200` seconds | AWS workload-cluster deletion wait |
+| `PROVIDER_DELETE_TIMEOUT` | `300` seconds | CAPI provider deletion wait |
+| `MGMT_KUBECONFIG` | `~/.kube/knr-ops-mgmt.yaml` | Post-pivot controller-host kubeconfig |
+
+Teardown checks required tools before mutation:
+
+| Mode | Required tools |
+|---|---|
+| `local-host` | `kind`, `kubectl`; `AWS_ONLY=1` is rejected |
+| normal `aws` | `kind`, `helm`, `kubectl`, `xargs`; AWS CLI is optional and its absence skips the orphan sweep |
+| `AWS_ONLY=1` | AWS CLI only |
+
+Teardown discovers where the CAPI controllers run: the pre-pivot kind cluster,
+the post-pivot self-managed management cluster, or no reachable cluster. It
+then preserves the shell implementation's reverse-order and best-effort
+cleanup semantics.
+
+- `local-host`: suspend the workload Kustomization, delete the CAPD workload
+  cluster and wait for its containers to disappear, remove kind or the
+  self-managed management containers, then remove the local registry.
+- `aws`: suspend Flux, delete and wait for workload CAPI clusters, run the AWS
+  orphan sweep for both workloads and the self-managed management cluster,
+  remove CAPI providers and bootstrap Helm releases when the controller host is
+  still reachable, and enforce the controller-host deletion guard. The sweep
+  covers pod identity associations, nodegroups, EKS clusters, RDS, CAPA-tagged
+  VPC resources, versioned S3 buckets, IAM roles and users, and the
+  `clusterawsadm` CloudFormation stack.
+
+`AWS_ONLY=1` is the recovery path when only AWS cleanup remains. A missing tool
+fails preflight before mutation; in the normal AWS path, a missing AWS CLI is
+reported and the orphan sweep is skipped rather than misclassified as an
+empty account.
+
+## Entry-point and parity status
+
+`mise run bootstrap`, `mise run pivot`, and `mise run teardown` now invoke
+`scripts/toolbox-run.sh`, which runs this CLI in the toolbox container. The
+`pivot` task is a named resume path for the rerun-safe default lifecycle; it
+does not select a separate CLI subcommand.
+
+The three shell scripts remain as native reference and fallback paths until
+full parity runs pass for both environments. Local-host bootstrap, pivot, and
+post-pivot teardown have completed parity runs. AWS full-parity runs still gate
+script retirement. At this revision no semver tag has run the release workflow,
+and no Podman-host acceptance run is recorded.

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -1,59 +1,92 @@
 # Dependencies
 
-Dependency versions live in the native files that consume them: mise configs,
-Kubernetes/Flux manifests, HelmRelease charts, GitHub Actions workflows, the
-airgap image inventory, zarf.yaml, and annotated version constants in
-bootstrap-rs sources. There is no central catalog. Renovate discovers every
-pinned version in those files and opens update PRs, configured in
-[`renovate.json5`](../renovate.json5) and running weekly via the hosted
-Renovate GitHub App (issue #90). Pending and proposed updates are tracked in
-the Renovate dependency dashboard issue.
+Dependency versions live in the files that consume them: mise configuration,
+`bootstrap.toml`, Cargo manifests and locks, the toolbox Dockerfile,
+Kubernetes and Flux manifests, GitHub Actions workflows, and the air-gap image
+inventory. There is no central version catalog.
+
+Renovate discovers the pins through [`renovate.json5`](../renovate.json5) and
+opens weekly update PRs through the hosted Renovate GitHub App. Pending and
+proposed updates appear in the Renovate dependency dashboard issue.
 
 ## Managed surfaces
 
 Renovate discovers and updates versions in:
 
-- `mise.toml`, `mise.aws.toml`, `mise.local-host.toml`: tool pins and the
-  zarf CLI pin (explicit per-tool custom managers; the native mise manager
-  is disabled so resolution is deterministic).
-- `mgmt/**` and `workload/**` YAML: Flux (HelmRelease/HelmRepository),
-  Kubernetes manifests, Helm values, and clusterctl provider manifests
-  under `capi-providers/`.
-- `kindest/node` image tags wherever referenced (mgmt, airgap scripts).
-- `airgap/images.txt` and `airgap/zarf.yaml`: container image refs, pinned
-  by digest.
-- `.github/workflows/`: GitHub Actions versions, including the Renovate CLI
-  pin used by the CI detection tests.
-- `pivot.sh`: imperative Helm chart pins (cert-manager,
-  cluster-api-operator), grouped with their GitOps HelmRelease counterparts.
-- `bootstrap-rs/src/`: version constants carrying a
-  `// renovate: datasource=... depName=...` annotation.
+- `mise.toml`, `mise.aws.toml`, and `mise.local-host.toml`: tool pins and the
+  Zarf CLI pin. Explicit per-tool custom managers replace the native mise
+  manager so each pin resolves against the intended upstream project.
+- `bootstrap-rs/Cargo.toml` and `bootstrap-rs/Cargo.lock`: Rust crate
+  dependencies through Renovate's Cargo manager.
+- `bootstrap.toml`: the Flux Operator, cert-manager, and CAPI Operator chart
+  pins consumed by `knr-bootstrap`. One annotation-driven custom manager reads
+  the adjacent `# renovate:` metadata. `mise run validate` cross-checks these
+  pins against their declarative Helm releases and proxies.
+- `bootstrap-rs/Dockerfile`: digest-pinned build and runtime base images, plus
+  the mise CLI and Podman remote-client build arguments used by the toolbox.
+- `mgmt/**` and `workload/**` YAML: Flux, Helm, Kubernetes manifests, chart
+  values, and clusterctl provider CRs under `capi-providers/`.
+- `kindest/node` image tags wherever they are referenced in management
+  manifests and air-gap scripts.
+- `airgap/images.txt` and `airgap/zarf.yaml`: container image references,
+  pinned by digest.
+- `.github/workflows/`: GitHub Actions references and the Renovate CLI pin used
+  by the digest and managed-pin coverage tests.
+- `pivot.sh`: imperative cert-manager and CAPI Operator chart pins, retained
+  and grouped with `bootstrap.toml` and the Git manifests until the native
+  shell path retires.
 
-Grouping rules (flux family together, CAPI family together, imperative chart
-pins with their manifest counterparts, node versions kept separate) and
-pinning behavior are defined in [`renovate.json5`](../renovate.json5).
+Grouping rules keep Flux updates together, CAPI updates together, imperative
+chart pins with their declarative counterparts, and node-version updates
+separate. Base images in `bootstrap-rs/Dockerfile` and air-gap images are
+digest-pinned while retaining readable tags. Nothing automerges.
+
+## Toolbox release version
+
+The `knr-bootstrap` package version lives in `bootstrap-rs/Cargo.toml`. It is a
+release version, not a dependency pin, so Renovate does not increment it. When
+a `v*` tag is pushed, `.github/workflows/toolbox-release.yml` fails unless the
+tag matches that package version, then publishes the multi-architecture
+toolbox image, signs it, and attaches an SPDX SBOM attestation.
+
+Lifecycle tool versions installed in the image come from `mise.toml` and
+`mise.aws.toml`. The Dockerfile separately pins its Rust builder and Debian
+runtime base images, plus the mise installer and Podman remote-client build
+arguments. Renovate manages those base references and build arguments.
 
 ## Update procedure
 
-1. Wait for a Renovate PR. For troubleshooting, a local dry-run command is
-   documented in [AGENTS.md](../AGENTS.md) ("Editing renovate.json5").
-2. Review the rendered diff; CI (`validate` workflow) builds every kustomize
-   overlay on each update PR.
-3. Merge manually; nothing automerges.
+1. Wait for a Renovate PR. For configuration troubleshooting, use the pinned
+   local dry-run procedure in [AGENTS.md](../AGENTS.md) under "Editing
+   renovate.json5".
+2. Review the raw and rendered diffs. The `validate` workflow checks kustomize
+   builds, air-gap digest pinning, managed-pin extraction coverage,
+   `bootstrap.toml` consistency, and YAML.
+3. For toolbox inputs, also require the `bootstrap-rs` workflow's Rust checks
+   and container build/smoke job.
+4. Merge manually.
 
-If an image appears in both a manifest and the airgap inventory
-(`airgap/images.txt` or `zarf.yaml`), bump them in the same PR. There is no
-automated completeness check between manifests and the inventory, so verify
-the pairing during review.
+If an image appears in both a manifest and the air-gap inventory
+(`airgap/images.txt` or `airgap/zarf.yaml`), update both in the same PR. There
+is no automated completeness check between manifests and the inventory, so
+verify the pairing during review.
 
 ## Intentional differences
 
 - The kind management node image, CAPD workload node images, and EKS cluster
-  versions are separate pins on purpose and upgrade independently.
+  versions are separate pins and can upgrade independently.
 - EKS addon versions (`*-eksbuild.*`) have no public registry datasource and
   are updated manually.
-- Unversioned tags (e.g. the locally built `localhost:5001/knr-ops-airgap`
-  registry image) have no comparable version and are untracked.
-- `*.sops.yaml` `version:` fields, `apiVersion` strings, chart
-  `appVersion` values, and the Zarf package `metadata.version` are not
-  dependencies and are not managed.
+- Unversioned local tags such as
+  `localhost:5001/knr-ops-airgap:latest` have no comparable release version
+  and remain untracked.
+- `scripts/toolbox-run.sh` defaults `TOOLBOX_IMAGE` to the mutable
+  `ghcr.io/polarsquad/knr-ops-toolbox:latest`; Renovate does not manage this
+  runtime default.
+- The toolbox Dockerfile installs `docker-ce-cli` from Docker's apt repository
+  without a package-version pin. Its client version intentionally follows that
+  repository, while the base image, mise installer, and Podman client remain
+  Renovate-managed.
+- `*.sops.yaml` `version:` fields, Kubernetes `apiVersion` strings, Helm chart
+  `appVersion` values, `bootstrap-rs/Cargo.toml`'s package version, and the
+  Zarf package `metadata.version` are not dependency pins.

--- a/docs/local-host-infra.svg
+++ b/docs/local-host-infra.svg
@@ -15,7 +15,7 @@
   <rect width="1600" height="1150" fill="#0f0f0f"/>
 
   <!-- ===== title block ===== -->
-  <text x="800" y="60" text-anchor="middle" font-family="DejaVu Sans" font-size="40" font-weight="bold" fill="#ff78c9">knr-ops &#183; local-host Profile &#183; Same Chain, Zero Cloud</text>
+  <text x="800" y="60" text-anchor="middle" font-family="DejaVu Sans" font-size="40" font-weight="bold" fill="#ff78c9">knr-ops &#183; local-host Environment &#183; Same Chain, Zero Cloud</text>
   <text x="800" y="96" text-anchor="middle" font-family="DejaVu Sans" font-size="19" fill="#8f8f8f">Flux + CAPI/CAPD &#183; local OCI registry replaces GitHub &#183; the full GitOps + CAPI lifecycle on one laptop</text>
 
   <!-- ===== section headers ===== -->
@@ -25,7 +25,7 @@
   <!-- ===== connections (behind boxes) ===== -->
   <line x1="612" y1="256" x2="508" y2="256" stroke="#ab9fd6" stroke-width="2.5" marker-end="url(#arrow-purple)"/>
   <text x="561" y="222" text-anchor="middle" font-family="DejaVu Sans" font-size="17" font-weight="bold" fill="#fafafa">2. syncs</text>
-  <text x="561" y="244" text-anchor="middle" font-family="DejaVu Sans Mono" font-size="16" fill="#85c7bb">mgmt/local-host/</text>
+  <text x="561" y="244" text-anchor="middle" font-family="DejaVu Sans Mono" font-size="11" fill="#85c7bb">mgmt/local-host/</text>
   <path d="M284,484 V594" fill="none" stroke="#85c7bb" stroke-width="2.5" stroke-dasharray="7,6" marker-end="url(#arrow-teal)"/>
   <text x="470" y="530" text-anchor="middle" font-family="DejaVu Sans" font-size="16" fill="#d6d6d6">3. provisions CAPD cluster &#183; installs Flux via <tspan font-family="DejaVu Sans Mono" fill="#85c7bb">flux-apps</tspan></text>
   <path d="M820,484 V560 H560 V594" fill="none" stroke="#ab9fd6" stroke-width="2.5" stroke-dasharray="7,6" marker-end="url(#arrow-purple)"/>
@@ -35,7 +35,7 @@
   <rect x="64" y="150" width="440" height="330" rx="14" fill="#131320" stroke="#3d3d55" stroke-width="1.5"/>
   <rect x="80" y="158" width="408" height="5" rx="2.5" fill="#85c7bb"/>
   <text x="284" y="198" text-anchor="middle" font-family="DejaVu Sans" font-size="25" font-weight="bold" fill="#85c7bb">Management Cluster</text>
-  <text x="284" y="222" text-anchor="middle" font-family="DejaVu Sans" font-size="16" fill="#8f8f8f">(local kind cluster &#183; Flux Operator + FluxInstance)</text>
+  <text x="284" y="222" text-anchor="middle" font-family="DejaVu Sans" font-size="16" fill="#8f8f8f">(self-managed CAPD &#183; post-pivot)</text>
   <!-- flux glyph -->
   <g transform="translate(122,262)">
     <path d="M0,-18 L15,0 L0,18 L-15,0 Z" fill="#85c7bb"/>
@@ -148,9 +148,9 @@
   <!-- step 1 -->
   <circle cx="1140" cy="208" r="15" fill="#ab9fd6"/>
   <text x="1140" y="214" text-anchor="middle" font-family="DejaVu Sans" font-size="15" font-weight="bold" fill="#0f0f0f">1</text>
-  <text x="1168" y="204" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">Bootstrap creates kind + registry;</text>
-  <text x="1168" y="230" font-family="DejaVu Sans Mono" font-size="16" fill="#ab9fd6">oci-push<tspan font-family="DejaVu Sans" font-size="17" fill="#d6d6d6"> publishes </tspan>mgmt/<tspan font-family="DejaVu Sans" font-size="17" fill="#d6d6d6"> and</tspan></text>
-  <text x="1168" y="256" font-family="DejaVu Sans Mono" font-size="16" fill="#ab9fd6">workload/<tspan font-family="DejaVu Sans" font-size="17" fill="#d6d6d6"> as </tspan>knr-ops:latest<tspan font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">.</tspan></text>
+  <text x="1168" y="204" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">Toolbox creates kind + registry;</text>
+  <text x="1168" y="230" font-family="DejaVu Sans Mono" font-size="15.5" fill="#ab9fd6">oci-push publishes mgmt/ and</text>
+  <text x="1168" y="256" font-family="DejaVu Sans Mono" font-size="15.5" fill="#ab9fd6">workload/ as knr-ops:latest.</text>
   <text x="1168" y="282" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">No GitHub PAT, no AWS account.</text>
   <line x1="1122" y1="316" x2="1504" y2="316" stroke="#34344a" stroke-width="1.2"/>
 
@@ -200,6 +200,6 @@
   <text x="1412" y="1020" font-family="DejaVu Sans Mono" font-size="14" fill="#d6d6d6">app</text>
 
   <!-- ===== footer ===== -->
-  <text x="800" y="1102" text-anchor="middle" font-family="DejaVu Sans" font-size="17" fill="#8f8f8f">The identical chain as the aws profile: management plane provisions, workload plane reconciles.</text>
-  <text x="800" y="1128" text-anchor="middle" font-family="DejaVu Sans" font-size="17" fill="#8f8f8f">Swap CAPA for CAPD and GitHub for a local registry: the pattern is unchanged.</text>
+  <text x="800" y="1102" text-anchor="middle" font-family="DejaVu Sans" font-size="17" fill="#8f8f8f">After workload readiness, pivot moves CAPI into local-management and deletes kind.</text>
+  <text x="800" y="1128" text-anchor="middle" font-family="DejaVu Sans" font-size="17" fill="#8f8f8f">Same chain as aws: CAPD and a local registry replace CAPA and GitHub.</text>
 </svg>

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -2,13 +2,27 @@
 
 ## Prerequisites
 
-### Toolbox container (primary interface, issue #104)
+### Toolbox container (primary interface)
 
-The toolbox image (`ghcr.io/polarsquad/knr-ops-toolbox`) carries the bootstrap
-CLI plus every pinned tool. The host needs only a running container engine —
-Docker, or Podman 5.5+ — and the repository checkout. The engine socket is
-mounted into the container; kind creates its clusters through it. The
-documented interface is the raw run invocation:
+The toolbox image (`ghcr.io/polarsquad/knr-ops-toolbox`) carries
+`knr-bootstrap` plus every tool used by bootstrap, pivot, and teardown. It
+intentionally omits development-only Go and Python toolchains and the Zarf CLI.
+The host needs the repository checkout and a running Docker engine or Podman
+5.5+.
+
+No semver release has been published yet. A future matching `v*` tag runs
+`.github/workflows/toolbox-release.yml`, which is configured to publish Linux
+amd64 and arm64 tags `X.Y.Z`, `X.Y`, and stable `latest`, sign the image with
+GitHub OIDC, and attach a Syft SPDX JSON SBOM attestation. Build the current
+checkout locally:
+
+```sh
+docker build -f bootstrap-rs/Dockerfile -t knr-ops-toolbox:dev .
+export TOOLBOX_IMAGE=knr-ops-toolbox:dev
+mkdir -p .kube
+```
+
+A complete raw Docker run for `local-host` is:
 
 ```sh
 docker run --rm -it \
@@ -16,26 +30,107 @@ docker run --rm -it \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v "$PWD/.kube:/root/.kube" \
   -e KUBECONFIG=/workspace/.kube/kind.yaml \
-  ghcr.io/polarsquad/knr-ops-toolbox:latest
+  "$TOOLBOX_IMAGE" local-host
 ```
 
-Podman is the same invocation with `podman run` and the podman socket. The
-socket path differs by platform; `scripts/toolbox-run.sh` (which
-`mise run bootstrap`/`pivot`/`teardown` wrap) resolves it for Docker
-Desktop, rootful/rootless Podman, and podman machine, forwards `.env` with
-proper quote handling, and keeps kubeconfig state under the repo-local
-`.kube/` directory (gitignored).
+This form assumes the standard `/var/run/docker.sock` daemon socket. Use the
+wrapper below for Docker contexts or Podman installations with a different
+host socket.
 
-How the toolbox reaches what it needs:
+The AWS environment also needs the Git source, PAT, age key, and AWS
+credentials inside the container. Source the repository `.env` so shell quotes
+are removed, then pass values by name rather than putting secrets in argv:
 
-- The toolbox joins the `kind` Docker network after cluster creation, so the
-  internal API endpoint (`kind get kubeconfig --internal`) and the local
-  registry (`knr-registry:5000`) resolve by name.
-- Host-only rewrites (published localhost ports) are skipped inside the
-  toolbox; the CAPD-recorded endpoints already resolve there.
-- KUBECONFIG must name one writable file (the wrapper sets
-  `/workspace/.kube/kind.yaml`); the CLI rewrites it with the internal
-  kubeconfig after each `kind create`.
+```sh
+cp .env.example .env
+$EDITOR .env
+set -a
+. ./.env
+set +a
+
+docker run --rm -it \
+  -v "$PWD:/workspace" -w /workspace \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -v "$PWD/.kube:/root/.kube" \
+  -e KUBECONFIG=/workspace/.kube/kind.yaml \
+  -e GIT_REPO_URL -e GITHUB_TOKEN -e GITHUB_USER \
+  -e AGE_KEY_FILE -e AGE_PUBLIC_KEY \
+  -e AWS_REGION -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY \
+  -e AWS_SESSION_TOKEN -e AWS_PROFILE \
+  "$TOOLBOX_IMAGE"
+```
+
+Generate the age key and re-encrypt secrets for a new fork before the AWS run;
+see [Secret management](./secrets.md). If credentials come from an AWS shared
+configuration instead of environment variables, also mount that configuration
+under `/root/.aws` and pass `AWS_PROFILE`.
+
+Podman socket locations differ across rootful Linux, rootless Linux, and
+`podman machine`. Use the checked-in wrapper to resolve the host mount and the
+socket path seen by the daemon:
+
+```sh
+TOOLBOX_IMAGE="$TOOLBOX_IMAGE" scripts/toolbox-run.sh bootstrap local-host
+CONTAINER_ENGINE=podman TOOLBOX_IMAGE="$TOOLBOX_IMAGE" \
+  scripts/toolbox-run.sh bootstrap local-host
+```
+
+The same wrapper powers `mise run bootstrap`, `mise run pivot`, and
+`mise run teardown`. It detects the engine, loads every `.env` assignment with
+outer quote stripping, and passes only this allowlist into the container:
+
+- Engine and lifecycle: `CONTAINER_ENGINE`, `ENGINE_SOCK`, `KNR_OPS_PROFILE`,
+  `REGISTRY_PORT`, `OCI_REPOSITORY`, `OCI_TAG`, `BOOTSTRAP_PIVOT`,
+  `PIVOT_SKIP_DELETE`
+- GitHub and age: `GIT_REPO_URL`, `GITHUB_TOKEN`, `GITHUB_USER`, `AGE_KEY_FILE`,
+  `AGE_PUBLIC_KEY`
+- AWS: `AWS_REGION`, `AWS_PROFILE`, `AWS_ACCESS_KEY_ID`,
+  `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`
+
+It does not pass `BOOTSTRAP_CONFIG`, `REGISTRY_READY_RETRIES`,
+`LOCAL_RECONCILE_TIMEOUT`, `MGMT_KUBECONFIG`, `MGMT_READY_TIMEOUT`,
+`MGMT_POLL_INTERVAL`, `BOOTSTRAP_KUBECONTEXT`, or the teardown controls
+`AWS_ONLY`, `FORCE_KIND_DELETE`, `CLUSTER_DELETE_TIMEOUT`, and
+`PROVIDER_DELETE_TIMEOUT`. Use a raw container run with explicit `-e` entries,
+or the native CLI, when overriding those values. Direct use of the wrapper does
+not require host mise.
+
+Inside the toolbox:
+
+- The entrypoint sets `KNR_TOOLBOX=1` and resolves the daemon-side
+  `ENGINE_SOCK` used by kind's socket mount.
+- Each new toolbox container best-effort joins an existing `kind` network at
+  startup. Bootstrap joins explicitly after creating kind; recreate, pivot, and
+  teardown detach before deleting the bootstrap cluster.
+- Kind's internal API endpoint and `knr-registry:5000` then resolve by name.
+- Host-only CAPD endpoint rewrites are skipped because the recorded endpoints
+  already resolve on that network.
+- `KUBECONFIG` must name one writable file. The documented invocation uses
+  `/workspace/.kube/kind.yaml`, and the CLI replaces it with kind's internal
+  kubeconfig after creation.
+- `/root/.kube` maps to the checkout's `.kube/`, so the exported management
+  kubeconfig persists on the host as `.kube/knr-ops-mgmt.yaml`.
+
+### Verifying a toolbox release
+
+After the first release is published, replace `X.Y.Z` in these commands with
+the matching Cargo and Git tag version:
+
+```sh
+IMAGE=ghcr.io/polarsquad/knr-ops-toolbox:X.Y.Z
+IDENTITY=https://github.com/polarsquad/knr-ops/.github/workflows/toolbox-release.yml@refs/tags/vX.Y.Z
+
+cosign verify \
+  --certificate-identity "$IDENTITY" \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  "$IMAGE"
+
+cosign verify-attestation \
+  --type spdxjson \
+  --certificate-identity "$IDENTITY" \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  "$IMAGE"
+```
 
 ### Native host path
 
@@ -51,7 +146,10 @@ This provides `kubectl`, `kind`, `helm`, `flux`, `clusterctl`, `go`, `sops`,
 `clusterawsadm` (`mise -E aws install`); the `local-host` environment needs
 no extra tools. Building the bootstrap CLI additionally requires a Rust
 toolchain ([rustup](https://rustup.rs/); the pin lives in
-`bootstrap-rs/rust-toolchain.toml`).
+`bootstrap-rs/rust-toolchain.toml`). The lifecycle mise tasks still use the
+toolbox. For a fully native run from the repository root, invoke
+`./bootstrap-rs/target/debug/knr-bootstrap` or call `./bootstrap.sh`,
+`./pivot.sh`, and `./teardown.sh` directly.
 
 You also need:
 
@@ -76,7 +174,8 @@ You also need:
   controllers are granted through the Git-declared
   `knr-ops-ack-rds-controller` pod-identity role — no extra static
   credentials are required for them.
-- The `clusterawsadm` IAM CloudFormation stack provisioned once per account:
+- The `clusterawsadm` IAM CloudFormation stack provisioned before bootstrap and
+  removed by a full AWS teardown:
 
   ```sh
   clusterawsadm bootstrap iam create-cloudformation-stack --region eu-north-1
@@ -102,8 +201,16 @@ cp .env.example .env
 $EDITOR .env
 ```
 
-The Flux Operator chart is pulled anonymously for both environments. The GitHub PAT,
-AWS credentials, and `AWS_REGION` are only needed with the AWS environment.
+The Flux Operator chart is pulled anonymously for both environments. The
+GitHub PAT, AWS credentials, and `AWS_REGION` are only needed with the AWS
+environment.
+
+Repository-owned lifecycle configuration lives in `bootstrap.toml`. It defines
+the environment names, sync paths, management clusters, imperative chart
+versions, provider manifests, and teardown targets. `knr-bootstrap` reads it
+from the working directory unless `BOOTSTRAP_CONFIG` selects another path.
+Runtime environment variables take precedence over configurable defaults, and
+`mise run validate` cross-checks the file against the manifests.
 
 ## Bootstrap
 
@@ -112,10 +219,10 @@ mise run bootstrap                 # AWS environment (toolbox container via scri
 mise -E local-host run bootstrap   # local-host environment
 ```
 
-> Before the first bootstrap, generate an age key for SOPS (see
-> [Secret management](./secrets.md)): `mise run sops-keygen`.
+> Before the first AWS bootstrap, generate an age key for SOPS. See
+> [Secret management](./secrets.md) for native and toolbox-only setup.
 
-This is the only imperative step. It:
+This initial imperative phase performs these steps:
 
 1. Creates the `mgmt` kind cluster.
 2. Installs the Flux Operator (Helm).
@@ -178,16 +285,22 @@ elsewhere in the repository from being packaged.
 
 The AWS environment adds the GitHub/SOPS secrets and configures the FluxInstance to sync `mgmt/aws/`.
 
-Watch reconciliation:
+Watch reconciliation after a toolbox run with the persisted management
+kubeconfig:
 
 ```sh
+export KUBECONFIG="$PWD/.kube/knr-ops-mgmt.yaml"
 flux get kustomizations --watch
 ```
 
-For the local-host environment, export and verify the CAPD workload kubeconfig after
-`docker-workload-cluster` reports Ready:
+A native CLI or shell run writes the same context to
+`~/.kube/knr-ops-mgmt.yaml` unless `MGMT_KUBECONFIG` overrides it.
+
+For the local-host environment, export and verify the CAPD workload kubeconfig
+after `docker-workload-cluster` reports Ready:
 
 ```sh
+export KUBECONFIG="$PWD/.kube/knr-ops-mgmt.yaml"  # toolbox management cluster
 mise -E local-host run kubeconfigs
 KUBECONFIG=local-workload.kubeconfig kubectl get nodes
 ```
@@ -212,7 +325,8 @@ Ready, it connects to `local-workload`, streams the workload Flux controller
 error logs, and returns after the workload root Kustomization becomes Ready.
 Filtering the workload stream to errors avoids showing normal startup retries
 and advisory messages as apparent failures. Each readiness wait defaults to 15
-minutes and can be changed with `LOCAL_RECONCILE_TIMEOUT`.
+minutes and can be changed with `LOCAL_RECONCILE_TIMEOUT` in a raw container or
+native run. The current wrapper does not forward that override.
 
 EKS clusters typically take 15–25 minutes to come up; node groups and the
 downstream app chain follow a few minutes after.
@@ -223,6 +337,7 @@ For the local-host end-to-end chain:
 
 ```sh
 mise -E local-host run bootstrap
+export KUBECONFIG="$PWD/.kube/knr-ops-mgmt.yaml"
 mise -E local-host run kubeconfigs
 KUBECONFIG=local-workload.kubeconfig flux get all --all-namespaces
 mise -E local-host run podinfo-port-forward  # browse to http://localhost:9898
@@ -235,13 +350,14 @@ Flux instance successfully delivered the application.
 For the AWS chain:
 
 ```sh
-# Management cluster
+# Management cluster after a toolbox run
+export KUBECONFIG="$PWD/.kube/knr-ops-mgmt.yaml"
 kubectl get kustomizations -n flux-system            # all Ready
 kubectl get clusters.cluster.x-k8s.io -A             # Provisioned
 kubectl get roles.iam.services.k8s.aws -n ack-system
 kubectl get podidentityassociations.eks.services.k8s.aws -n ack-system
 
-# Workload clusters — export kubeconfigs first:
+# Workload clusters: export kubeconfigs first
 #   mise -E aws run kubeconfigs && export KUBECONFIG=~/.kube/knr-ops-workloads.yaml
 #   kubectl config use-context eu-north-1-workload   (or eu-west-1-workload)
 kubectl get kustomizations -n flux-system            # aws-operators, s3-buckets, rds-instances, iam-roles
@@ -256,20 +372,20 @@ aws s3api get-public-access-block  --bucket knr-ops-<account>-eu-north-1-workloa
 Bootstrap ends with a pivot: the CAPI inventory moves from the local `mgmt`
 kind cluster into the self-managed management cluster, and the kind cluster
 is deleted. `mise run bootstrap` runs the pivot by default
-(`BOOTSTRAP_PIVOT=0` opts out); `mise run pivot` runs it standalone. The
-Rust CLI runs the same flow with resume-safe reruns; see
-[the bootstrap CLI](./bootstrap-cli.md) for its interface and knobs.
+(`BOOTSTRAP_PIVOT=0` opts out). `mise run pivot` starts the same rerun-safe CLI
+and resumes through the pivot; there is no separate pivot subcommand. See
+[the bootstrap CLI](./bootstrap-cli.md) for its interface and controls.
 
 `clusterctl move` is re-runnable: an object is deleted from the source kind
 cluster only after it was created on the target, so kind stays authoritative
 until the final kind deletion. If a pivot phase fails:
 
 1. Fix the reported cause.
-2. Re-run the pivot (`mise run pivot`, or rerun the bootstrap), from a
-   checkout of the revision you want self-managed (normally `main`). The
-   current kubectl context must be the bootstrap context (`kind-mgmt`;
-   `BOOTSTRAP_KUBECONTEXT` overrides). The Rust CLI additionally reuses an
-   existing healthy `mgmt` kind cluster on rerun.
+2. Re-run the pivot (`mise run pivot`, or rerun bootstrap) from a checkout of
+   the revision you want self-managed, normally `main`. A native run must use
+   the bootstrap context (`kind-mgmt`; `BOOTSTRAP_KUBECONTEXT` overrides).
+   Toolbox mode selects kind's internal kubeconfig automatically. The CLI
+   reuses an existing healthy `mgmt` kind cluster on rerun.
 3. Set `PIVOT_SKIP_DELETE=1` to keep the kind bootstrap cluster around for
    inspection once the pivot completes.
 
@@ -281,44 +397,93 @@ until the final kind deletion. If a pivot phase fails:
 > (for example an identity created by hand during a failed install) are safe
 > to delete.
 
-The management kubeconfig is written to `MGMT_KUBECONFIG` (default
-`~/.kube/knr-ops-mgmt.yaml`, context `knr-ops-mgmt`).
+The management kubeconfig is written to `MGMT_KUBECONFIG`, with context
+`knr-ops-mgmt`. Native runs default to `~/.kube/knr-ops-mgmt.yaml`; the toolbox
+mount makes its `/root/.kube/knr-ops-mgmt.yaml` appear on the host as
+`./.kube/knr-ops-mgmt.yaml`.
 
 ## Teardown
 
+The mise tasks run the Rust subcommand in the toolbox:
+
 ```sh
-mise run teardown    # or: ./teardown.sh
+mise run teardown                 # aws
+mise -E local-host run teardown   # local-host
 ```
 
-Tears down in reverse order: suspends Flux, deletes CAPI workload clusters (so
-CAPA or CAPD deprovisions their infrastructure), removes providers, uninstalls
-Flux, and deletes the kind cluster. The local-host environment waits for CAPD to
-remove the workload containers before deleting `mgmt`. The `clusterawsadm` IAM
-stack is intentionally left in place.
+Native equivalents are `knr-bootstrap teardown [PROFILE]` and the retained
+`./teardown.sh` reference path. The positional profile selects an environment
+from `bootstrap.toml`. Teardown reads resource names and targets from
+`bootstrap.toml` and discovers where the CAPI controllers are running:
 
-> Note: S3 buckets, RDS instances, and IAM reader roles created by ACK on the
-> workload clusters are deleted when their `Bucket`/`DBInstance`/`Role` CRs
-> are pruned — but if the workload clusters are destroyed before the CRs are
-> removed, they survive as orphans. The teardown script's AWS cleanup step
-> runs in **both regions** (`eu-north-1`, `eu-west-1`) and deletes the
-> orphaned RDS instances (`knr-ops-*-workload-db`, skipping the final
-> snapshot), the orphaned S3 data buckets
-> (`knr-ops-<account>-*-workload-data`, purging all object versions), the
-> orphaned `knr-ops-*-workload-reader` roles, the CAPA-created per-cluster
-> IAM roles (`*-workload-*` prefix sweep), the `knr-ops-ack-s3-controller` /
-> `knr-ops-ack-rds-controller` / `knr-ops-ack-iam-controller` IAM roles, and
-> the `knr-ops-reader` IAM user (including its login profile and inline
-> policy). Slow deletions (nodegroups, EKS control planes) are awaited so
-> VPC cleanup succeeds within the same run.
+- the `mgmt` kind cluster before pivot
+- the exported self-managed management kubeconfig after pivot
+- no reachable Kubernetes controller host, which falls back to AWS orphan
+  cleanup for the AWS environment
+
+The main controls keep the shell interface:
+
+| Variable | Default | Effect |
+|---|---|---|
+| `AWS_ONLY` | `0` | Literal `1` runs only the AWS orphan sweep; invalid with `local-host` |
+| `FORCE_KIND_DELETE` | `0` | Literal `1` overrides the final controller-host deletion guard |
+| `CLUSTER_DELETE_TIMEOUT` | `1200` seconds | AWS workload-cluster deletion wait |
+| `PROVIDER_DELETE_TIMEOUT` | `300` seconds | CAPI provider deletion wait |
+| `MGMT_KUBECONFIG` | native: `~/.kube/knr-ops-mgmt.yaml` | Post-pivot controller-host kubeconfig |
+
+The hard preflight depends on the mode:
+
+| Mode | Required tools |
+|---|---|
+| `local-host` | `kind`, `kubectl`; `AWS_ONLY=1` is rejected |
+| normal `aws` | `kind`, `helm`, `kubectl`, `xargs`; a missing AWS CLI skips the orphan sweep |
+| `AWS_ONLY=1` | AWS CLI only |
+
+A required-tool failure happens before mutation. The wrapper does not forward
+the four teardown controls in the table above; use a raw container invocation
+with explicit `-e` entries or a native run for recovery overrides.
+
+For `local-host`, teardown suspends the workload Kustomization, deletes the
+CAPD workload cluster, waits for its containers to disappear, removes either
+the pre-pivot kind cluster or the post-pivot self-managed management
+containers, and removes `knr-registry` last.
+
+For `aws`, teardown suspends Flux, deletes every workload CAPI Cluster while
+leaving the management Cluster object alone, and waits before touching the
+controller host. It then runs a best-effort AWS sweep for both workload
+regions and the self-managed management cluster. The sweep removes pod
+identity associations, nodegroups, EKS control planes, orphaned RDS instances,
+CAPA-tagged VPC resources in dependency order, versioned S3 buckets, CAPA and
+ACK IAM roles, the `knr-ops-reader` user, and the `clusterawsadm`
+CloudFormation stack. It removes CAPI providers and bootstrap Helm releases
+when the controller host remains reachable.
+
+The controller-host guard prevents removal while CAPI workload deletion is
+unconfirmed. Do not bypass it unless you accept orphaned infrastructure. If a
+management cluster is already unreachable, rerun with `AWS_ONLY=1` to make the
+recovery mode explicit. A missing AWS CLI in normal AWS mode is reported and
+the orphan sweep is skipped; `AWS_ONLY=1` requires the CLI and fails preflight
+without it.
+
+ACK resources can survive if their workload cluster disappears before their
+custom resources finish deleting. The explicit sweep is what removes those
+orphans, including both workload regions and the self-managed management
+cluster.
 
 ## Validation
 
-Build every kustomize overlay locally before pushing (mirrors CI). This covers
-both `mgmt/aws/` and `workload/`:
+Run the repository validation before pushing:
 
 ```sh
 mise run validate
 ```
 
-CI runs the same kustomize build plus yamllint on every push and PR
-(`.github/workflows/validate.yml`).
+The task checks shell syntax for the retained lifecycle scripts, runs the
+`bootstrap.toml` manifest cross-check, and builds every kustomize overlay under
+`mgmt/` and `workload/`.
+
+`.github/workflows/validate.yml` separately builds every overlay, runs the
+Renovate air-gap digest and managed-pin coverage tests, cross-checks
+`bootstrap.toml`, and lints YAML on pushes to `main` and on pull requests.
+`.github/workflows/bootstrap-rs.yml` runs Rust format, clippy, build, and tests,
+then builds and smokes the toolbox image when its inputs change.

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -24,13 +24,41 @@ with `spec.decryption.provider: sops`):
 
 ```sh
 mise run sops-keygen        # creates ./age.agekey and prints the public key
+export SOPS_AGE_KEY_FILE="$PWD/age.agekey"
 ```
 
-Put the printed public key into the `age:` field of `.sops.yaml`, then
-re-encrypt existing secrets so they target your key:
+`AGE_KEY_FILE` is the bootstrap input; `SOPS_AGE_KEY_FILE` tells the SOPS CLI
+which private key to use while editing encrypted files.
+
+With the toolbox and no host mise installation:
+
+```sh
+docker run --rm --user "$(id -u):$(id -g)" \
+  -e HOME=/tmp \
+  -v "$PWD:/workspace" -w /workspace \
+  --entrypoint age-keygen "$TOOLBOX_IMAGE" -o age.agekey
+```
+
+Set `TOOLBOX_IMAGE` to a published toolbox tag or a local build. Put the
+printed public key into the `age:` field of `.sops.yaml`, then re-encrypt
+existing secrets so they target your key:
 
 ```sh
 mise run sops-updatekeys
+```
+
+The container-only equivalent uses the new private key explicitly:
+
+```sh
+docker run --rm --user "$(id -u):$(id -g)" \
+  -e HOME=/tmp \
+  -v "$PWD:/workspace" -w /workspace \
+  -e SOPS_AGE_KEY_FILE=/workspace/age.agekey \
+  --entrypoint sh "$TOOLBOX_IMAGE" -c '
+    for f in $(find mgmt/aws -name "*.sops.yaml"); do
+      sops updatekeys --yes "$f"
+    done
+  '
 ```
 
 ## Setting / rotating AWS credentials


### PR DESCRIPTION
## Summary

- Refresh the README and operations guidance for the toolbox-first bootstrap, pivot, and teardown lifecycle.
- Document the exact CLI interface, `bootstrap.toml` ownership, wrapper environment allowlist, kubeconfig paths, teardown preflight, release verification, Renovate surfaces, and container-only SOPS setup.
- Update the architecture and air-gap documentation and diagrams for post-pivot management clusters and the current offline boundary.

## Verification

- `mise run validate`
- `cargo fmt --check`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo test --locked` (47 passed)
- Toolbox image build, CLI help, and installed-tool smoke test
- Container-only age generation, SOPS updatekeys, and decryption test
- 46 local documentation links and 12 external links checked
- SVG XML validation and rendered-layout inspection
