### PR TITLE
feat(local-talos): environment manifest tree (#105, 1/3)

### DIFF
--- a/mgmt/local-talos/capi-providers/cabpt-system/kustomization.yaml
+++ b/mgmt/local-talos/capi-providers/cabpt-system/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - provider.yaml

--- a/mgmt/local-talos/capi-providers/cabpt-system/namespace.yaml
+++ b/mgmt/local-talos/capi-providers/cabpt-system/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cabpt-system

--- a/mgmt/local-talos/capi-providers/cabpt-system/provider.yaml
+++ b/mgmt/local-talos/capi-providers/cabpt-system/provider.yaml
@@ -1,0 +1,16 @@
+# Talos bootstrap provider. fetchConfig is mandatory: without it the CAPI
+# operator's embedded default (from clusterctl, CAPI v1.12.10 embedded in
+# operator 0.28.0) points at the STALE siderolabs org; the maintained line
+# lives under sidero-community, where all fork work was upstreamed (#105).
+# version + fetchConfig.url pairing is the operator contract for GitHub
+# release sources: URL is the /releases page, version picks the tag.
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
+kind: BootstrapProvider
+metadata:
+  name: talos
+  namespace: cabpt-system
+spec:
+  # renovate: datasource=github-releases depName=sidero-community/cluster-api-bootstrap-provider-talos
+  version: "v0.7.6"
+  fetchConfig:
+    url: "https://github.com/sidero-community/cluster-api-bootstrap-provider-talos/releases"

--- a/mgmt/local-talos/capi-providers/cacppt-system/kustomization.yaml
+++ b/mgmt/local-talos/capi-providers/cacppt-system/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - provider.yaml

--- a/mgmt/local-talos/capi-providers/cacppt-system/namespace.yaml
+++ b/mgmt/local-talos/capi-providers/cacppt-system/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cacppt-system

--- a/mgmt/local-talos/capi-providers/cacppt-system/provider.yaml
+++ b/mgmt/local-talos/capi-providers/cacppt-system/provider.yaml
@@ -1,0 +1,13 @@
+# Talos control-plane provider. fetchConfig is mandatory (same stale-org
+# default as cabpt-system/provider.yaml); version pairs with the /releases
+# URL per the CAPI operator GitHub-release contract.
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
+kind: ControlPlaneProvider
+metadata:
+  name: talos
+  namespace: cacppt-system
+spec:
+  # renovate: datasource=github-releases depName=sidero-community/cluster-api-control-plane-provider-talos
+  version: "v0.6.4"
+  fetchConfig:
+    url: "https://github.com/sidero-community/cluster-api-control-plane-provider-talos/releases"

--- a/mgmt/local-talos/capi-providers/capi-system/kustomization.yaml
+++ b/mgmt/local-talos/capi-providers/capi-system/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - providers.yaml

--- a/mgmt/local-talos/capi-providers/capi-system/namespace.yaml
+++ b/mgmt/local-talos/capi-providers/capi-system/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: capi-system

--- a/mgmt/local-talos/capi-providers/capi-system/providers.yaml
+++ b/mgmt/local-talos/capi-providers/capi-system/providers.yaml
@@ -1,0 +1,42 @@
+# Talos/Tinkerbell variant of the CAPI core + kubeadm providers. The kubeadm
+# bootstrap/control-plane providers ride along as CAPI defaults (no Talos
+# cluster uses them here, but dropping them shrinks the clusterctl move
+# inventory and is not worth the divergence).
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
+kind: CoreProvider
+metadata:
+  name: cluster-api
+  namespace: capi-system
+spec:
+  version: "v1.14.0"
+  deployment:
+    containers:
+      - name: manager
+        args:
+          "--feature-gates": "ClusterTopology=true"
+---
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
+kind: BootstrapProvider
+metadata:
+  name: kubeadm
+  namespace: capi-system
+spec:
+  version: "v1.14.0"
+  deployment:
+    containers:
+      - name: manager
+        args:
+          "--feature-gates": "ClusterTopology=true"
+---
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
+kind: ControlPlaneProvider
+metadata:
+  name: kubeadm
+  namespace: capi-system
+spec:
+  version: "v1.14.0"
+  deployment:
+    containers:
+      - name: manager
+        args:
+          "--feature-gates": "ClusterTopology=true"

--- a/mgmt/local-talos/capi-providers/capt-system/kustomization.yaml
+++ b/mgmt/local-talos/capi-providers/capt-system/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - provider.yaml

--- a/mgmt/local-talos/capi-providers/capt-system/namespace.yaml
+++ b/mgmt/local-talos/capi-providers/capt-system/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: capt-system

--- a/mgmt/local-talos/capi-providers/capt-system/provider.yaml
+++ b/mgmt/local-talos/capi-providers/capt-system/provider.yaml
@@ -1,0 +1,14 @@
+# Tinkerbell infrastructure provider (CAPT). The well-known clusterctl name
+# is "tinkerbell-tinkerbell" (its embedded default already points at the
+# right repo), but fetchConfig is set explicitly to stay independent of the
+# operator's embedded clusterctl defaults (#105).
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
+kind: InfrastructureProvider
+metadata:
+  name: tinkerbell-tinkerbell
+  namespace: capt-system
+spec:
+  # renovate: datasource=github-releases depName=tinkerbell/cluster-api-provider-tinkerbell
+  version: "v0.7.0"
+  fetchConfig:
+    url: "https://github.com/tinkerbell/cluster-api-provider-tinkerbell/releases"

--- a/mgmt/local-talos/capi-providers/flux-ks.yaml
+++ b/mgmt/local-talos/capi-providers/flux-ks.yaml
@@ -1,0 +1,90 @@
+# Registers one Flux Kustomization per provider directory, all depending on
+# capi-operator (infrastructure/) and capi-system (the CAPI core). Health
+# checks gate on each provider's CRDs so dependents only apply once the
+# provider APIs exist. Mirrors mgmt/local-host/capi-providers/flux-ks.yaml.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: capi-system
+  namespace: flux-system
+spec:
+  interval: 5m
+  retryInterval: 2m
+  timeout: 5m
+  prune: true
+  wait: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./mgmt/local-talos/capi-providers/capi-system
+  dependsOn:
+    - name: capi-operator
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cabpt-system
+  namespace: flux-system
+spec:
+  interval: 5m
+  retryInterval: 2m
+  timeout: 5m
+  prune: true
+  wait: false
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./mgmt/local-talos/capi-providers/cabpt-system
+  dependsOn:
+    - name: capi-system
+  healthChecks:
+    - apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      name: talosconfigs.bootstrap.cluster.x-k8s.io
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cacppt-system
+  namespace: flux-system
+spec:
+  interval: 5m
+  retryInterval: 2m
+  timeout: 5m
+  prune: true
+  wait: false
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./mgmt/local-talos/capi-providers/cacppt-system
+  dependsOn:
+    - name: capi-system
+  healthChecks:
+    - apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      name: taloscontrolplanes.controlplane.cluster.x-k8s.io
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: capt-system
+  namespace: flux-system
+spec:
+  interval: 5m
+  retryInterval: 2m
+  timeout: 5m
+  prune: true
+  wait: false
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./mgmt/local-talos/capi-providers/capt-system
+  dependsOn:
+    - name: capi-system
+  healthChecks:
+    - apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      name: tinkerbellclusters.infrastructure.cluster.x-k8s.io
+    - apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      name: tinkerbellmachines.infrastructure.cluster.x-k8s.io

--- a/mgmt/local-talos/clusters/flux-ks.yaml
+++ b/mgmt/local-talos/clusters/flux-ks.yaml
@@ -1,0 +1,29 @@
+# The Talos management cluster: created by CAPT in the kind bootstrap
+# cluster, moved into itself by `clusterctl move` (knr-bootstrap pivot), and
+# from then on reconciled from GitHub by the Flux instance running inside it.
+# Health check gates on the Cluster's Available condition (v1beta2 serves
+# Available, not Ready).
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: talos-management-cluster
+  namespace: flux-system
+spec:
+  interval: 5m
+  retryInterval: 2m
+  timeout: 5m
+  prune: true
+  wait: false
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./mgmt/local-talos/clusters/management
+  dependsOn:
+    - name: cacppt-system
+    - name: capt-system
+    - name: cabpt-system
+  healthChecks:
+    - apiVersion: cluster.x-k8s.io/v1beta2
+      kind: Cluster
+      name: local-talos-management
+      namespace: default

--- a/mgmt/local-talos/clusters/kustomization.yaml
+++ b/mgmt/local-talos/clusters/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flux-ks.yaml

--- a/mgmt/local-talos/clusters/management/cluster.yaml
+++ b/mgmt/local-talos/clusters/management/cluster.yaml
@@ -10,10 +10,12 @@
 #   spec.controlPlaneEndpoint.host       - the machine's stable IP
 #   TinkerbellMachineTemplate hardwareName - your Tinkerbell Hardware CR name
 #
-# The installer image is deliberately NOT pinned here: CAPT resolves it from
-# the Hardware (status.installerImage) and CABPT injects it as
-# machine.install.image, so hardware-specific system extensions arrive
-# without hand-maintained image refs (#105).
+# The installer image is deliberately NOT pinned here: CABPT (>= v0.7.6)
+# injects the InfraMachine's status.installerImage as machine.install.image
+# when the infrastructure provider publishes it. Upstream CAPT v0.7.0 does
+# not populate that field (#156), so installs use the default Image Factory
+# schematic until the CAPT-side resolution lands; CABPT treats the absent
+# field as "no override".
 ---
 apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster

--- a/mgmt/local-talos/clusters/management/cluster.yaml
+++ b/mgmt/local-talos/clusters/management/cluster.yaml
@@ -1,0 +1,90 @@
+# Single-node Talos management cluster for the local-talos environment (#105).
+#
+# Shape: imperative (explicit controlPlaneRef), NOT ClusterClass topology —
+# Tinkerbell hardware selection is operator/site-specific and one machine
+# carries the whole management plane.
+#
+# SITE-SPECIFIC VALUES (edit before deploying to your metal; the repo
+# convention for management clusters is committed site values, like
+# mgmt/aws/clusters/eu-north-1/management/):
+#   spec.controlPlaneEndpoint.host       - the machine's stable IP
+#   TinkerbellMachineTemplate hardwareName - your Tinkerbell Hardware CR name
+#
+# The installer image is deliberately NOT pinned here: CAPT resolves it from
+# the Hardware (status.installerImage) and CABPT injects it as
+# machine.install.image, so hardware-specific system extensions arrive
+# without hand-maintained image refs (#105).
+---
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: Cluster
+metadata:
+  name: local-talos-management
+  namespace: default
+  labels:
+    knr-ops.polarsquad.com/environment: local-talos
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+        - 192.168.0.0/16
+    serviceDomain: cluster.local
+    services:
+      cidrBlocks:
+        - 10.128.0.0/12
+  controlPlaneEndpoint:
+    host: 192.168.1.50
+    port: 6443
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    kind: TalosControlPlane
+    name: local-talos-management
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: TinkerbellCluster
+    name: local-talos-management
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: TinkerbellCluster
+metadata:
+  name: local-talos-management
+  namespace: default
+spec: {}
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: TalosControlPlane
+metadata:
+  name: local-talos-management
+  namespace: default
+spec:
+  replicas: 1
+  version: v1.36.0
+  infrastructureTemplate:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: TinkerbellMachineTemplate
+    name: local-talos-management
+  controlPlaneConfig:
+    controlplane:
+      generateType: controlplane
+      # Pinned so a provider upgrade does not silently change the generated
+      # machine config (docs/extending.md Talos rule; lives at
+      # controlPlaneConfig.controlplane.talosVersion in the v1beta1 API,
+      # not at the spec root).
+      talosVersion: v1.14
+      strategicPatches:
+        # One machine carries the whole management plane (#105).
+        - |
+          cluster:
+            allowSchedulingOnControlPlanes: true
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: TinkerbellMachineTemplate
+metadata:
+  name: local-talos-management
+  namespace: default
+spec:
+  template:
+    spec:
+      # Direct hardware binding: the single management machine by its
+      # Tinkerbell Hardware CR name. hardwareAffinity selectors would also
+      # work but are unnecessary for exactly one known machine.
+      hardwareName: talos-mgmt-01

--- a/mgmt/local-talos/clusters/management/kustomization.yaml
+++ b/mgmt/local-talos/clusters/management/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cluster.yaml

--- a/mgmt/local-talos/infrastructure/capi-operator/helmrelease.yaml
+++ b/mgmt/local-talos/infrastructure/capi-operator/helmrelease.yaml
@@ -1,0 +1,17 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: capi-operator
+  namespace: flux-system
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: cluster-api-operator
+      sourceRef:
+        kind: HelmRepository
+        name: capi-operator
+      # renovate: datasource=helm registryUrl=https://kubernetes-sigs.github.io/cluster-api-operator depName=cluster-api-operator
+      version: "0.28.0"
+  values:
+    manager: {}

--- a/mgmt/local-talos/infrastructure/capi-operator/helmrepo.yaml
+++ b/mgmt/local-talos/infrastructure/capi-operator/helmrepo.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: capi-operator
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://kubernetes-sigs.github.io/cluster-api-operator

--- a/mgmt/local-talos/infrastructure/capi-operator/kustomization.yaml
+++ b/mgmt/local-talos/infrastructure/capi-operator/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrepo.yaml
+  - helmrelease.yaml

--- a/mgmt/local-talos/infrastructure/cert-manager/helmrelease.yaml
+++ b/mgmt/local-talos/infrastructure/cert-manager/helmrelease.yaml
@@ -1,0 +1,18 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: cert-manager
+  namespace: flux-system
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: cert-manager
+      sourceRef:
+        kind: HelmRepository
+        name: jetstack
+      # renovate: datasource=helm registryUrl=https://charts.jetstack.io depName=cert-manager
+      version: "1.21.1"
+  values:
+    crds:
+      enabled: true

--- a/mgmt/local-talos/infrastructure/cert-manager/helmrepo.yaml
+++ b/mgmt/local-talos/infrastructure/cert-manager/helmrepo.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: jetstack
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://charts.jetstack.io

--- a/mgmt/local-talos/infrastructure/cert-manager/kustomization.yaml
+++ b/mgmt/local-talos/infrastructure/cert-manager/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrepo.yaml
+  - helmrelease.yaml

--- a/mgmt/local-talos/infrastructure/flux-ks.yaml
+++ b/mgmt/local-talos/infrastructure/flux-ks.yaml
@@ -1,0 +1,33 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cert-manager
+  namespace: flux-system
+spec:
+  interval: 5m
+  retryInterval: 2m
+  timeout: 5m
+  prune: true
+  wait: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./mgmt/local-talos/infrastructure/cert-manager
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: capi-operator
+  namespace: flux-system
+spec:
+  interval: 5m
+  retryInterval: 2m
+  timeout: 5m
+  prune: true
+  wait: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./mgmt/local-talos/infrastructure/capi-operator
+  dependsOn:
+    - name: cert-manager

--- a/mgmt/local-talos/kustomization.yaml
+++ b/mgmt/local-talos/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Root of the local-talos GitHub-synced tree: each entry registers Flux
+# Kustomizations reconciling the corresponding component from the
+# GitRepository source (like mgmt/aws, NOT the laptop OCI registry:
+# a physical machine cannot reach the laptop-hosted knr-registry).
+#
+# Deliberately absent vs local-host:
+# - addons/cni: CNI on Talos is built in (flannel default).
+# - addons/flux-apps + caaph-system: no HelmChartProxy consumers — this
+#   environment is management-only (#105 scope fence); the management
+#   cluster's own Flux instance is seeded by knr-bootstrap, not by Git.
+#   A future Talos workload cluster issue adds both back.
+resources:
+  - infrastructure/flux-ks.yaml
+  - capi-providers/flux-ks.yaml
+  - clusters/flux-ks.yaml


### PR DESCRIPTION
Adds the `mgmt/local-talos/` manifest tree, PR 1 of 3 for #105 (the single-node Talos management cluster environment). Follow-up PRs: environment wiring (bootstrap.toml + mise), then Renovate coverage + docs.

## What's in the tree

- `infrastructure/`: cert-manager and capi-operator HelmReleases, synced from GitHub (GitRepository source like `mgmt/aws`, not the laptop OCI registry - a physical machine cannot reach knr-registry).
- `capi-providers/`: CAPI core v1.14.0 + CABPT v0.7.6 + CACPPT v0.6.4 + CAPT v0.7.0, each with a Flux Kustomization gated on the provider CRDs.
- `clusters/management/`: imperative Cluster + TalosControlPlane (replicas 1, k8s v1.36.0, talosVersion v1.14, allowSchedulingOnControlPlanes via strategic patch) + TinkerbellCluster/TinkerbellMachineTemplate.
- Deliberately absent vs local-host: no CNI addon (Talos ships flannel), no addons/flux-apps or caaph-system (management-only scope fence; the management cluster's own Flux is seeded by knr-bootstrap).

## Deviation from the issue: upstream providers, not the forks

The issue names the shrinedogg CABPT/CACPPT forks. During implementation I verified the fork work was fully upstreamed: fork `main` is an ancestor of `sidero-community/cluster-api-bootstrap-provider-talos` **v0.7.6** and `sidero-community/cluster-api-control-plane-provider-talos` **v0.6.4** (both released 2026-08-30), with zero fork-only commits remaining. The forks have no releases of their own. Pinning upstream releases satisfies the issue's actual requirements (maintained line, v1beta2 contract via `cluster.x-k8s.io/v1beta2: v1beta1` in the released metadata, installer-image handoff commit `494dd22` included) without the fork-release prerequisite. Happy to switch to fork tags if you prefer an explicit fork line.

All three provider CRs set explicit `fetchConfig` URLs: the CAPI operator's embedded clusterctl defaults (CAPI v1.12.10 inside operator 0.28.0) point `talos` at the stale `siderolabs` org, and the well-known CAPT name is `tinkerbell-tinkerbell`.

## Site-specific values needing operator input (flagged, not secrets)

Two values in `clusters/management/cluster.yaml` are per-machine placeholders to be set for real hardware (repo convention: committed site values like `mgmt/aws/clusters/eu-north-1/management/`):

- `spec.controlPlaneEndpoint.host: 192.168.1.50` - the machine's stable IP
- `TinkerbellMachineTemplate.spec.template.spec.hardwareName: talos-mgmt-01` - the Tinkerbell Hardware CR name

The installer image is intentionally not pinned: CABPT (>= v0.7.6, which includes handoff commit `494dd22`) injects the InfraMachine's `status.installerImage` as `machine.install.image` when the infrastructure provider publishes it. Note: upstream CAPT v0.7.0 does not populate that field, so installs currently use the default Image Factory schematic; the CAPT-side resolution is tracked in #156.

## Verification

- `mise run validate`: 49 overlay builds pass (40 before + 9 new local-talos overlays).
- Field names grounded in the released CRD schemas (CACPPT v0.6.4, CAPT v0.7.0) and CAPT's cluster-template: `talosVersion` lives at `controlPlaneConfig.controlplane.talosVersion` in the v1beta1 API, not the spec root; `hardwareName` is the direct hardware binding.
- End-to-end run still requires the operator-side Tinkerbell prerequisite (boots/PXE stack + Hardware CR), documented in PR 3.

