### PR TITLE
docs(agents): document the mgmt/local-talos environment tree

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,18 @@ resources. There is no app source code here, only declarative infrastructure.
 - `mgmt/local-host/`: the local-host management variant (kind-based).
   Same layout as `mgmt/aws/` (`clusters/docker`, `capi-providers/`,
   `addons/`, `infrastructure/`) with no cloud dependencies.
+- `mgmt/local-talos/`: the single-node Talos management variant (issue
+  #105). Same component layout as `mgmt/aws/` minus addons
+  (`infrastructure/`, `capi-providers/`, `clusters/management/`), synced
+  from the GitHub GitRepository source like `mgmt/aws`, NOT the laptop OCI
+  registry (a physical machine cannot reach knr-registry). Providers are
+  Talos + Tinkerbell (CABPT/CACPPT from sidero-community releases, CAPT)
+  instead of CAPD; the cluster definition is imperative (explicit
+  controlPlaneRef, no ClusterClass) with committed site-specific values
+  (control plane endpoint IP, Tinkerbell Hardware name). Scope fence:
+  management-only; no `addons/` (Talos ships its own CNI, no
+  HelmChartProxy consumers). Bootstrap/pivot wiring and docs land with
+  the rest of the #105 series.
 - `workload/`: synced by each WORKLOAD cluster's Flux.
   - `base/`: ACK controllers and S3/RDS/IAM custom resources.
   - `<region>-01/`: per-cluster overlays pointing at `../base`.


### PR DESCRIPTION
Adds the `mgmt/local-talos/` entry to the AGENTS.md layout section, closing #158.

PR #155 added the tree without the same-PR AGENTS.md update the file's own golden rule requires; this settles it as a standalone amendment rather than waiting for the #105 series docs PR. Content covers only what distinguishes the environment: GitHub-synced (not laptop OCI), Talos+Tinkerbell provider set from sidero-community releases, imperative single-node cluster with committed site values, management-only scope fence.

Verification: `mise run validate` passes; no manifest changes.
