### PR TITLE
test: enforce digest pins in changed airgap sources

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -6,12 +6,26 @@ on:
   pull_request:
 
 jobs:
+  airgap-image-pins:
+    name: Air-gap image digest pins
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Verify committed air-gap image digests
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+        run: python3 airgap/tests/test-airgap-image-digests.py --changed-from "$BASE_SHA"
+
   kustomize-build:
     name: Build kustomize overlays
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7.0.1
 
       - name: Install kustomize
         env:
@@ -66,10 +80,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7.0.1
 
       - name: Run yamllint
-        uses: ibiqlik/action-yamllint@v3
+        uses: ibiqlik/action-yamllint@v3.1.1
         with:
           file_or_dir: mgmt workload
           config_data: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,6 +165,14 @@ locally: `mise x node@24 -- python3 tests/test-renovate-coverage.py`. They
 do not cover lookup liveness or the replacement path; only the
 dry-run and the handlebars simulation cover those.
 
+The offline `airgap/tests/test-airgap-image-digests.py` gate is separate from
+Renovate: it scans air-gap inventories and scripts changed by the PR, requires
+readable tags plus SHA-256 digests, and rejects inconsistent repeated
+references within the changed files. Untouched legacy files are not checked.
+It runs in both `mise run validate` and CI and performs no registry lookups.
+Use `python3 airgap/tests/test-airgap-image-digests.py --all` for a full-clone
+audit, including untouched legacy files.
+
 ## Where to look next
 
 Load these only when the task touches their domain:

--- a/airgap/tests/test-airgap-image-digests.py
+++ b/airgap/tests/test-airgap-image-digests.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Require immutable digests in air-gap image sources changed by a PR."""
+
+import argparse
+import re
+import subprocess
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INVENTORY_FILES = {
+    "airgap/images.txt",
+    "airgap/zarf.yaml",
+}
+LOCAL_EXCEPTIONS = {
+    "localhost:5001/knr-ops-airgap:latest": (
+        "built immediately before packaging; the build script substitutes the "
+        "selected OCI registry and tag"
+    ),
+}
+NON_IMAGE_REFERENCES = {"127.0.0.1:31999"}
+IGNORED_AIRGAP_PREFIXES = (
+    "airgap/archives/",
+    "airgap/manifests/",
+    "airgap/rendered/",
+    "airgap/sbom/",
+    "airgap/tests/",
+)
+POTENTIAL_SOURCE_SUFFIXES = {".json", ".sh", ".toml", ".txt", ".yaml", ".yml"}
+IMAGE_REF = re.compile(
+    # A shell parameter default commonly places the reference after `:-`.
+    r"(?:(?<![\w./-])|(?<=:-))"
+    r"(?P<name>(?:[a-z0-9][a-z0-9.-]*(?::[0-9]+)?/)?"
+    r"(?:[a-z0-9][a-z0-9._-]*/)*[a-z0-9][a-z0-9._-]*)"
+    r"(?:"
+    r":(?P<tag>[A-Za-z0-9_][A-Za-z0-9_.-]*)"
+    r"(?:@(?P<digest>sha256:[a-f0-9]{64}))?"
+    r"|@(?P<digest_only>sha256:[a-f0-9]{64})"
+    r")"
+)
+
+
+def source_lines(relative: str):
+    """Yield (line number, text) containing authoritative image references."""
+    lines = (REPO_ROOT / relative).read_text().splitlines()
+    if relative == "airgap/images.txt":
+        for number, line in enumerate(lines, 1):
+            if line.strip() and not line.lstrip().startswith("#"):
+                yield number, line
+        return
+
+    if relative == "airgap/zarf.yaml":
+        in_images = False
+        for number, line in enumerate(lines, 1):
+            if line == "    images:":
+                in_images = True
+                continue
+            if in_images and line.startswith("      - "):
+                yield number, line
+            elif (
+                in_images
+                and line.strip()
+                and not line.lstrip().startswith("#")
+                and len(line) - len(line.lstrip()) <= 4
+            ):
+                in_images = False
+        return
+
+    for number, line in enumerate(lines, 1):
+        code = line.split("#", 1)[0]
+        if code.strip():
+            yield number, code
+
+
+def is_image_source(relative: str) -> bool:
+    return relative in INVENTORY_FILES or (
+        relative.startswith("airgap/scripts/") and relative.endswith(".sh")
+    )
+
+
+def is_potential_image_source(relative: str) -> bool:
+    path = Path(relative)
+    return (
+        relative.startswith("airgap/")
+        and not relative.startswith(IGNORED_AIRGAP_PREFIXES)
+        and path.suffix in POTENTIAL_SOURCE_SUFFIXES
+    )
+
+
+def contains_image_reference(relative: str) -> bool:
+    for line in (REPO_ROOT / relative).read_text().splitlines():
+        code = line.split("#", 1)[0]
+        for match in IMAGE_REF.finditer(code):
+            if match.group(0) not in NON_IMAGE_REFERENCES:
+                return True
+    return False
+
+
+def all_image_sources():
+    scripts = {
+        path.relative_to(REPO_ROOT).as_posix()
+        for path in (REPO_ROOT / "airgap/scripts").glob("*.sh")
+    }
+    return sorted(INVENTORY_FILES | scripts)
+
+
+def changed_paths(base):
+    if base:
+        command = [
+            "git",
+            "diff",
+            "--name-only",
+            "--diff-filter=ACMR",
+            f"{base}...HEAD",
+        ]
+        return subprocess.run(
+            command, cwd=REPO_ROOT, check=True, text=True, capture_output=True
+        ).stdout.splitlines()
+
+    committed = []
+    for candidate in ("origin/main", "main"):
+        exists = subprocess.run(
+            ["git", "rev-parse", "--verify", "--quiet", candidate],
+            cwd=REPO_ROOT,
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        if exists.returncode == 0:
+            committed = subprocess.run(
+                [
+                    "git",
+                    "diff",
+                    "--name-only",
+                    "--diff-filter=ACMR",
+                    f"{candidate}...HEAD",
+                ],
+                cwd=REPO_ROOT,
+                check=True,
+                text=True,
+                capture_output=True,
+            ).stdout.splitlines()
+            break
+    modified = subprocess.run(
+        ["git", "diff", "--name-only", "--diff-filter=ACMR", "HEAD"],
+        cwd=REPO_ROOT,
+        check=True,
+        text=True,
+        capture_output=True,
+    ).stdout.splitlines()
+    untracked = subprocess.run(
+        ["git", "ls-files", "--others", "--exclude-standard"],
+        cwd=REPO_ROOT,
+        check=True,
+        text=True,
+        capture_output=True,
+    ).stdout.splitlines()
+    return committed + modified + untracked
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    scope = parser.add_mutually_exclusive_group()
+    scope.add_argument(
+        "--changed-from",
+        metavar="GIT_REF",
+        help="check image-source files changed between GIT_REF and HEAD",
+    )
+    scope.add_argument(
+        "--all",
+        action="store_true",
+        help="audit every authoritative image source in the cloned repository",
+    )
+    args = parser.parse_args()
+    if args.all:
+        sources = all_image_sources()
+        changed = []
+    else:
+        changed = changed_paths(args.changed_from)
+        sources = sorted(
+            {
+                path
+                for path in changed
+                if is_image_source(path)
+            }
+        )
+
+    failures = []
+    seen = defaultdict(list)
+
+    for relative in sorted(set(changed) - set(sources)):
+        if is_potential_image_source(relative) and contains_image_reference(relative):
+            failures.append(
+                f"{relative}: uncovered image-bearing source; register it in the gate"
+            )
+
+    for relative in sources:
+        matches = 0
+        for number, line in source_lines(relative):
+            for match in IMAGE_REF.finditer(line):
+                reference = match.group(0)
+                if reference in NON_IMAGE_REFERENCES:
+                    continue
+                matches += 1
+                if reference in LOCAL_EXCEPTIONS:
+                    continue
+                if match.group("digest_only") is not None:
+                    failures.append(
+                        f"{relative}:{number}: digest-only image (readable tag required): "
+                        f"{reference}"
+                    )
+                    continue
+                digest = match.group("digest")
+                if digest is None:
+                    failures.append(f"{relative}:{number}: unpinned image: {reference}")
+                    continue
+                key = (match.group("name"), match.group("tag"))
+                seen[key].append((digest, relative, number))
+        if matches == 0 and relative in INVENTORY_FILES:
+            failures.append(f"{relative}: no image references found; parser coverage is stale")
+
+    for (name, tag), occurrences in sorted(seen.items()):
+        digests = {digest for digest, _, _ in occurrences}
+        if len(digests) > 1:
+            locations = ", ".join(
+                f"{path}:{number}={digest}" for digest, path, number in occurrences
+            )
+            failures.append(f"inconsistent digest for {name}:{tag}: {locations}")
+
+    if failures:
+        print("Air-gap image digest check FAILED:", file=sys.stderr)
+        for failure in failures:
+            print(f"  - {failure}", file=sys.stderr)
+        return 1
+
+    scope_name = "repository" if args.all else "changed files"
+    print(f"Air-gap image digest check OK ({len(sources)} {scope_name} checked)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/airgap.md
+++ b/docs/airgap.md
@@ -30,6 +30,18 @@ mise pin in `mise.toml` selects the matching Linux or macOS arm64 release
 asset. Docker and kind are also required on the deploy host (the prototype
 keeps kind as the management-cluster substrate; see Known limitations).
 
+CI requires every external image in an air-gap inventory or script changed by
+a pull request to use `repository:readable-tag@sha256:<digest>`. The tag
+documents the selected version; the digest makes the fetched content
+immutable. Untouched legacy files are migrated when first changed. Run
+`python3 airgap/tests/test-airgap-image-digests.py` (or `mise run validate`)
+to check relevant working-tree changes without registry or network access.
+Run `python3 airgap/tests/test-airgap-image-digests.py --all` in a clone to
+audit every air-gap inventory and shell script, including untouched legacy
+files.
+The locally built `localhost:5001/knr-ops-airgap:latest` config artifact is the
+only documented exception because it is created immediately before packaging.
+
 Every package build must be signed. For an operator build, generate or obtain
 a Cosign-compatible key pair, keep the private key outside the repository, and
 set `ZARF_SIGNING_KEY` to it. Set `ZARF_SIGNING_KEY_PASS` when the key is

--- a/mise.toml
+++ b/mise.toml
@@ -23,7 +23,7 @@ bin = "zarf"
 env_file = ".env"
 
 [tasks.validate]
-description = "Check shell scripts, run the bootstrap config cross-check, and build every kustomize overlay"
+description = "Check scripts and air-gap image pins, cross-check bootstrap config, and build every kustomize overlay"
 run = '''
 fail=0
 for script in bootstrap.sh bootstrap-common.sh pivot.sh teardown.sh; do
@@ -33,6 +33,11 @@ for script in bootstrap.sh bootstrap-common.sh pivot.sh teardown.sh; do
     fail=1
   fi
 done
+echo "==> air-gap image digest pins"
+if ! python3 airgap/tests/test-airgap-image-digests.py; then
+  echo "    FAILED: air-gap image digest pins" >&2
+  fail=1
+fi
 echo "==> bootstrap.toml cross-check"
 if ! python3 tests/test-bootstrap-config.py; then
   echo "    FAILED: bootstrap.toml cross-check" >&2


### PR DESCRIPTION
## Summary

- add an offline check that requires digest pins in air-gap image-source files changed by a pull request
- support local changed-file checks, explicit base-ref checks, and full-clone audits
- detect digest-only references and newly introduced, unregistered image-bearing sources
- run the check through `mise run validate` and a dedicated CI job
- pin every action used by `validate.yml` to its latest exact release
- document the incremental enforcement policy and local commands

Existing tag-only inventories will be migrated by Renovate in separate PRs; this PR intentionally introduces incremental enforcement and does not close the full migration issue.

## Testing

- `mise run validate`
- `python3 airgap/tests/test-airgap-image-digests.py`
- `python3 -m py_compile airgap/tests/test-airgap-image-digests.py`
- `git diff --check`
- negative historical-diff check rejects tag-only changed image sources
- `--all` audit reports the expected untouched legacy tag-only backlog
- Renovate integration test proposes 45 digest pins for `airgap/images.txt` and 14 for `airgap/zarf.yaml`

Refs #165