### PR TITLE
feat(renovate): cover the mgmt/local-talos version pins

### DIFF
--- a/mgmt/local-talos/clusters/management/cluster.yaml
+++ b/mgmt/local-talos/clusters/management/cluster.yaml
@@ -59,7 +59,8 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  version: v1.36.0
+  # renovate: datasource=github-releases depName=kubernetes/kubernetes
+  version: "v1.36.0"
   infrastructureTemplate:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: TinkerbellMachineTemplate
@@ -70,7 +71,9 @@ spec:
       # Pinned so a provider upgrade does not silently change the generated
       # machine config (docs/extending.md Talos rule; lives at
       # controlPlaneConfig.controlplane.talosVersion in the v1beta1 API,
-      # not at the spec root).
+      # not at the spec root). Major.minor only: the machine-config contract
+      # version, not a specific Talos build.
+      # renovate: datasource=github-releases depName=siderolabs/talos
       talosVersion: v1.14
       strategicPatches:
         # One machine carries the whole management plane (#105).

--- a/renovate.json5
+++ b/renovate.json5
@@ -212,6 +212,27 @@
     },
     {
       "customType": "regex",
+      "description": "Annotated version pins in local-talos manifests (#157)",
+      "managerFilePatterns": ["/(^|/)mgmt/local-talos/.+\\.ya?ml$/"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-z0-9-]+) depName=(?<depName>\\S+)\\n\\s{2,}version: \\\"v(?<currentValue>[^\\\"]+)\\\""
+      ],
+      "extractVersionTemplate": "^v(?<version>.+)",
+      "autoReplaceStringTemplate": "# renovate: datasource={{{datasource}}} depName={{{depName}}}\n  version: \"v{{{newValue}}}\""
+    },
+    {
+      "customType": "regex",
+      "description": "local-talos talosVersion machine-config contract pin (#157)",
+      "managerFilePatterns": ["/(^|/)mgmt/local-talos/clusters/management/cluster\\.yaml$/"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-z0-9-]+) depName=(?<depName>siderolabs/talos)\\n\\s+talosVersion: v(?<currentValue>[0-9]+\\.[0-9]+)"
+      ],
+      "extractVersionTemplate": "^v(?<version>\\d+\\.\\d+)",
+      "versioningTemplate": "loose",
+      "autoReplaceStringTemplate": "# renovate: datasource={{{datasource}}} depName={{{depName}}}\n      talosVersion: v{{{newValue}}}"
+    },
+    {
+      "customType": "regex",
       "description": "pivot.sh imperative Helm chart pins",
       "managerFilePatterns": ["/(^|/)pivot\\.sh$/"],
       "matchStrings": [
@@ -246,9 +267,9 @@
     // ── clusterctl operator provider manifests ───────────────────────────
     {
       "customType": "regex",
-      "description": "CAPI core, kubeadm, and CAPD provider versions",
+      "description": "CAPI core, kubeadm, and CAPD provider versions (aws, local-host, local-talos)",
       "managerFilePatterns": [
-        "/(^|/)mgmt/(aws|local-host)/capi-providers/(capi-system|capd-system)/.+\\.ya?ml$/"
+        "/(^|/)mgmt/(aws|local-host|local-talos)/capi-providers/(capi-system|capd-system)/.+\\.ya?ml$/"
       ],
       "matchStrings": ["\\s{2}version: \"v(?<currentValue>[^\"]+)\""],
       "depNameTemplate": "kubernetes-sigs/cluster-api",

--- a/tests/test-renovate-coverage.py
+++ b/tests/test-renovate-coverage.py
@@ -21,6 +21,22 @@ EXPECTED = {
     },
     "pivot.sh": {"cert-manager", "cluster-api-operator"},
     ".github/workflows/validate.yml": {"renovate"},
+    "mgmt/local-talos/capi-providers/capi-system/providers.yaml": {
+        "kubernetes-sigs/cluster-api",
+    },
+    "mgmt/local-talos/capi-providers/cabpt-system/provider.yaml": {
+        "sidero-community/cluster-api-bootstrap-provider-talos",
+    },
+    "mgmt/local-talos/capi-providers/cacppt-system/provider.yaml": {
+        "sidero-community/cluster-api-control-plane-provider-talos",
+    },
+    "mgmt/local-talos/capi-providers/capt-system/provider.yaml": {
+        "tinkerbell/cluster-api-provider-tinkerbell",
+    },
+    "mgmt/local-talos/clusters/management/cluster.yaml": {
+        "kubernetes/kubernetes",
+        "siderolabs/talos",
+    },
 }
 
 


### PR DESCRIPTION
Makes every version pin in `mgmt/local-talos/` visible to Renovate, closing #157 and satisfying the #105 acceptance criterion that provider, Kubernetes, and Talos versions appear in the dependency dashboard.

Mechanisms, smallest-change-first:

- `capi-system` CAPI core pins: path extension of the existing CAPI provider manager (aws|local-host to aws|local-host|local-talos); the matchString already fits.
- CABPT/CACPPT/CAPT provider CRs: a new annotated-YAML regex manager consuming the `# renovate:` comments #155 pre-placed; the annotation is the source of datasource and depName, so no per-dependency manager entries.
- TalosControlPlane `spec.version`: annotated (`kubernetes/kubernetes`) and quoted to match the manager's single quoted form. The #142 topology-version work does not cover this pin (imperative control plane, no ClusterClass).
- `talosVersion`: annotated (`siderolabs/talos`) with a dedicated manager whose `extractVersionTemplate` collapses upstream tags to major.minor, keeping the pin a machine-config contract version.

Verification (per the AGENTS.md renovate editing procedure):

- `tests/test-renovate-coverage.py` extended first (red: all five new paths missing detection), green after the managers; the five new paths assert detection permanently in CI.
- Pinned dry-run (`renovate@44.50.1 --platform=local --dry-run=full`, Node 24.20): all six depNames extracted (CAPI core, CABPT, CACPPT, CAPT, kubernetes, talos), zero "Failed to look up", zero unhandledRejection.
- `renovate-config-validator` passes; `mise run validate` passes (the cluster.yaml quoting and comment edits break no overlay).
