### PR TITLE
feat(local-talos): consume CAPT fork v0.7.1 producing status.installerImage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,11 @@ resources. There is no app source code here, only declarative infrastructure.
   Talos + Tinkerbell (CABPT/CACPPT from sidero-community releases, CAPT)
   instead of CAPD; the cluster definition is imperative (explicit
   controlPlaneRef, no ClusterClass) with committed site-specific values
-  (control plane endpoint IP, Tinkerbell Hardware name). Scope fence:
+  (control plane endpoint IP, Tinkerbell Hardware name). CAPT is pinned to
+  the shrinedogg fork release v0.7.1 (upstream main plus the
+  installer-image annotation mirror, PR tinkerbell#604; see
+  `capi-providers/capt-system/provider.yaml`); re-point at upstream once a
+  release there includes it. Scope fence:
   management-only; no `addons/` (Talos ships its own CNI, no
   HelmChartProxy consumers). Bootstrap/pivot wiring and docs land with
   the rest of the #105 series.

--- a/mgmt/local-talos/capi-providers/capt-system/provider.yaml
+++ b/mgmt/local-talos/capi-providers/capt-system/provider.yaml
@@ -2,13 +2,20 @@
 # is "tinkerbell-tinkerbell" (its embedded default already points at the
 # right repo), but fetchConfig is set explicitly to stay independent of the
 # operator's embedded clusterctl defaults (#105).
+#
+# Pinned to the fork release, not upstream: upstream CAPT v0.7.0 does not
+# populate TinkerbellMachine status.installerImage, which the installer-image
+# handoff depends on (#156). The fork tag is upstream main plus exactly that
+# feature (PR tinkerbell/cluster-api-provider-tinkerbell#604): it mirrors the
+# Hardware `hardware.tinkerbell.org/installer-image` annotation into machine
+# status. Re-point this at upstream once a release there includes #604.
 apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: InfrastructureProvider
 metadata:
   name: tinkerbell-tinkerbell
   namespace: capt-system
 spec:
-  # renovate: datasource=github-releases depName=tinkerbell/cluster-api-provider-tinkerbell
-  version: "v0.7.0"
+  # renovate: datasource=github-releases depName=shrinedogg/cluster-api-provider-tinkerbell
+  version: "v0.7.1"
   fetchConfig:
-    url: "https://github.com/tinkerbell/cluster-api-provider-tinkerbell/releases"
+    url: "https://github.com/shrinedogg/cluster-api-provider-tinkerbell/releases"

--- a/mgmt/local-talos/clusters/management/cluster.yaml
+++ b/mgmt/local-talos/clusters/management/cluster.yaml
@@ -10,12 +10,12 @@
 #   spec.controlPlaneEndpoint.host       - the machine's stable IP
 #   TinkerbellMachineTemplate hardwareName - your Tinkerbell Hardware CR name
 #
-# The installer image is deliberately NOT pinned here: CABPT (>= v0.7.6)
-# injects the InfraMachine's status.installerImage as machine.install.image
-# when the infrastructure provider publishes it. Upstream CAPT v0.7.0 does
-# not populate that field (#156), so installs use the default Image Factory
-# schematic until the CAPT-side resolution lands; CABPT treats the absent
-# field as "no override".
+# The installer image is deliberately NOT pinned here: annotate the
+# Hardware CR with `hardware.tinkerbell.org/installer-image` and the pinned
+# CAPT fork (v0.7.1) mirrors it into the InfraMachine's
+# status.installerImage (#156), which CABPT (>= v0.7.6) injects as
+# machine.install.image. Without the annotation, installs use the default
+# Image Factory schematic; CABPT treats an absent field as "no override".
 ---
 apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster

--- a/tests/test-renovate-coverage.py
+++ b/tests/test-renovate-coverage.py
@@ -31,7 +31,7 @@ EXPECTED = {
         "sidero-community/cluster-api-control-plane-provider-talos",
     },
     "mgmt/local-talos/capi-providers/capt-system/provider.yaml": {
-        "tinkerbell/cluster-api-provider-tinkerbell",
+        "shrinedogg/cluster-api-provider-tinkerbell",
     },
     "mgmt/local-talos/clusters/management/cluster.yaml": {
         "kubernetes/kubernetes",


### PR DESCRIPTION
## What

Flip the local-talos CAPT pin from upstream `v0.7.0` to the shrinedogg fork release `v0.7.1`, completing the #156 Option 2 chain: the Hardware `hardware.tinkerbell.org/installer-image` annotation is now mirrored into `TinkerbellMachine.status.installerImage`, which CABPT (>= v0.7.6) injects as `machine.install.image`.

Closes #156.

## Why

Upstream CAPT v0.7.0 has no `status.installerImage` field at all, so the installer-image handoff described in #105 was inert. The fork tag is upstream `main` plus exactly one commit (the annotation mirror, proposed upstream as tinkerbell/cluster-api-provider-tinkerbell#604). The fork release v0.7.1 is verified: CRD ships the new status field, image is on GHCR (multi-arch), all three clusterctl assets present.

## Changes

- `mgmt/local-talos/capi-providers/capt-system/provider.yaml`: `v0.7.1`, fetchConfig URL and Renovate depName pointed at the fork; comment documents why and when to re-point upstream (once a release there includes #604)
- `mgmt/local-talos/clusters/management/cluster.yaml`: comment now documents the Hardware annotation as the input mechanism instead of describing upstream v0.7.0 as inert
- `tests/test-renovate-coverage.py`: capt depName expectation flipped to `shrinedogg/cluster-api-provider-tinkerbell`
- `AGENTS.md`: local-talos entry now records the CAPT fork pin and the upstream re-point condition (repo golden rule: same-PR doc updates)

## Verification

- Coverage test green under Node 24.20 (renovate 44.50.1): all pins detected including the flipped depName
- `mise run validate`: all overlays build

## Re-pointing upstream

When a tinkerbell/cluster-api-provider-tinkerbell release includes #604, flip `version`, `fetchConfig.url`, the Renovate annotation depName, and the coverage-test expectation back; the fork tag then becomes unnecessary.
