### PR TITLE
feat(local-talos): bootstrap wiring, sync source, and teardown semantics (#105, 2/3)

### DIFF
--- a/bootstrap-rs/src/config.rs
+++ b/bootstrap-rs/src/config.rs
@@ -44,11 +44,26 @@ pub struct BootstrapSection {
     pub mgmt_context: String,
 }
 
+/// The Flux sync source for an environment
+/// (`[environments.<name>].sync`, issue #105 scope item 6): where the
+/// management cluster's FluxInstance pulls its configuration from.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SyncSource {
+    /// GitRepository against GitHub, authenticated by the PAT secret
+    /// (aws, local-talos).
+    Github,
+    /// OCI artifact published from the checkout to the local registry
+    /// (local-host).
+    Oci,
+}
+
 /// One `[environments.<name>]` section.
 #[derive(Clone, Debug, Deserialize)]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub struct Environment {
     pub kind: String,
+    pub sync: SyncSource,
     pub sync_path: String,
     pub mgmt_cluster: String,
     pub mgmt_ready_timeout: String,
@@ -132,6 +147,13 @@ pub struct TeardownEnv {
     pub mgmt_eks_cluster_name: Option<String>,
     #[serde(default)]
     pub mgmt_iam_role_prefix: Option<String>,
+    /// Bare-metal semantics (local-talos only, issue #105 scope item 8):
+    /// teardown deletes the CAPI objects so CAPT releases the Tinkerbell
+    /// Hardware back to the pool, but the machine itself is never wiped
+    /// or reclaimed: it is left running Talos for the operator to re-use
+    /// or PXE-boot fresh.
+    #[serde(default)]
+    pub hardware_release: bool,
 }
 
 impl BootstrapConfig {
@@ -223,6 +245,7 @@ flux-operator = "0.58.0"
 
 [environments.local-host]
 kind = "local-host"
+sync = "oci"
 sync-path = "mgmt/local-host"
 mgmt-cluster = "local-management"
 mgmt-ready-timeout = "15m"
@@ -232,6 +255,7 @@ provider-manifests = []
 
 [environments.aws]
 kind = "aws"
+sync = "github"
 sync-path = "mgmt/aws"
 mgmt-cluster = "eu-north-1-management"
 mgmt-ready-timeout = "40m"
@@ -260,11 +284,13 @@ manifest = "mgmt/aws/infrastructure/aws-identity/identity.yaml"
 
         let aws = config.environment("aws").unwrap();
         assert_eq!(aws.mgmt_cluster, "eu-north-1-management");
+        assert_eq!(aws.sync, SyncSource::Github);
         assert_eq!(aws.move_fallbacks.len(), 1);
         assert_eq!(aws.move_fallbacks[0].name, "default");
 
         let local = config.environment("local-host").unwrap();
         assert!(local.move_fallbacks.is_empty());
+        assert_eq!(local.sync, SyncSource::Oci);
         assert_eq!(
             (
                 local.infra_provider_namespace.as_str(),

--- a/bootstrap-rs/src/main.rs
+++ b/bootstrap-rs/src/main.rs
@@ -2384,7 +2384,7 @@ async fn run_bootstrap(cfg: &Config, http: &reqwest::Client) -> Result<()> {
              check 'kubectl -n flux-system get pods' before relying on the cluster"
         );
     }
-    if cfg.profile == "aws" {
+    if runs_github_preflight(cfg) {
         let url = preflight
             .github
             .as_ref()
@@ -2394,9 +2394,7 @@ async fn run_bootstrap(cfg: &Config, http: &reqwest::Client) -> Result<()> {
         println!(">>> Watch progress with: flux get kustomizations --watch");
     } else {
         let registry_name = &cfg.repo.bootstrap.registry_name;
-        println!(
-            ">>> Local-host profile complete: Flux is reconciling from the local OCI artifact"
-        );
+        println!(">>> Bootstrap complete: Flux is reconciling from the local OCI artifact");
         println!(
             ">>> Local registry: localhost:{port} (cluster endpoint: {registry_name}:5000)",
             port = cfg.registry_port

--- a/bootstrap-rs/src/main.rs
+++ b/bootstrap-rs/src/main.rs
@@ -20,7 +20,7 @@
 mod config;
 mod teardown;
 
-use config::{BootstrapConfig, Environment};
+use config::{BootstrapConfig, Environment, SyncSource};
 
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
@@ -401,21 +401,31 @@ fn unpause_patch() -> serde_json::Value {
     json!({ "spec": { "paused": false } })
 }
 
-/// Tools required on PATH for the given profile (local-host needs the
-/// reconciliation-watch and oci-push tools; the environment names are the
-/// binary's sequence contract, issue #98 decision 3).
-fn required_tools(is_local: bool) -> Vec<&'static str> {
+/// Tools required on PATH for the given environment's sync surface (the
+/// environment names are the binary's sequence contract, issue #98
+/// decision 3; the extras are the sync source's, issue #105 scope item 6).
+fn required_tools(env: &Environment) -> Vec<&'static str> {
     // The binary owns the HTTP checks the scripts used curl for. curl
-    // stays required for local-host anyway: the mise oci-push task shells
-    // out to curl for its registry availability check. flux is exercised
-    // by the local-host reconciliation watch (Step 5). clusterctl and mise
-    // are pivot tools (clusterctl get kubeconfig / describe / move; mise
-    // aws-credentials / oci-push) required on BOTH profiles.
+    // stays required for oci-sync environments anyway: the mise oci-push
+    // task shells out to curl for its registry availability check. flux
+    // is exercised by the local-host reconciliation watch (Step 5).
+    // clusterctl and mise are pivot tools (clusterctl get kubeconfig /
+    // describe / move; mise aws-credentials / oci-push) required on
+    // EVERY environment. talosctl is deliberately absent for local-talos:
+    // the machine is remote and talosctl is an operator convenience, not
+    // a bootstrap dependency.
     let mut tools = vec!["kind", "helm", "kubectl", "clusterctl", "mise"];
-    if is_local {
+    if env.sync == SyncSource::Oci {
         tools.extend(["flux", "curl"]);
     }
     tools
+}
+
+/// Whether the GitHub/age preflight (PAT, repo branch probe, sops age
+/// key) must run: gated on the sync source (issue #105 scope item 6),
+/// not the profile name. AWS-only credential steps stay profile-gated.
+fn runs_github_preflight(cfg: &Config) -> bool {
+    cfg.environment.sync == SyncSource::Github
 }
 
 // ── Process helpers ───────────────────────────────────────────────────────────
@@ -554,7 +564,7 @@ impl Drop for ChildGuard {
 
 // ── Preflight ─────────────────────────────────────────────────────────────────
 
-struct AwsContext {
+struct GithubContext {
     git_repo_url: String,
     github_user: String,
     github_token: String,
@@ -565,12 +575,12 @@ struct AwsContext {
 struct Preflight {
     engine: String,
     engine_sock: String,
-    aws: Option<AwsContext>,
+    github: Option<GithubContext>,
 }
 
 async fn preflight_checks(cfg: &Config, http: &reqwest::Client) -> Result<Preflight> {
     // Report every missing tool at once instead of failing on the first.
-    let missing: Vec<&str> = required_tools(cfg.is_local())
+    let missing: Vec<&str> = required_tools(&cfg.environment)
         .into_iter()
         .filter(|t| !command_exists(t))
         .collect();
@@ -578,8 +588,8 @@ async fn preflight_checks(cfg: &Config, http: &reqwest::Client) -> Result<Prefli
         bail!("missing required tools in PATH: {}", missing.join(", "));
     }
 
-    let aws = if cfg.profile == "aws" {
-        Some(preflight_aws(cfg, http).await?)
+    let github = if runs_github_preflight(cfg) {
+        Some(preflight_github(cfg, http).await?)
     } else {
         None
     };
@@ -643,11 +653,11 @@ async fn preflight_checks(cfg: &Config, http: &reqwest::Client) -> Result<Prefli
     Ok(Preflight {
         engine,
         engine_sock,
-        aws,
+        github,
     })
 }
 
-async fn preflight_aws(cfg: &Config, http: &reqwest::Client) -> Result<AwsContext> {
+async fn preflight_github(cfg: &Config, http: &reqwest::Client) -> Result<GithubContext> {
     let github_token = cfg
         .github_token
         .clone()
@@ -714,7 +724,7 @@ async fn preflight_aws(cfg: &Config, http: &reqwest::Client) -> Result<AwsContex
             )
         })?;
 
-    Ok(AwsContext {
+    Ok(GithubContext {
         git_repo_url,
         github_user,
         github_token,
@@ -1121,9 +1131,9 @@ async fn install_flux_operator(
     run("helm", &arg_refs).await
 }
 
-async fn create_aws_secrets(
+async fn create_github_secrets(
     repo: &BootstrapConfig,
-    aws: &AwsContext,
+    github: &GithubContext,
     kubeconfig: Option<&str>,
 ) -> Result<()> {
     // Both secrets are applied as manifests on stdin: idempotent on rerun,
@@ -1142,8 +1152,8 @@ async fn create_aws_secrets(
             "metadata": { "name": pat_secret, "namespace": flux_ns },
             "type": "Opaque",
             "stringData": {
-                "username": aws.github_user,
-                "password": aws.github_token,
+                "username": github.github_user,
+                "password": github.github_token,
             },
         }),
     )
@@ -1178,7 +1188,7 @@ async fn create_aws_secrets(
             "metadata": { "name": sops_secret, "namespace": flux_ns },
             "type": "Opaque",
             "stringData": {
-                format!("keys.{}.agekey", aws.age_pubkey): aws.age_key_content,
+                format!("keys.{}.agekey", github.age_pubkey): github.age_key_content,
             },
         }),
     )
@@ -1187,7 +1197,7 @@ async fn create_aws_secrets(
 
 async fn install_flux_instance(
     cfg: &Config,
-    aws: Option<&AwsContext>,
+    github: Option<&GithubContext>,
     registry_config: &Path,
     kubeconfig: Option<&str>,
 ) -> Result<bool> {
@@ -1234,13 +1244,13 @@ async fn install_flux_instance(
         args.extend(["--kubeconfig".into(), kc.to_string()]);
     }
 
-    match aws {
-        Some(aws) => {
+    match github {
+        Some(github) => {
             args.extend([
                 "--set".into(),
                 "instance.sync.kind=GitRepository".into(),
                 "--set".into(),
-                format!("instance.sync.url={}", aws.git_repo_url),
+                format!("instance.sync.url={}", github.git_repo_url),
                 "--set".into(),
                 format!(
                     "instance.sync.ref=refs/heads/{}",
@@ -2097,10 +2107,10 @@ async fn pivot_seed_target(
     // seed_flux against the target: the same operator + secrets + instance
     // sequence the bootstrap ran against kind.
     install_flux_operator(&cfg.repo, registry_config, Some(kc)).await?;
-    if let Some(aws) = preflight.aws.as_ref() {
-        create_aws_secrets(&cfg.repo, aws, Some(kc)).await?;
+    if let Some(github) = preflight.github.as_ref() {
+        create_github_secrets(&cfg.repo, github, Some(kc)).await?;
     }
-    install_flux_instance(cfg, preflight.aws.as_ref(), registry_config, Some(kc)).await?;
+    install_flux_instance(cfg, preflight.github.as_ref(), registry_config, Some(kc)).await?;
 
     println!(">>> Kustomizations on the management cluster:");
     run(
@@ -2206,7 +2216,7 @@ async fn run_pivot(cfg: &Config, preflight: &Preflight, http: &reqwest::Client) 
     // ── Phase 0: preflight ────────────────────────────────────────────────
     // Required tools were already checked by the bootstrap preflight
     // (clusterctl and mise are required on both profiles for the pivot);
-    // the aws flux-env checks ran in preflight_aws; the GitHub branch
+    // the aws flux-env checks ran in preflight_github; the GitHub branch
     // check is not repeated here.
     pivot_check_context(cfg).await?;
     pivot_check_management_cluster(&cfg.repo.bootstrap.mgmt_namespace, mgmt_cluster).await?;
@@ -2352,14 +2362,14 @@ async fn run_bootstrap(cfg: &Config, http: &reqwest::Client) -> Result<()> {
     // Step 2: install the Flux Operator.
     install_flux_operator(&cfg.repo, registry_config.path(), None).await?;
 
-    // Step 3: GitHub PAT + SOPS age secrets (aws only).
-    if let Some(aws) = preflight.aws.as_ref() {
-        create_aws_secrets(&cfg.repo, aws, None).await?;
+    // Step 3: GitHub PAT + SOPS age secrets (github-sync environments).
+    if let Some(github) = preflight.github.as_ref() {
+        create_github_secrets(&cfg.repo, github, None).await?;
     }
 
     // Step 4: install the FluxInstance via Helm.
     let controllers_ready =
-        install_flux_instance(cfg, preflight.aws.as_ref(), registry_config.path(), None).await?;
+        install_flux_instance(cfg, preflight.github.as_ref(), registry_config.path(), None).await?;
 
     // Step 5: watch local-host reconciliation.
     if cfg.is_local() {
@@ -2376,7 +2386,7 @@ async fn run_bootstrap(cfg: &Config, http: &reqwest::Client) -> Result<()> {
     }
     if cfg.profile == "aws" {
         let url = preflight
-            .aws
+            .github
             .as_ref()
             .map(|a| a.git_repo_url.as_str())
             .unwrap_or_default();
@@ -2426,6 +2436,12 @@ mod tests {
 
     fn config_from(cli: &Cli, get: impl Fn(&str) -> Option<String>) -> Config {
         Config::from_env(cli, repo_config(), get).unwrap()
+    }
+
+    // A Config skeleton for tests that only exercise profile-gated logic.
+    fn teardown_minimal_config() -> Config {
+        let cli = Cli::try_parse_from(["knr-bootstrap", "aws"]).unwrap();
+        Config::from_env(&cli, repo_config(), |_| None).unwrap()
     }
 
     const VALID_AGE_KEY: &str = "# created: 2026-01-01T00:00:00+02:00\n# public key: age1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq\nAGE-SECRET-KEY-1SECRETSECRETSECRET\n";
@@ -2589,6 +2605,74 @@ mod tests {
     }
 
     #[test]
+    fn sync_source_is_config_driven() {
+        // The FluxInstance sync source comes from bootstrap.toml [environments.*]
+        // (issue #105 scope item 6), not from the profile name: aws and
+        // local-talos sync from GitHub, local-host from the local OCI registry.
+        let repo = repo_config();
+        assert_eq!(
+            repo.environment("aws").unwrap().sync,
+            SyncSource::Github,
+            "aws must declare sync = \"github\""
+        );
+        assert_eq!(
+            repo.environment("local-talos").unwrap().sync,
+            SyncSource::Github,
+            "local-talos must declare sync = \"github\""
+        );
+        assert_eq!(
+            repo.environment("local-host").unwrap().sync,
+            SyncSource::Oci,
+            "local-host must declare sync = \"oci\""
+        );
+    }
+
+    #[test]
+    fn github_preflight_runs_for_github_sync_environments() {
+        // The GitHub/age preflight (PAT, repo branch probe, sops key) is
+        // gated on the sync source, not the aws profile name: local-talos
+        // needs the identical checks. The AWS-only credential steps stay
+        // gated on the profile.
+        assert!(runs_github_preflight(&Config {
+            profile: "aws".into(),
+            environment: repo_config().environment("aws").unwrap().clone(),
+            ..teardown_minimal_config()
+        }));
+        assert!(runs_github_preflight(&Config {
+            profile: "local-talos".into(),
+            environment: repo_config().environment("local-talos").unwrap().clone(),
+            ..teardown_minimal_config()
+        }));
+        assert!(!runs_github_preflight(&Config {
+            profile: "local-host".into(),
+            environment: repo_config().environment("local-host").unwrap().clone(),
+            ..teardown_minimal_config()
+        }));
+    }
+
+    #[test]
+    fn required_tools_match_the_sync_surface() {
+        // Base tools for every environment; local-host adds the local
+        // reconciliation-watch and oci-push tools. local-talos needs
+        // nothing beyond the base set: the machine is remote (no
+        // localhost rewrite, no oci-push) and talosctl is an operator
+        // convenience, not a bootstrap dependency.
+        let base = ["kind", "helm", "kubectl", "clusterctl", "mise"];
+        assert_eq!(
+            required_tools(&repo_config().environment("aws").unwrap()),
+            base
+        );
+        assert_eq!(
+            required_tools(&repo_config().environment("local-talos").unwrap()),
+            base
+        );
+        let local = required_tools(&repo_config().environment("local-host").unwrap());
+        assert!(local.len() > base.len());
+        assert!(local.contains(&"flux"));
+        assert!(local.contains(&"curl"));
+    }
+
+    #[test]
     fn toolbox_kind_kubeconfig_uses_one_explicit_file() {
         assert_eq!(
             toolbox_kubeconfig_path(true, Some("/state/kind.yaml")).unwrap(),
@@ -2707,7 +2791,7 @@ mod tests {
         let err = resolve_environment(Some("bogus"), None, &repo).unwrap_err();
         assert_eq!(
             err.to_string(),
-            "unsupported profile 'bogus' (expected 'local-host' or 'aws')"
+            "unsupported profile 'bogus' (expected 'local-host' or 'aws' or 'local-talos')"
         );
     }
 
@@ -2757,7 +2841,7 @@ mod tests {
             resolve_environment(Some("bogus"), Some("local-host"), &repo)
                 .unwrap_err()
                 .to_string(),
-            "unsupported profile 'bogus' (expected 'local-host' or 'aws')"
+            "unsupported profile 'bogus' (expected 'local-host' or 'aws' or 'local-talos')"
         );
     }
 
@@ -2847,10 +2931,11 @@ mod tests {
 
     #[test]
     fn required_tools_cover_every_invoked_binary() {
-        // The pivot invokes clusterctl and mise on both profiles.
-        let aws = required_tools(false);
+        // The pivot invokes clusterctl and mise on every environment.
+        let repo = repo_config();
+        let aws = required_tools(repo.environment("aws").unwrap());
         assert_eq!(aws, vec!["kind", "helm", "kubectl", "clusterctl", "mise"]);
-        let local = required_tools(true);
+        let local = required_tools(repo.environment("local-host").unwrap());
         assert_eq!(
             local,
             vec![

--- a/bootstrap-rs/src/main.rs
+++ b/bootstrap-rs/src/main.rs
@@ -2659,14 +2659,14 @@ mod tests {
         // convenience, not a bootstrap dependency.
         let base = ["kind", "helm", "kubectl", "clusterctl", "mise"];
         assert_eq!(
-            required_tools(&repo_config().environment("aws").unwrap()),
+            required_tools(repo_config().environment("aws").unwrap()),
             base
         );
         assert_eq!(
-            required_tools(&repo_config().environment("local-talos").unwrap()),
+            required_tools(repo_config().environment("local-talos").unwrap()),
             base
         );
-        let local = required_tools(&repo_config().environment("local-host").unwrap());
+        let local = required_tools(repo_config().environment("local-host").unwrap());
         assert!(local.len() > base.len());
         assert!(local.contains(&"flux"));
         assert!(local.contains(&"curl"));

--- a/bootstrap-rs/src/teardown.rs
+++ b/bootstrap-rs/src/teardown.rs
@@ -1739,6 +1739,118 @@ pub async fn run_teardown(cfg: &Config, tcfg: &TeardownConfig) -> Result<()> {
         return Ok(());
     }
 
+    // ── local-talos path (bare metal; issue #105 scope item 8) ────────
+    if td.hardware_release {
+        if tcfg.aws_only {
+            bail!(
+                "AWS_ONLY=1 cannot be combined with the local-talos profile\n       There is no AWS orphan sweep for operator-owned hardware"
+            );
+        }
+        for cmd in ["kubectl", "helm", "xargs"] {
+            if which_failure(cmd).await {
+                bail!("{cmd} not found in PATH");
+            }
+        }
+
+        // The CAPI inventory lives in kind pre-pivot, in the management
+        // cluster itself post-pivot (same discovery as aws).
+        let host = discover_controller_host(cfg).await;
+        let kc: Option<String> = match &host {
+            ControllerHost::Kind => None,
+            ControllerHost::SelfManaged => {
+                Some(tcfg.mgmt_kubeconfig.to_string_lossy().into_owned())
+            }
+            ControllerHost::Unreachable => {
+                println!(">>> No reachable controller host; nothing to release");
+                println!();
+                println!("✓ Teardown complete.");
+                return Ok(());
+            }
+        };
+
+        if let Some(kc) = kc.as_deref() {
+            suspend_flux(Some(kc)).await?;
+        } else {
+            suspend_flux(None).await?;
+        }
+        // Delete every CAPI Cluster (the management cluster included: its
+        // deletion is the release). CAPT deprovisions the machine's CAPI
+        // footprint; the Hardware CR stays in the Tinkerbell stack and the
+        // node keeps running Talos for the operator.
+        let mut clusters_gone = true;
+        let listing = capture_lossy(
+            "kubectl",
+            &kubectl_cmd(kc.as_deref(), &["get", "clusters", "-A", "-o", "name"]),
+        )
+        .await;
+        let clusters: Vec<String> = listing
+            .lines()
+            .filter_map(|l| l.trim().rsplit('/').next())
+            .map(String::from)
+            .collect();
+        if clusters.is_empty() {
+            println!(">>> No CAPI clusters found; nothing to release");
+        } else {
+            for cluster in &clusters {
+                println!(">>> Deleting CAPI cluster '{cluster}' (Hardware release)...");
+                let _ = run(
+                    "kubectl",
+                    &kubectl_cmd(
+                        kc.as_deref(),
+                        &["delete", "cluster", cluster, "--ignore-not-found"],
+                    ),
+                )
+                .await;
+            }
+            println!(
+                ">>> Waiting up to {}s for the clusters to be deleted...",
+                tcfg.cluster_delete_timeout
+            );
+            let deadline = std::time::Instant::now()
+                + std::time::Duration::from_secs(tcfg.cluster_delete_timeout);
+            loop {
+                let remaining = capture_lossy(
+                    "kubectl",
+                    &kubectl_cmd(kc.as_deref(), &["get", "clusters", "-A", "-o", "name"]),
+                )
+                .await;
+                if remaining.trim().is_empty() {
+                    println!("✓   All CAPI clusters deleted; Hardware released to the pool");
+                    break;
+                }
+                if std::time::Instant::now() >= deadline {
+                    eprintln!("!   Timed out waiting for CAPI clusters to delete; aborting.");
+                    eprintln!("!   The management cluster was left intact; re-run teardown once");
+                    eprintln!("!   'kubectl get clusters -A' is empty.");
+                    clusters_gone = false;
+                    break;
+                }
+                println!(">>>   clusters still deleting...");
+                tokio::time::sleep(std::time::Duration::from_secs(30)).await;
+            }
+        }
+
+        if clusters_gone && host == ControllerHost::Kind {
+            // Pre-pivot: the bootstrap kind cluster owns nothing else.
+            let name = cfg.repo.bootstrap.kind_cluster.clone();
+            println!(">>> Deleting kind bootstrap cluster '{name}'...");
+            if run("kind", &["delete", "cluster", "--name", &name])
+                .await
+                .is_ok()
+            {
+                println!("✓   kind cluster '{name}' deleted");
+            } else {
+                warn("kind cluster could not be deleted – it may already be gone");
+            }
+        }
+
+        println!();
+        println!("✓ Teardown complete.");
+        println!("!   The machine was NOT wiped: it still runs Talos. Re-use it or");
+        println!("!   PXE-boot it fresh (issue #105 teardown semantics).");
+        return Ok(());
+    }
+
     // ── aws path ──────────────────────────────────────────────────────
     let host = if tcfg.aws_only {
         ControllerHost::Unreachable

--- a/bootstrap-rs/src/teardown.rs
+++ b/bootstrap-rs/src/teardown.rs
@@ -1746,7 +1746,7 @@ pub async fn run_teardown(cfg: &Config, tcfg: &TeardownConfig) -> Result<()> {
                 "AWS_ONLY=1 cannot be combined with the local-talos profile\n       There is no AWS orphan sweep for operator-owned hardware"
             );
         }
-        for cmd in ["kubectl", "helm", "xargs"] {
+        for cmd in ["kind", "kubectl"] {
             if which_failure(cmd).await {
                 bail!("{cmd} not found in PATH");
             }

--- a/bootstrap.toml
+++ b/bootstrap.toml
@@ -63,6 +63,8 @@ s3-bucket-pattern = "knr-ops-{account_id}-{cluster_name}-data"
 
 [environments.local-host]
 kind = "local-host"
+# Flux syncs the OCI artifact published from the checkout by oci-push.
+sync = "oci"
 sync-path = "mgmt/local-host"
 mgmt-cluster = "local-management"
 mgmt-ready-timeout = "15m"
@@ -88,6 +90,8 @@ mgmt-container-prefix = "local-management"
 
 [environments.aws]
 kind = "aws"
+# Flux syncs the GitHub repository (GitRepository + flux-github-pat).
+sync = "github"
 sync-path = "mgmt/aws"
 mgmt-cluster = "eu-north-1-management"
 mgmt-ready-timeout = "40m"
@@ -129,3 +133,38 @@ region = "eu-west-1"
 cluster-name = "eu-west-1-workload"
 eks-cluster-name = "default_eu-west-1-workload-control-plane"
 rds-instance = "knr-ops-eu-west-1-workload-db"
+
+[environments.local-talos]
+kind = "local-talos"
+# Flux syncs the GitHub repository, like aws: a physical machine cannot
+# reach the laptop's OCI registry (issue #105 decision). Requires a GitHub
+# PAT (flux-github-pat), unlike local-host.
+sync = "github"
+sync-path = "mgmt/local-talos"
+mgmt-cluster = "local-talos-management"
+# PXE install + first Talos boot takes longer than kind/EKS provisioning.
+mgmt-ready-timeout = "30m"
+# The Tinkerbell infrastructure provider (well-known clusterctl name
+# "tinkerbell-tinkerbell", see capi-providers/capt-system/provider.yaml).
+infra-provider-namespace = "capt-system"
+infra-provider-name = "tinkerbell-tinkerbell"
+provider-manifests = [
+  "mgmt/local-talos/capi-providers/capi-system/namespace.yaml",
+  "mgmt/local-talos/capi-providers/capi-system/providers.yaml",
+  "mgmt/local-talos/capi-providers/cabpt-system/namespace.yaml",
+  "mgmt/local-talos/capi-providers/cabpt-system/provider.yaml",
+  "mgmt/local-talos/capi-providers/cacppt-system/namespace.yaml",
+  "mgmt/local-talos/capi-providers/cacppt-system/provider.yaml",
+  "mgmt/local-talos/capi-providers/capt-system/namespace.yaml",
+  "mgmt/local-talos/capi-providers/capt-system/provider.yaml",
+]
+
+[environments.local-talos.teardown]
+# local-talos owns no workload clusters (scope fence: management-only).
+capi-workloads = []
+# Bare-metal semantics (issue #105 scope item 8): teardown deletes the
+# CAPI objects so CAPT releases the Tinkerbell Hardware back to the pool,
+# but the machine itself is never wiped or reclaimed: it is left running
+# Talos for the operator to re-use or PXE-boot fresh. No container-prefix
+# sweep (that is the local-host CAPD path) and no AWS orphan sweep.
+hardware-release = true

--- a/mise.local-talos.toml
+++ b/mise.local-talos.toml
@@ -1,0 +1,27 @@
+# local-talos environment task layer (issue #105).
+#
+# Unlike local-host this environment syncs its configuration from GitHub
+# (a physical machine cannot reach the laptop's OCI registry), so there is
+# no oci-push task and no workload-cluster kubeconfig port rewrite: the
+# single management machine is reached directly through the endpoint
+# committed in mgmt/local-talos/clusters/management/cluster.yaml.
+
+[env]
+KNR_OPS_PROFILE = "local-talos"
+
+[tools]
+talosctl = "1.14.0"
+
+[tasks.kubeconfigs]
+description = "Export the Talos management-cluster kubeconfig (no rewrite: the machine is remote)"
+run = '''
+MGMT_CLUSTER="${MGMT_CLUSTER:-local-talos-management}"
+MGMT_KUBECONFIG="${MGMT_KUBECONFIG:-$HOME/.kube/knr-ops-mgmt.yaml}"
+clusterctl get kubeconfig "$MGMT_CLUSTER" -n default > "$MGMT_KUBECONFIG"
+chmod 600 "$MGMT_KUBECONFIG"
+kubectl --kubeconfig "$MGMT_KUBECONFIG" config rename-context \
+  "$(kubectl --kubeconfig "$MGMT_KUBECONFIG" config current-context)" \
+  knr-ops-mgmt >/dev/null
+echo "Wrote ${MGMT_KUBECONFIG}"
+echo "Use with: KUBECONFIG=${MGMT_KUBECONFIG} kubectl get nodes"
+'''

--- a/mise.toml
+++ b/mise.toml
@@ -90,7 +90,7 @@ run = "scripts/toolbox-run.sh pivot"
 [tasks.mgmt-kubeconfig]
 description = "Export the management-cluster kubeconfig to ~/.kube/knr-ops-mgmt.yaml"
 run = '''
-MGMT_CLUSTER="${MGMT_CLUSTER:-$([ "${KNR_OPS_PROFILE:-aws}" = local-host ] && echo local-management || echo eu-north-1-management)}"
+MGMT_CLUSTER="${MGMT_CLUSTER:-$(case "${KNR_OPS_PROFILE:-aws}" in local-host) echo local-management;; local-talos) echo local-talos-management;; *) echo eu-north-1-management;; esac)}"
 MGMT_KUBECONFIG="${MGMT_KUBECONFIG:-$HOME/.kube/knr-ops-mgmt.yaml}"
 clusterctl get kubeconfig "$MGMT_CLUSTER" -n default > "$MGMT_KUBECONFIG"
 chmod 600 "$MGMT_KUBECONFIG"

--- a/tests/test-bootstrap-config.py
+++ b/tests/test-bootstrap-config.py
@@ -26,10 +26,12 @@ CHART_MANIFESTS = {
     "cert-manager": [
         "mgmt/aws/infrastructure/cert-manager/helmrelease.yaml",
         "mgmt/local-host/infrastructure/cert-manager/helmrelease.yaml",
+        "mgmt/local-talos/infrastructure/cert-manager/helmrelease.yaml",
     ],
     "capi-operator": [
         "mgmt/aws/infrastructure/capi-operator/helmrelease.yaml",
         "mgmt/local-host/infrastructure/capi-operator/helmrelease.yaml",
+        "mgmt/local-talos/infrastructure/capi-operator/helmrelease.yaml",
     ],
 }
 
@@ -76,6 +78,16 @@ def main() -> int:
         sync = REPO_ROOT / env.get("sync-path", "")
         if not sync.is_dir():
             failures.append(f"environments.{name}.sync-path '{env.get('sync-path')}' is not a directory")
+        # The sync source drives the FluxInstance seeding (issue #105):
+        # 'github' (GitRepository + PAT secret, aws and local-talos) or
+        # 'oci' (local registry artifact, local-host). The Rust enum must
+        # agree with every declared value (unknown value = startup error).
+        if "sync" not in env:
+            failures.append(f"environments.{name} is missing the 'sync' key")
+        elif env["sync"] not in ("github", "oci"):
+            failures.append(
+                f"environments.{name}.sync {env['sync']!r} must be 'github' or 'oci'"
+            )
         for manifest in env.get("provider-manifests", []):
             if not (REPO_ROOT / manifest).is_file():
                 failures.append(f"environments.{name} provider manifest missing: {manifest}")


### PR DESCRIPTION
## What

PR 2 of the #105 series: the local-talos bootstrap/pivot wiring. The Rust binary and the repo config now know the local-talos environment end to end, with the Flux sync source made config-driven instead of profile-gated.

Refs #105 (not closing: docs, Renovate surfaces, and the hardware acceptance run remain).

## Why the milestone's "does not touch bootstrap-rs/" note is superseded

The milestone note predates #98. Issue #105 scope item 6 says local-talos "should be the first consumer of the `bootstrap.toml` `[environments.<name>]` surface rather than another enum variant", and the pre-#98 code could not honor that: the GitHub sync behavior (FluxInstance `instance.sync.kind=GitRepository`, PAT secret creation, branch probe, sops-age key validation) was gated on `profile == "aws"`. This PR implements exactly the issue's directive; the change is config-surface-first (one new enum + one gate flip), not a rewrite.

## Changes

**`bootstrap.toml`** - new `[environments.local-talos]`: `sync = "github"`, `sync-path = "mgmt/local-talos"`, `mgmt-cluster = "local-talos-management"`, `mgmt-ready-timeout = "30m"` (PXE + first Talos boot), `tinkerbell-tinkerbell` provider names, 8 provider manifests, teardown `capi-workloads = []` + `hardware-release = true`. Existing environments gained explicit `sync` keys (`aws`/`local-talos`: `github`; `local-host`: `oci`).

**`bootstrap-rs/src/config.rs`** - `SyncSource` enum (`github` | `oci`) deserialized from the new required `sync` key; `TeardownEnv.hardware_release` bool.

**`bootstrap-rs/src/main.rs`** - `preflight_aws` renamed `preflight_github` (its checks are entirely GitHub + age validation, zero AWS content); the gate is now `runs_github_preflight()` = sync source is github. The CAPA-credentials step stays gated on `profile == "aws"`. `required_tools` takes the `Environment` and derives extras from the sync source: only OCI environments require `flux` + `curl`; local-talos requires the base five (talosctl deliberately absent: the machine is remote and talosctl is an operator convenience, not a bootstrap dependency).

**`bootstrap-rs/src/teardown.rs`** - new local-talos path (dispatched on `hardware_release`): refuses AWS_ONLY, discovers the controller host (kind pre-pivot / self-managed post-pivot), suspends Flux, deletes every CAPI Cluster (the deletion IS the Hardware release), waits for deprovision, deletes the kind bootstrap cluster if pre-pivot. The machine itself is never wiped; final message says so.

**`mise.local-talos.toml`** - new task layer: `KNR_OPS_PROFILE = "local-talos"`, `talosctl = "1.14.0"`, `kubeconfigs` without the CAPD localhost rewrite.

**`mise.toml`** - the `mgmt-kubeconfig` MGMT_CLUSTER default chain learns local-talos (`case` replaces the single-pattern `[ ... = local-host ]`).

**`tests/test-bootstrap-config.py`** - requires `sync` on every environment with value check; chart cross-check extends to the local-talos helmreleases.

## TDD evidence

- Python cross-check RED (sync keys missing) -> GREEN after bootstrap.toml edits.
- Rust RED (15 errors: no `SyncSource`, no field `sync`, missing helpers) -> GREEN: 50/50 tests pass, `cargo fmt --check` clean, clippy 0 warnings.
- Contract-change failures fixed deliberately: the unsupported-profile message now lists three environments (two tests updated), the MINIMAL fixture gained `sync` lines with new assertions.

## Verification

- `mise run validate` exit 0 (49 overlays).
- `mise -E local-talos run kubeconfigs` fails gracefully with the clusterctl "no configuration" error when no cluster exists (verified; expected without hardware).
- No em-dashes in the diff.

## Deliberately out of scope

- Docs (extending/operations/README) - PR 3.
- Renovate coverage for the new talosctl pin - PR 3 (needs a mise-tools manager extension).
- AGENTS.md - the write to the protected file timed out waiting for approval; to be folded in separately.
- End-to-end run - blocked on Tinkerbell hardware (issue acceptance).
