### PR TITLE
docs: local-talos documentation and talosctl Renovate pin (#105, 3/3)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,15 +3,15 @@
 #
 #   cp .env.example .env
 
-# ── GitOps source (AWS profile) ───────────────────────────────────────────────
-# HTTPS URL of THIS repository. The AWS profile uses it for Flux sync.
-# Flux syncs the mgmt/ path from here.
+# ── GitOps source (GitHub-synced profiles) ────────────────────────────────────
+# HTTPS URL of THIS repository. The aws and local-talos profiles use it for
+# Flux sync. Flux syncs the mgmt/ path from here.
 GIT_REPO_URL="https://github.com/polarsquad/knr-ops"
 
-# ── GitHub PAT for Flux (AWS profile) ─────────────────────────────────────────
+# ── GitHub PAT for Flux (GitHub-synced profiles) ──────────────────────────────
 # Create a fine-grained token with read-only Contents access, or a classic token
-# with the `repo` scope. The AWS profile uses it for Flux to clone this
-# repository; the Flux Operator chart is pulled anonymously.
+# with the `repo` scope. The aws and local-talos profiles use it for Flux to
+# clone this repository; the Flux Operator chart is pulled anonymously.
 GITHUB_TOKEN=""
 # Basic-auth username paired with the token. Any non-empty value works for
 # GitHub PATs; "git" is a safe default.

--- a/.env.example
+++ b/.env.example
@@ -3,14 +3,14 @@
 #
 #   cp .env.example .env
 
-# ── GitOps source (GitHub-synced profiles) ────────────────────────────────────
-# HTTPS URL of THIS repository. The aws and local-talos profiles use it for
+# ── GitOps source (GitHub-synced environments) ────────────────────────────────
+# HTTPS URL of THIS repository. The aws and local-talos environments use it for
 # Flux sync. Flux syncs the mgmt/ path from here.
 GIT_REPO_URL="https://github.com/polarsquad/knr-ops"
 
-# ── GitHub PAT for Flux (GitHub-synced profiles) ──────────────────────────────
+# ── GitHub PAT for Flux (GitHub-synced environments) ──────────────────────────
 # Create a fine-grained token with read-only Contents access, or a classic token
-# with the `repo` scope. The aws and local-talos profiles use it for Flux to
+# with the `repo` scope. The aws and local-talos environments use it for Flux to
 # clone this repository; the Flux Operator chart is pulled anonymously.
 GITHUB_TOKEN=""
 # Basic-auth username paired with the token. Any non-empty value works for

--- a/README.md
+++ b/README.md
@@ -5,9 +5,11 @@
 
 A GitOps pattern for managing cloud infrastructure through the Kubernetes API:
 no Terraform, no DSLs, no state files, no second toolchain. This repository is
-a working reference implementation of that pattern, with two environments:
-`aws`, which runs it end-to-end on AWS EKS, and `local-host`, which runs the
-same lifecycle on local clusters with no cloud account involved. **It is not a
+a working reference implementation of that pattern, with three environments:
+`aws`, which runs it end-to-end on AWS EKS; `local-host`, which runs the
+same lifecycle on local clusters with no cloud account involved; and
+`local-talos`, which pivots onto a single-node Talos Linux cluster
+PXE-booted onto operator-provided bare metal. **It is not a
 product**: fork it, strip it down, and adapt the layout to your own cloud and
 clusters.
 
@@ -30,6 +32,12 @@ provider instead of CAPA: a local OCI registry, a one-control-plane/one-worker
 workload cluster, a second Flux instance, and a Podinfo app reachable from
 your laptop. It covers the complete GitOps, CAPI, and pivot lifecycle without
 provisioning AWS resources.
+
+The `local-talos` environment runs the same chain onto physical hardware:
+Tinkerbell (CAPT) PXE-boots one machine with [Talos
+Linux](https://www.talos.dev/), and the single-node Talos cluster becomes
+the self-managed management plane, syncing from GitHub like `aws`. Scope
+fence: management-only, no workload cluster.
 
 The imperative part of the lifecycle (bootstrap, pivot, and teardown) is a
 single Rust CLI, [`knr-bootstrap`](docs/bootstrap-cli.md), that replaces the
@@ -90,7 +98,11 @@ A future matching `v*` tag publishes
 `ghcr.io/polarsquad/knr-ops-toolbox` for Linux amd64 and arm64 as `X.Y.Z`,
 `X.Y`, and stable `latest`, with a keyless signature and SPDX SBOM
 attestation. The `aws` environment additionally requires a GitHub PAT with
-read access, AWS credentials and service quotas, and an age private key.
+read access, AWS credentials and service quotas, and an age private key. The
+`local-talos` environment needs the PAT and age key too (it syncs from
+GitHub), plus a reachable Tinkerbell stack and the site values in
+`mgmt/local-talos/clusters/management/cluster.yaml`; see
+[Operations](docs/operations.md).
 
 Native development and air-gap work additionally need:
 
@@ -193,6 +205,21 @@ controller host, deletes the workload clusters, sweeps orphaned resources in
 both workload regions plus the self-managed management cluster, and removes
 the `clusterawsadm` CloudFormation stack.
 
+The `local-talos` environment targets a physical machine through Tinkerbell:
+a PXE install of Talos Linux, then the same bootstrap, pivot, and
+self-management flow, synced from GitHub. It needs the GitHub PAT and age
+key, a reachable Tinkerbell stack with a `Hardware` resource for the
+machine, and the site values in
+`mgmt/local-talos/clusters/management/cluster.yaml`:
+
+```sh
+mise -E local-talos install  # adds talosctl
+mise -E local-talos run bootstrap
+export KUBECONFIG="$PWD/.kube/knr-ops-mgmt.yaml"
+mise -E local-talos run kubeconfigs
+mise -E local-talos run teardown  # releases the Hardware; never wipes the machine
+```
+
 ## The bootstrap CLI
 
 The single `knr-bootstrap` binary implements bootstrap, the default pivot, and
@@ -236,7 +263,8 @@ teardown controls, toolbox release, and current parity status.
 ├── scripts/toolbox-run.sh         Docker/Podman wrapper used by lifecycle tasks
 ├── tests/                         Config and Renovate coverage cross-checks
 ├── docs/                          Detailed documentation (see table above)
-├── mise.toml / mise.*.toml        Pinned toolchain and AWS/local-host tasks
+├── mise.toml / mise.*.toml        Pinned toolchain and per-environment
+│                                  task layers (aws, local-talos)
 ├── renovate.json5                 Hosted Renovate discovery and grouping rules
 ├── mgmt/aws/                      Synced by the MANAGEMENT cluster's Flux
 │   ├── infrastructure/           cert-manager, CAPI operator, CAPA identity,
@@ -252,6 +280,9 @@ teardown controls, toolbox release, and current parity status.
 │                                  carries the self-managed management cluster
 ├── mgmt/local-host/              OCI-synced CAPI/CAPD local workload cluster
 │                                  and its management cluster definition
+├── mgmt/local-talos/             Single-node Talos management cluster on
+│                                  bare metal via Tinkerbell (CAPT);
+│                                  GitHub-synced like mgmt/aws
 └── workload/                     Synced by each WORKLOAD cluster's Flux
     ├── base/                     ACK S3/RDS/IAM controllers, Bucket CRs,
     │                              DBInstance CRs, reader Role CRs

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ docker build -f bootstrap-rs/Dockerfile -t knr-ops-toolbox:dev .
 export TOOLBOX_IMAGE=knr-ops-toolbox:dev
 mise trust
 mise install
-cp .env.example .env        # AWS only: fill in the Git source and PAT
+cp .env.example .env        # aws and local-talos: fill in the Git source and PAT
 mise run sops-keygen         # first time only: age key for SOPS
 mise run bootstrap           # toolbox: bootstrap, Flux handoff, then pivot
 export KUBECONFIG="$PWD/.kube/knr-ops-mgmt.yaml"
@@ -231,7 +231,7 @@ defaults remain in the binary.
 
 `mise run bootstrap`, `pivot`, and `teardown` now run the CLI through the
 toolbox wrapper. The shell scripts remain native reference and fallback paths
-until both environments complete parity runs; local-host has passed the full
+until all environments complete parity runs; local-host has passed the full
 lifecycle, while AWS parity still gates retirement. See
 [The bootstrap CLI](docs/bootstrap-cli.md) for the interface, configuration,
 teardown controls, toolbox release, and current parity status.
@@ -264,7 +264,7 @@ teardown controls, toolbox release, and current parity status.
 ├── tests/                         Config and Renovate coverage cross-checks
 ├── docs/                          Detailed documentation (see table above)
 ├── mise.toml / mise.*.toml        Pinned toolchain and per-environment
-│                                  task layers (aws, local-talos)
+│                                  task layers (aws, local-host, local-talos)
 ├── renovate.json5                 Hosted Renovate discovery and grouping rules
 ├── mgmt/aws/                      Synced by the MANAGEMENT cluster's Flux
 │   ├── infrastructure/           cert-manager, CAPI operator, CAPA identity,

--- a/docs/bootstrap-cli.md
+++ b/docs/bootstrap-cli.md
@@ -161,7 +161,7 @@ knr-bootstrap teardown [PROFILE]
 |---|---|---|
 | `AWS_ONLY` | `0` | Literal `1` skips Kubernetes steps and runs only the AWS orphan sweep; invalid with `local-host` and `local-talos` |
 | `FORCE_KIND_DELETE` | `0` | Literal `1` removes the controller host even when CAPI cluster deletion was not confirmed |
-| `CLUSTER_DELETE_TIMEOUT` | `1200` seconds | AWS workload-cluster deletion wait |
+| `CLUSTER_DELETE_TIMEOUT` | `1200` seconds | CAPI cluster deletion wait (aws workloads, local-talos management) |
 | `PROVIDER_DELETE_TIMEOUT` | `300` seconds | CAPI provider deletion wait |
 | `MGMT_KUBECONFIG` | `~/.kube/knr-ops-mgmt.yaml` | Post-pivot controller-host kubeconfig |
 
@@ -208,7 +208,7 @@ empty account.
 does not select a separate CLI subcommand.
 
 The three shell scripts remain as native reference and fallback paths until
-full parity runs pass for both environments. Local-host bootstrap, pivot, and
+full parity runs pass for all environments. Local-host bootstrap, pivot, and
 post-pivot teardown have completed parity runs. AWS full-parity runs still gate
 script retirement. The local-talos environment has not run end to end yet;
 its acceptance run waits on operator Tinkerbell hardware (issue #105). At

--- a/docs/bootstrap-cli.md
+++ b/docs/bootstrap-cli.md
@@ -68,8 +68,8 @@ knr-bootstrap teardown local-host     # local-host teardown
 
 - `PROFILE` is the CLI's retained positional name. Its value names a section
   under `[environments.*]` in
-  [`bootstrap.toml`](../bootstrap.toml). The checked-in environments are `aws`
-  and `local-host`.
+  [`bootstrap.toml`](../bootstrap.toml). The checked-in environments are `aws`,
+  `local-host`, and `local-talos`.
 - A non-empty `KNR_OPS_PROFILE` overrides the positional profile. If
   neither is set, `bootstrap.default-environment` from `bootstrap.toml` is
   used.
@@ -101,15 +101,15 @@ pins together with their declarative counterparts. See
 | `REGISTRY_READY_RETRIES` | `120` | Local-host registry readiness attempts |
 | `LOCAL_RECONCILE_TIMEOUT` | `15m` | Local-host management and workload reconciliation waits |
 | `CONTAINER_ENGINE` | auto-detect Docker, then Podman | kind and registry engine |
-| `GIT_REPO_URL` | required for `aws` | Management Flux Git source |
-| `GITHUB_TOKEN` | required for `aws` | PAT with read access to the repository |
+| `GIT_REPO_URL` | required for `aws` and `local-talos` | Management Flux Git source |
+| `GITHUB_TOKEN` | required for `aws` and `local-talos` | PAT with read access to the repository |
 | `GITHUB_USER` | `git` | Basic-auth username paired with the PAT |
 | `AGE_KEY_FILE` | `age.agekey` | SOPS age private key loaded into `sops-age` |
 | `AGE_PUBLIC_KEY` | derived from `AGE_KEY_FILE` | Public key override during secret creation |
 | `OCI_REPOSITORY` / `OCI_TAG` | `knr-ops` / `latest` | Local-host OCI artifact name |
 | `BOOTSTRAP_PIVOT` | `1` | Any value other than literal `1` skips pivot |
 | `MGMT_KUBECONFIG` | `~/.kube/knr-ops-mgmt.yaml` | Exported management kubeconfig for native runs |
-| `MGMT_READY_TIMEOUT` | `40m` for aws, `15m` for local-host | Management cluster provisioning wait |
+| `MGMT_READY_TIMEOUT` | `40m` for aws, `15m` for local-host, `30m` for local-talos (PXE install + first Talos boot) | Management cluster provisioning wait |
 | `MGMT_POLL_INTERVAL` | `10` seconds | Management cluster provisioning poll |
 | `BOOTSTRAP_KUBECONTEXT` | config value `kind-mgmt` | Source context required by pivot |
 | `PIVOT_SKIP_DELETE` | `0` | Literal `1` keeps kind after a successful pivot |
@@ -132,13 +132,14 @@ limitations are documented in [Operations](./operations.md#toolbox-container-pri
 ## What bootstrap and pivot do
 
 1. **Preflight:** validate the environment and required tools, select a running
-   container engine, and perform the AWS GitHub/token/age-key checks when
-   needed. Native runs require `kind`, `helm`, `kubectl`, `clusterctl`, and
-   `mise`; local-host also requires `flux` and `curl`.
+   container engine, and perform the GitHub token/age-key checks for
+   GitHub-synced environments (`aws`, `local-talos`). Native runs require
+   `kind`, `helm`, `kubectl`, `clusterctl`, and `mise`; OCI-synced
+   environments (`local-host`) also require `flux` and `curl`.
 2. **Bootstrap kind:** create or reuse `mgmt`, start the local registry for
-   local-host, install the Flux Operator, create the AWS Git and SOPS secrets
-   or publish the local OCI artifact, install the `FluxInstance`, and watch
-   reconciliation.
+   local-host, install the Flux Operator, create the Git and SOPS secrets
+   (GitHub-synced environments) or publish the local OCI artifact, install
+   the `FluxInstance`, and watch reconciliation.
 3. **Pivot by default:** wait for the CAPI-managed management cluster, export
    its kubeconfig, install cert-manager, the CAPI operator, and provider CRs at
    the versions declared in `bootstrap.toml`, suspend Flux in kind, run
@@ -158,7 +159,7 @@ knr-bootstrap teardown [PROFILE]
 
 | Variable | Default | Effect |
 |---|---|---|
-| `AWS_ONLY` | `0` | Literal `1` skips Kubernetes steps and runs only the AWS orphan sweep; invalid with `local-host` |
+| `AWS_ONLY` | `0` | Literal `1` skips Kubernetes steps and runs only the AWS orphan sweep; invalid with `local-host` and `local-talos` |
 | `FORCE_KIND_DELETE` | `0` | Literal `1` removes the controller host even when CAPI cluster deletion was not confirmed |
 | `CLUSTER_DELETE_TIMEOUT` | `1200` seconds | AWS workload-cluster deletion wait |
 | `PROVIDER_DELETE_TIMEOUT` | `300` seconds | CAPI provider deletion wait |
@@ -169,6 +170,7 @@ Teardown checks required tools before mutation:
 | Mode | Required tools |
 |---|---|
 | `local-host` | `kind`, `kubectl`; `AWS_ONLY=1` is rejected |
+| `local-talos` | `kind`, `kubectl`; `AWS_ONLY=1` is rejected |
 | normal `aws` | `kind`, `helm`, `kubectl`, `xargs`; AWS CLI is optional and its absence skips the orphan sweep |
 | `AWS_ONLY=1` | AWS CLI only |
 
@@ -180,6 +182,11 @@ cleanup semantics.
 - `local-host`: suspend the workload Kustomization, delete the CAPD workload
   cluster and wait for its containers to disappear, remove kind or the
   self-managed management containers, then remove the local registry.
+- `local-talos`: suspend Flux and delete every CAPI Cluster, the management
+  cluster included; the deletion IS the release, and CAPT returns the
+  machine's Hardware to the Tinkerbell pool. The machine is never wiped: it
+  keeps running Talos for the operator. `AWS_ONLY=1` is rejected because
+  there is no AWS orphan sweep for operator-owned hardware.
 - `aws`: suspend Flux, delete and wait for workload CAPI clusters, run the AWS
   orphan sweep for both workloads and the self-managed management cluster,
   remove CAPI providers and bootstrap Helm releases when the controller host is
@@ -203,5 +210,7 @@ does not select a separate CLI subcommand.
 The three shell scripts remain as native reference and fallback paths until
 full parity runs pass for both environments. Local-host bootstrap, pivot, and
 post-pivot teardown have completed parity runs. AWS full-parity runs still gate
-script retirement. At this revision no semver tag has run the release workflow,
+script retirement. The local-talos environment has not run end to end yet;
+its acceptance run waits on operator Tinkerbell hardware (issue #105). At
+this revision no semver tag has run the release workflow,
 and no Podman-host acceptance run is recorded.

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -13,9 +13,10 @@ proposed updates appear in the Renovate dependency dashboard issue.
 
 Renovate discovers and updates versions in:
 
-- `mise.toml`, `mise.aws.toml`, and `mise.local-host.toml`: tool pins and the
-  Zarf CLI pin. Explicit per-tool custom managers replace the native mise
-  manager so each pin resolves against the intended upstream project.
+- `mise.toml`, `mise.aws.toml`, `mise.local-host.toml`, and
+  `mise.local-talos.toml`: tool pins and the Zarf CLI pin. Explicit per-tool
+  custom managers replace the native mise manager so each pin resolves against
+  the intended upstream project.
 - `bootstrap-rs/Cargo.toml` and `bootstrap-rs/Cargo.lock`: Rust crate
   dependencies through Renovate's Cargo manager.
 - `bootstrap.toml`: the Flux Operator, cert-manager, and CAPI Operator chart

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -114,41 +114,41 @@ which backs the managed-AKS path.
    place of `${AWS_REGION}`. The AWS-only steps (Pod Identity associations,
    ACK controllers) have no Azure equivalent; skip them.
 
-### Talos (CABPT + CACPT)
+### Talos (CABPT + CACPPT)
 
 Talos supplies the bootstrap and control plane providers only; pair it with
-any infrastructure provider (CAPA, CAPZ, k0smotron RemoteMachine, ...) that
-supplies the machines.
+any infrastructure provider (CAPT, CAPA, CAPZ, ...) that supplies the
+machines. The worked in-repo example is the `local-talos` environment:
+`mgmt/local-talos/` pairs the Talos providers with Tinkerbell (CAPT) to
+PXE-boot a bare-metal management machine.
 
 1. Two directories, matching the upstream namespace conventions:
 
    ```yaml
-   # mgmt/aws/capi-providers/cabpt-system/providers.yaml
+   # mgmt/local-talos/capi-providers/cabpt-system/provider.yaml
    apiVersion: operator.cluster.x-k8s.io/v1alpha2
    kind: BootstrapProvider
    metadata:
      name: talos
      namespace: cabpt-system
    spec:
-     version: "v0.6.11"
-   ---
-   # mgmt/aws/capi-providers/cacppt-system/providers.yaml
-   apiVersion: operator.cluster.x-k8s.io/v1alpha2
-   kind: ControlPlaneProvider
-   metadata:
-     name: talos
-     namespace: cacppt-system
-   spec:
-     version: "v0.5.13"
+     version: "v0.7.6"
+     fetchConfig:
+       url: "https://github.com/sidero-community/cluster-api-bootstrap-provider-talos/releases"
    ```
 
-2. No cloud credentials: Talos machine secrets are generated per cluster by
+   The control plane provider is the same shape
+   (`cacppt-system/provider.yaml`: ControlPlaneProvider `talos` v0.6.4).
+2. Set `fetchConfig.url` explicitly to the
+   [sidero-community](https://github.com/sidero-community) releases: the CAPI
+   operator's embedded clusterctl defaults resolve `talos` to the archived
+   siderolabs org. The sidero-community line serves the v1beta2 contract
+   (`cluster.x-k8s.io/v1beta2: v1beta1` in the released metadata), so the
+   contract note above does not impose a migration deadline on it.
+3. No cloud credentials: Talos machine secrets are generated per cluster by
    `TalosControlPlane` / `TalosConfig`. Always set `talosVersion` explicitly
-   (e.g. `v1.12`) so a provider upgrade does not silently change the
+   (e.g. `v1.14`) so a provider upgrade does not silently change the
    generated machine config.
-3. Contract caveat: the stable Talos providers still implement the v1beta1
-   contract, which CAPI serves only until ~April 2027. The v1beta2 line is
-   CABPT v0.7.0 (in alpha at time of writing); adopt it once it goes stable.
 4. In cluster definitions, swap `KubeadmControlPlane` for `TalosControlPlane`
    and `KubeadmConfigTemplate` for `TalosConfigTemplate`; the infrastructure
    templates stay whatever the paired infra provider supplies.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -194,7 +194,7 @@ You also need:
   stack is operator-owned infrastructure this repository does not deploy.
   Minimal setup:
   1. Install the [tink stack](https://tinkerbell.org/docs/setup/install/)
-     (boots serving DHCP/PXE/iPXE, plus the Tinkerbell API) on a helper
+     (Smee serving DHCP/PXE/iPXE, plus the Tinkerbell API) on a helper
      Kubernetes cluster that can reach the machine's L2 network.
   2. Create the `Hardware` CR naming the machine's MAC address and reserved
      IP; its name must match the `hardwareName` in
@@ -207,7 +207,7 @@ You also need:
      `status.installerImage` and CABPT injects it as the Talos
      `machine.install.image`; without the annotation the default schematic
      is used.
-  4. Set the machine to PXE-boot from the network boots serves.
+  4. Set the machine to PXE-boot from the network Smee serves.
 - Two site-specific values in
   `mgmt/local-talos/clusters/management/cluster.yaml` before the first run:
   `spec.controlPlaneEndpoint.host` (the machine's stable IP) and the
@@ -477,7 +477,7 @@ The main controls keep the shell interface:
 |---|---|---|
 | `AWS_ONLY` | `0` | Literal `1` runs only the AWS orphan sweep; invalid with `local-host` and `local-talos` |
 | `FORCE_KIND_DELETE` | `0` | Literal `1` overrides the final controller-host deletion guard |
-| `CLUSTER_DELETE_TIMEOUT` | `1200` seconds | AWS workload-cluster deletion wait |
+| `CLUSTER_DELETE_TIMEOUT` | `1200` seconds | CAPI cluster deletion wait (aws workloads, local-talos management) |
 | `PROVIDER_DELETE_TIMEOUT` | `300` seconds | CAPI provider deletion wait |
 | `MGMT_KUBECONFIG` | native: `~/.kube/knr-ops-mgmt.yaml` | Post-pivot controller-host kubeconfig |
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -63,7 +63,8 @@ docker run --rm -it \
 Generate the age key and re-encrypt secrets for a new fork before the AWS run;
 see [Secret management](./secrets.md). If credentials come from an AWS shared
 configuration instead of environment variables, also mount that configuration
-under `/root/.aws` and pass `AWS_PROFILE`.
+under `/root/.aws` and pass `AWS_PROFILE`. The local-talos environment needs
+the same Git source, PAT, and age key, but no AWS credentials.
 
 Podman socket locations differ across rootful Linux, rootless Linux, and
 `podman machine`. Use the checked-in wrapper to resolve the host mount and the
@@ -144,7 +145,9 @@ mise install
 This provides `kubectl`, `kind`, `helm`, `flux`, `clusterctl`, `go`, `sops`,
 `age`, and the `zarf` CLI. The `aws` environment layers on `aws-cli` and
 `clusterawsadm` (`mise -E aws install`); the `local-host` environment needs
-no extra tools. Building the bootstrap CLI additionally requires a Rust
+no extra tools; the `local-talos` environment layers on `talosctl`
+(`mise -E local-talos install`). Building the bootstrap CLI additionally
+requires a Rust
 toolchain ([rustup](https://rustup.rs/); the pin lives in
 `bootstrap-rs/rust-toolchain.toml`). The lifecycle mise tasks still use the
 toolbox. For a fully native run from the repository root, invoke
@@ -181,6 +184,35 @@ You also need:
   clusterawsadm bootstrap iam create-cloudformation-stack --region eu-north-1
   ```
 
+**local-talos environment only:**
+- The GitHub PAT and age key, as for the AWS environment: local-talos syncs
+  its configuration from GitHub (a physical machine cannot reach the
+  laptop-hosted OCI registry), so bootstrap seeds the same `flux-github-pat`
+  and `sops-age` secrets.
+- A reachable [Tinkerbell](https://tinkerbell.org/) stack on the machine's
+  network, and a `Hardware` resource describing the target machine. The
+  stack is operator-owned infrastructure this repository does not deploy.
+  Minimal setup:
+  1. Install the [tink stack](https://tinkerbell.org/docs/setup/install/)
+     (boots serving DHCP/PXE/iPXE, plus the Tinkerbell API) on a helper
+     Kubernetes cluster that can reach the machine's L2 network.
+  2. Create the `Hardware` CR naming the machine's MAC address and reserved
+     IP; its name must match the `hardwareName` in
+     `mgmt/local-talos/clusters/management/cluster.yaml` (`talos-mgmt-01`
+     as checked in).
+  3. Annotate the `Hardware` CR with
+     `hardware.tinkerbell.org/installer-image: <image URL>` when the machine
+     needs a non-default Image Factory schematic (system extensions, custom
+     kernel args). The pinned CAPT fork mirrors the annotation into
+     `status.installerImage` and CABPT injects it as the Talos
+     `machine.install.image`; without the annotation the default schematic
+     is used.
+  4. Set the machine to PXE-boot from the network boots serves.
+- Two site-specific values in
+  `mgmt/local-talos/clusters/management/cluster.yaml` before the first run:
+  `spec.controlPlaneEndpoint.host` (the machine's stable IP) and the
+  `TinkerbellMachineTemplate` `hardwareName` (the Hardware CR name).
+
 ### AWS service quotas (common first-run blockers)
 
 | Quota | Code | Needed | Why |
@@ -201,8 +233,9 @@ cp .env.example .env
 $EDITOR .env
 ```
 
-The Flux Operator chart is pulled anonymously for both environments. The
-GitHub PAT, AWS credentials, and `AWS_REGION` are only needed with the AWS
+The Flux Operator chart is pulled anonymously for all environments. The
+GitHub PAT is needed for the AWS and local-talos environments (both sync
+from GitHub); AWS credentials and `AWS_REGION` are only needed with the AWS
 environment.
 
 Repository-owned lifecycle configuration lives in `bootstrap.toml`. It defines
@@ -217,6 +250,7 @@ Runtime environment variables take precedence over configurable defaults, and
 ```sh
 mise run bootstrap                 # AWS environment (toolbox container via scripts/toolbox-run.sh)
 mise -E local-host run bootstrap   # local-host environment
+mise -E local-talos run bootstrap  # local-talos environment
 ```
 
 > Before the first AWS bootstrap, generate an age key for SOPS. See
@@ -257,6 +291,19 @@ Flux control plane on that cluster, and reconciles a reachable Podinfo workload.
 It exercises the complete cluster-to-workload GitOps lifecycle locally; only
 the AWS-specific infrastructure and ACK resources are outside its scope.
 
+The local-talos environment performs the same kind bootstrap and Flux
+handoff, but syncs from GitHub like AWS and pivots onto operator-provided
+bare metal: CAPT PXE-boots the machine named by the Tinkerbell `Hardware`
+resource, installs Talos with the image resolved from the Hardware's
+`hardware.tinkerbell.org/installer-image` annotation, and the single-node
+Talos cluster takes over as the management cluster. The management-ready
+wait defaults to 30 minutes (`mgmt-ready-timeout` in `bootstrap.toml`) to
+cover the PXE install and first Talos boot. Scope fence: management-only.
+There is no workload cluster and no CNI addon; Talos ships flannel. Verify
+after the pivot with `mise -E local-talos run kubeconfigs` and
+`kubectl get nodes`: one Ready node on the committed endpoint, schedulable
+for the full management plane (`allowSchedulingOnControlPlanes`).
+
 **OCI Registry (local-host environment only):**
 - Provides a local container registry for development workflows
 - Enables developers to build and push OCI artifacts from git checkouts
@@ -283,7 +330,9 @@ preserving those directory paths when the artifact is pulled. Keeping the
 source scope narrow also prevents local credentials and age private keys
 elsewhere in the repository from being packaged.
 
-The AWS environment adds the GitHub/SOPS secrets and configures the FluxInstance to sync `mgmt/aws/`.
+The AWS and local-talos environments add the GitHub/SOPS secrets and
+configure the FluxInstance to sync `mgmt/aws/` or `mgmt/local-talos/`
+respectively.
 
 Watch reconciliation after a toolbox run with the persisted management
 kubeconfig:
@@ -409,6 +458,7 @@ The mise tasks run the Rust subcommand in the toolbox:
 ```sh
 mise run teardown                 # aws
 mise -E local-host run teardown   # local-host
+mise -E local-talos run teardown  # local-talos
 ```
 
 Native equivalents are `knr-bootstrap teardown [PROFILE]` and the retained
@@ -425,7 +475,7 @@ The main controls keep the shell interface:
 
 | Variable | Default | Effect |
 |---|---|---|
-| `AWS_ONLY` | `0` | Literal `1` runs only the AWS orphan sweep; invalid with `local-host` |
+| `AWS_ONLY` | `0` | Literal `1` runs only the AWS orphan sweep; invalid with `local-host` and `local-talos` |
 | `FORCE_KIND_DELETE` | `0` | Literal `1` overrides the final controller-host deletion guard |
 | `CLUSTER_DELETE_TIMEOUT` | `1200` seconds | AWS workload-cluster deletion wait |
 | `PROVIDER_DELETE_TIMEOUT` | `300` seconds | CAPI provider deletion wait |
@@ -436,6 +486,7 @@ The hard preflight depends on the mode:
 | Mode | Required tools |
 |---|---|
 | `local-host` | `kind`, `kubectl`; `AWS_ONLY=1` is rejected |
+| `local-talos` | `kind`, `kubectl`; `AWS_ONLY=1` is rejected |
 | normal `aws` | `kind`, `helm`, `kubectl`, `xargs`; a missing AWS CLI skips the orphan sweep |
 | `AWS_ONLY=1` | AWS CLI only |
 
@@ -447,6 +498,14 @@ For `local-host`, teardown suspends the workload Kustomization, deletes the
 CAPD workload cluster, waits for its containers to disappear, removes either
 the pre-pivot kind cluster or the post-pivot self-managed management
 containers, and removes `knr-registry` last.
+
+For `local-talos`, teardown suspends Flux and deletes every CAPI Cluster,
+the management cluster included: the deletion IS the release, and CAPT
+returns the machine's `Hardware` entry to the Tinkerbell pool. It waits for
+the deprovision to complete, then deletes the kind bootstrap cluster if the
+pivot has not run yet. The machine itself is never wiped: it keeps running
+Talos for the operator to re-use or PXE-boot fresh. There is no orphan
+sweep; the environment owns no cloud resources.
 
 For `aws`, teardown suspends Flux, deletes every workload CAPI Cluster while
 leaving the management Cluster object alone, and waits before touching the

--- a/renovate.json5
+++ b/renovate.json5
@@ -196,6 +196,16 @@
       "extractVersionTemplate": "^v(?<version>.+)",
       "autoReplaceStringTemplate": "clusterawsadm = { version = \"{{newValue}}\""
     },
+    {
+      "customType": "regex",
+      "description": "mise: talosctl pin (local-talos environment layer, issue #105)",
+      "managerFilePatterns": ["/(^|/)mise\\.local-talos\\.toml$/"],
+      "matchStrings": ["talosctl = \"(?<currentValue>[^\"]+)\""],
+      "depNameTemplate": "siderolabs/talos",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.+)",
+      "autoReplaceStringTemplate": "talosctl = \"{{newValue}}\""
+    },
     // ── bootstrap.toml chart pins (annotation-driven) ─────────────────────
     // Datasource and depName live in `# renovate:` comments next to the
     // chart pins in bootstrap.toml (consumed by the Rust binary since the

--- a/tests/test-renovate-coverage.py
+++ b/tests/test-renovate-coverage.py
@@ -37,6 +37,7 @@ EXPECTED = {
         "kubernetes/kubernetes",
         "siderolabs/talos",
     },
+    "mise.local-talos.toml": {"siderolabs/talos"},
 }
 
 


### PR DESCRIPTION
## What

PR 3 of the #105 series: the documentation for the local-talos environment, plus the talosctl Renovate pin deferred from PR 2/3.

Refs #105 (not closing: the hardware acceptance run remains; see below).

## Changes

**Docs** (`docs:` commit):

- `docs/extending.md` - the Talos provider section now points at the worked in-repo example (`mgmt/local-talos/`), pins the sidero-community versions and the `fetchConfig` pattern the repo actually uses, and drops the outdated v1beta1-contract caveat (the sidero-community line serves the v1beta2 contract via `cluster.x-k8s.io/v1beta2: v1beta1` in the released metadata). Issue scope item 10.
- `docs/operations.md` - local-talos prerequisites: the GitHub PAT + age key requirement (GitHub sync, like aws), the Tinkerbell stack prerequisite with a minimal setup (issue scope item 7: boots/PXE + API on a helper cluster, `Hardware` CR matching `hardwareName`, the `hardware.tinkerbell.org/installer-image` annotation, PXE boot), and the two site-specific values in `cluster.yaml`. Bootstrap and teardown command lists, teardown controls and preflight-tool tables gain the local-talos rows, and the teardown behavior paragraph documents the bare-metal semantics (deletion IS the Hardware release; the machine is never wiped; no orphan sweep).
- `README.md` - three environments, a local-talos overview and command block, prerequisites, and the repository layout gains `mgmt/local-talos/`.
- `docs/bootstrap-cli.md` - checked-in environments list, GitHub-required controls (`GIT_REPO_URL`/`GITHUB_TOKEN` for aws and local-talos), the 30m local-talos `MGMT_READY_TIMEOUT` default, sync-source-derived preflight tools, local-talos teardown table row and behavior bullet, and the parity status notes the pending hardware acceptance run.

**Renovate** (`feat(renovate):` commit):

- `renovate.json5` - new per-tool custom manager for `mise.local-talos.toml` mapping the `talosctl` pin to `siderolabs/talos` (github-releases). Every existing mise manager targets `mise.toml` or `mise.aws.toml` only, so without this a talosctl bump would never be proposed. This is the mise-tools manager extension PR 2/3 deferred.
- `tests/test-renovate-coverage.py` - asserts the detection permanently in CI.

## Verification

- TDD: coverage test red before the manager (`mise.local-talos.toml: missing detection for ['siderolabs/talos']`), green after.
- Pinned dry-run per AGENTS.md (`renovate@44.50.1`, Node 24.20, `--platform=local --dry-run=full`, tokens set): `siderolabs/talos` extracts from `mise.local-talos.toml` with `currentValue: 1.14.0` and a clean `replaceString`; zero "Failed to look up".
- `mise run validate` exit 0.
- No em-dashes in the diff.

## Deliberately out of scope

- `AGENTS.md` - the write to the protected file timed out waiting for approval. One stale sentence to fold in separately: the local-talos entry still says "Bootstrap/pivot wiring and docs land with the rest of the #105 series" (the wiring landed in #169, docs here).
- End-to-end acceptance run - blocked on operator Tinkerbell hardware; it is the remaining #105 acceptance item.
