### PR TITLE
fix: cover airgap image digests in Renovate

### DIFF
--- a/airgap/tests/test-renovate-digest-pinning.py
+++ b/airgap/tests/test-renovate-digest-pinning.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Verify Renovate proposes digest pins for both air-gap image inventories."""
+"""Verify Renovate proposes digest pins for authoritative air-gap sources."""
 
 import re
 import sys
@@ -8,8 +8,22 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "tests"))
 from renovate_harness import run_renovate
 
-EXPECTED_FILES = ["airgap/images.txt", "airgap/zarf.yaml"]
+EXPECTED_FILES = [
+    "airgap/images.txt",
+    "airgap/scripts/build-config-artifact.sh",
+    "airgap/scripts/build-package.sh",
+    "airgap/scripts/stage-and-create-cluster.sh",
+    "airgap/zarf.yaml",
+]
 DIGEST = re.compile(r"@sha256:[a-f0-9]{64}")
+EXCLUDED_DEP_NAMES = {"localhost:5001/knr-ops-airgap"}
+REQUIRED_DEP_NAMES = {
+    "airgap/images.txt": {"ghcr.io/fluxcd/source-controller"},
+    "airgap/scripts/build-config-artifact.sh": {"registry.k8s.io/pause"},
+    "airgap/scripts/build-package.sh": {"registry.k8s.io/pause"},
+    "airgap/scripts/stage-and-create-cluster.sh": {"kindest/node"},
+    "airgap/zarf.yaml": {"quay.io/jetstack/cert-manager-controller"},
+}
 
 
 def main() -> int:
@@ -19,20 +33,39 @@ def main() -> int:
         EXPECTED_FILES, transform=lambda _, text: DIGEST.sub("", text)
     )
 
-    pin_counts = {
-        package_file: result.pin_digest_count(package_file)
-        for package_file in EXPECTED_FILES
-    }
-    missing = [path for path, count in pin_counts.items() if count == 0]
-    if result.returncode or missing:
+    missing = {}
+    for package_file in EXPECTED_FILES:
+        dependencies = result.deps_without_pin_digest(
+            package_file, EXCLUDED_DEP_NAMES
+        )
+        if dependencies:
+            missing[package_file] = dependencies
+    missing_extractions = {}
+    for package_file, dep_names in REQUIRED_DEP_NAMES.items():
+        dependencies = dep_names - result.dep_names(package_file)
+        if dependencies:
+            missing_extractions[package_file] = sorted(dependencies)
+    if result.returncode or missing or missing_extractions:
         print("Renovate digest-pinning integration check failed", file=sys.stderr)
         print(f"exit code: {result.returncode}", file=sys.stderr)
-        print(f"pin counts: {pin_counts}", file=sys.stderr)
+        for package_file, dependencies in sorted(missing_extractions.items()):
+            print(
+                f"{package_file}: missing extraction for {dependencies}",
+                file=sys.stderr,
+            )
+        for package_file, dependencies in sorted(missing.items()):
+            print(
+                f"{package_file}: missing digest pin for {dependencies}",
+                file=sys.stderr,
+            )
         result.print_diagnostics()
         return 1
 
-    for package_file in sorted(pin_counts):
-        print(f"{package_file}: {pin_counts[package_file]} digest pin(s) proposed")
+    for package_file in sorted(EXPECTED_FILES):
+        print(
+            f"{package_file}: {result.pin_digest_count(package_file)} "
+            "digest pin(s) proposed"
+        )
     return 0
 
 

--- a/renovate.json5
+++ b/renovate.json5
@@ -304,10 +304,9 @@
     // ── kind node images ─────────────────────────────────────────────────
     {
       "customType": "regex",
-      "description": "kindest/node image pins in cluster classes and airgap scripts",
+      "description": "kindest/node image pins in management cluster manifests",
       "managerFilePatterns": [
-        "/(^|/)mgmt/.+\\.ya?ml$/",
-        "/(^|/)airgap/scripts/.+\\.sh$/"
+        "/(^|/)mgmt/.+\\.ya?ml$/"
       ],
       "matchStrings": ["kindest/node:v(?<currentValue>[0-9A-Za-z.\\-]+)"],
       "depNameTemplate": "kindest/node",
@@ -328,6 +327,16 @@
     },
     {
       "customType": "regex",
+      "description": "external container image refs in authoritative airgap scripts (#173)",
+      "managerFilePatterns": ["/(^|/)airgap/scripts/.+\\.sh$/"],
+      "matchStrings": [
+        "(?:^|\\n)(?:[ \\t]*|[^\\n#]*?(?:[ \\t\\\"'=(]|:-))(?<depName>(?:(?:[a-zA-Z0-9][a-zA-Z0-9._-]*\\.[a-zA-Z0-9._-]+|localhost)(?::[0-9]+)?/(?:[a-zA-Z0-9][a-zA-Z0-9._-]*/)*[a-zA-Z0-9][a-zA-Z0-9._-]*|(?:[a-zA-Z0-9][a-zA-Z0-9._-]*/)+[a-zA-Z0-9][a-zA-Z0-9._-]*|registry)):(?<currentValue>[a-zA-Z0-9_][a-zA-Z0-9_.-]*)(?:@(?<currentDigest>sha256:[a-f0-9]{64}))?"
+      ],
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "docker"
+    },
+    {
+      "customType": "regex",
       "description": "zarf.yaml image refs (registry with optional port)",
       "managerFilePatterns": ["/(^|/)airgap/zarf\\.yaml$/"],
       "matchStrings": [
@@ -338,17 +347,31 @@
     },
     // EKS addon versions (*-eksbuild.*) intentionally not managed: they have
     // no public registry datasource. Tracked in issue #74 as manual updates.
-    // Unversioned tags (e.g. localhost:5001/knr-ops-airgap:latest in
-    // zarf.yaml, built locally per run) are also intentionally untracked:
-    // a bare "latest" tag has no comparable version.
+    // The locally built localhost:5001/knr-ops-airgap:latest artifact is
+    // extracted but intentionally disabled by the scoped packageRule below.
     // ── end customManagers ────────────────────────────────────────────────
   ],
   "packageRules": [
     {
       "description": "Pin air-gap container images by digest while retaining readable tags",
       "matchDatasources": ["docker"],
-      "matchFileNames": ["airgap/images.txt", "airgap/zarf.yaml"],
+      "matchFileNames": [
+        "airgap/images.txt",
+        "airgap/zarf.yaml",
+        "airgap/scripts/*.sh"
+      ],
       "pinDigests": true
+    },
+    {
+      "description": "Do not resolve the air-gap config artifact built locally per run",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["localhost:5001/knr-ops-airgap"],
+      "matchFileNames": [
+        "airgap/images.txt",
+        "airgap/zarf.yaml",
+        "airgap/scripts/*.sh"
+      ],
+      "enabled": false
     },
     {
       "description": "Pin toolbox image base images by digest (issue #104)",

--- a/tests/renovate_harness.py
+++ b/tests/renovate_harness.py
@@ -57,6 +57,22 @@ class RenovateResult:
             for update in dep.get("updates", [])
         )
 
+    def deps_without_pin_digest(self, package_file, excluded_dep_names=None):
+        """Extracted dependencies lacking a valid sha256 pinDigest update."""
+        excluded_dep_names = set(excluded_dep_names or ())
+        return [
+            f"{dep.get('depName', '<unknown>')}:{dep.get('currentValue', '<unknown>')}"
+            for dep in self.deps_by_file[package_file]
+            if dep.get("depName") not in excluded_dep_names
+            and not any(
+                update.get("updateType") == "pinDigest"
+                and update.get("newDigest", "").startswith("sha256:")
+                and len(update["newDigest"]) == 71
+                and all(char in "0123456789abcdef" for char in update["newDigest"][7:])
+                for update in dep.get("updates", [])
+            )
+        ]
+
     def print_diagnostics(self, stream=None):
         stream = stream or sys.stderr
         if self.diagnostics:


### PR DESCRIPTION
## Summary

- extract Docker dependencies from authoritative `airgap/scripts/*.sh` sources
- enable digest pinning for those scripts without matching shell syntax, URLs, ports, or comments
- remove the overlapping tag-only `kindest/node` script manager and retain the local artifact exception
- extend the Renovate digest integration fixture to every current image-bearing air-gap source

## Testing

- `mise x node@24 -- npx --yes -p renovate@44.50.1 renovate-config-validator renovate.json5`
- authenticated `renovate --platform=local --dry-run=full`
- `mise x node@24 -- npx --yes -p renovate@44.50.1 -c 'python3 airgap/tests/test-renovate-digest-pinning.py'`\n- `mise x node@24 -- npx --yes -p renovate@44.50.1 -c 'python3 tests/test-renovate-coverage.py'`\n- `mise run validate`\n- `git diff --check`\n\nCloses #173