### PR TITLE
fix: toolbox wrapper bash 3.2 compat and post-pivot REGISTRY_HOST forwarding (#172, #174)

### DIFF
--- a/bootstrap-rs/src/main.rs
+++ b/bootstrap-rs/src/main.rs
@@ -2088,9 +2088,14 @@ async fn pivot_seed_target(
     // contain the management manifests.
     if cfg.is_local() {
         println!(">>> Publishing the current checkout as the OCI artifact...");
+        // Same endpoint forwarding as the initial publish: the mise
+        // oci-push task probes REGISTRY_HOST:REGISTRY_PORT, which is the
+        // kind-network name inside the toolbox and localhost on the host.
+        let (registry_host, oci_port) = cfg.registry_endpoint();
         let status = Command::new("mise")
             .args(["-E", &cfg.profile, "run", "oci-push"])
-            .env("REGISTRY_PORT", cfg.registry_port.to_string())
+            .env("REGISTRY_PORT", oci_port.to_string())
+            .env("REGISTRY_HOST", &registry_host)
             .env("OCI_REPOSITORY", &cfg.oci_repository)
             .env("OCI_TAG", &cfg.oci_tag)
             .status()

--- a/scripts/toolbox-run.sh
+++ b/scripts/toolbox-run.sh
@@ -27,7 +27,8 @@ Env:
   TOOLBOX_IMAGE   image reference (default: ${TOOLBOX_IMAGE};
                   build locally with: docker build -f bootstrap-rs/Dockerfile \\
                     -t knr-ops-toolbox:dev . && TOOLBOX_IMAGE=knr-ops-toolbox:dev)
-  KNR_OPS_PROFILE aws | local-host (default: the mise environment in use)
+  KNR_OPS_PROFILE aws | local-host | local-talos
+                  (default: the mise environment in use)
 EOF
   exit 2
 }
@@ -146,7 +147,7 @@ case "$LIFECYCLE" in
   *)         usage ;;
 esac
 
-exec "$CONTAINER_ENGINE" run --rm "${TTY_ARGS[@]}" \
+exec "$CONTAINER_ENGINE" run --rm ${TTY_ARGS[@]+"${TTY_ARGS[@]}"} \
   -v "$REPO_ROOT:/workspace" \
   -w /workspace \
   -v "$SOCK_SOURCE:/var/run/docker.sock" \
@@ -154,4 +155,4 @@ exec "$CONTAINER_ENGINE" run --rm "${TTY_ARGS[@]}" \
   -e KUBECONFIG="$KUBECONFIG_IN" \
   "${PASS_ENV[@]}" \
   "$TOOLBOX_IMAGE" \
-  "${CLI_ARGS[@]}"
+  ${CLI_ARGS[@]+"${CLI_ARGS[@]}"}


### PR DESCRIPTION
## What

Two independent fixes found while running the local-host regression for #105 acceptance on macOS; one commit each, one issue each.

**`fix: expand empty arrays safely in toolbox-run.sh for macOS bash 3.2`** (closes #172)

Under `set -u`, `"${ARR[@]}"` on an empty array is an unbound variable error on bash < 4.4, and macOS system bash is 3.2.57. The wrapper failed before reaching Docker in two trigger paths: non-interactive invocation (`TTY_ARGS` empty) and `bootstrap` with no extra args (`CLI_ARGS` empty). The `${ARR[@]+"${ARR[@]}"}` idiom expands safely on both bash 3.2 and 5. The usage text also gains `local-talos`.

**`fix: forward REGISTRY_HOST in the post-pivot OCI publish`** (closes #174)

`pivot_seed_target` spawned `mise run oci-push` without `REGISTRY_HOST` and with `cfg.registry_port` instead of `cfg.registry_endpoint()`, so toolbox runs probed `localhost:5001` inside the container after an otherwise successful pivot. The fix mirrors the initial publish call site: host and port come from `registry_endpoint()` (`knr-registry:5000` in the toolbox, `localhost:5001` on the host).

## Verification

- #172: before the fix the wrapper died at the `exec` line on this Mac (system bash 3.2.57, no homebrew bash); after the fix the same invocation runs the container end to end. `bash -n` clean; `mise run validate` shell check passes.
- #174: `cargo fmt --check`, clippy `-D warnings`, and 50/50 tests pass. In the live regression run, the pre-fix binary failed at the post-pivot publish (`localhost:5001` probe inside the toolbox); with the patched binary the publish succeeds against `knr-registry:5000` and the run proceeded through the seed into the reconciliation watch.
- Full bootstrap + teardown evidence comes from the #105 acceptance regression run; both fixes are the exact patches it ran with.
