### PR TITLE
docs(agents): local-talos wiring and docs have landed (#105 follow-up)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,8 +37,8 @@ resources. There is no app source code here, only declarative infrastructure.
   `capi-providers/capt-system/provider.yaml`); re-point at upstream once a
   release there includes it. Scope fence:
   management-only; no `addons/` (Talos ships its own CNI, no
-  HelmChartProxy consumers). Bootstrap/pivot wiring and docs land with
-  the rest of the #105 series.
+  HelmChartProxy consumers). The wiring landed in #169 and the docs in
+  #171; the remaining #105 item is the hardware acceptance run.
 - `workload/`: synced by each WORKLOAD cluster's Flux.
   - `base/`: ACK controllers and S3/RDS/IAM custom resources.
   - `<region>-01/`: per-cluster overlays pointing at `../base`.


### PR DESCRIPTION
## What

One-sentence follow-up to #171, deferred there because the protected-file
write timed out: the `mgmt/local-talos/` entry in `AGENTS.md` still says
the bootstrap/pivot wiring and docs "land with the rest of the #105
series". Both have landed: the wiring in #169, the docs (plus the
talosctl Renovate pin) in #171.

The sentence now states what actually remains on #105: the hardware
acceptance run on operator Tinkerbell hardware (the same pending item
`docs/bootstrap-cli.md` records).

## Verification

- `mise run validate` exit 0
- No em-dashes in the diff
- Single sentence replaced; nothing else in the file touched

Refs #105 (not closing: the acceptance run remains).
