### PR TITLE
Fix duplicate Renovate Helm registry URLs

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -249,7 +249,6 @@
         "CERT_MANAGER_VERSION=\"(?<currentValue>[^\"]+)\""
       ],
       "depNameTemplate": "cert-manager",
-      "registryUrlTemplate": "https://charts.jetstack.io",
       "datasourceTemplate": "helm",
       "autoReplaceStringTemplate": "CERT_MANAGER_VERSION=\"{{newValue}}\""
     },
@@ -261,7 +260,6 @@
         "CAPI_OPERATOR_VERSION=\"(?<currentValue>[^\"]+)\""
       ],
       "depNameTemplate": "cluster-api-operator",
-      "registryUrlTemplate": "https://kubernetes-sigs.github.io/cluster-api-operator",
       "datasourceTemplate": "helm",
       "autoReplaceStringTemplate": "CAPI_OPERATOR_VERSION=\"{{newValue}}\""
     },
@@ -388,6 +386,18 @@
       "matchDatasources": ["docker"],
       "matchFileNames": ["bootstrap-rs/Dockerfile"],
       "pinDigests": true
+    },
+    {
+      "description": "Resolve cert-manager Helm repo once across declarative and imperative pins",
+      "matchDatasources": ["helm"],
+      "matchPackageNames": ["cert-manager"],
+      "registryUrls": ["https://charts.jetstack.io"]
+    },
+    {
+      "description": "Resolve cluster-api-operator Helm repo once across declarative and imperative pins",
+      "matchDatasources": ["helm"],
+      "matchPackageNames": ["cluster-api-operator"],
+      "registryUrls": ["https://kubernetes-sigs.github.io/cluster-api-operator"]
     },
     {
       "description": "No automerge anywhere; merges stay manual (issue #74)",

--- a/tests/test-renovate-coverage.py
+++ b/tests/test-renovate-coverage.py
@@ -5,8 +5,15 @@ The catalog drift check was retired; these detection checks are what proves
 a bump cannot silently stop being proposed for the non-manifest surfaces
 (issue #74 acceptance criteria). Each entry maps a tracked file to the
 depNames Renovate must extract from it via custom.regex managers.
+
+The repo-level regression for #187 is checked separately via a full
+`--dry-run=full` run: the custom-regex harness only exercises the regex
+manager and therefore cannot merge the flux/helm and regex registry inputs
+for the same chart, which is where Renovate emits the real warning.
 """
 
+import os
+import subprocess
 import sys
 from pathlib import Path
 
@@ -40,6 +47,79 @@ EXPECTED = {
     "mise.local-talos.toml": {"siderolabs/talos"},
 }
 
+REQUIRED_SINGLE_REGISTRY = {
+    "cert-manager": "https://charts.jetstack.io",
+    "cluster-api-operator": "https://kubernetes-sigs.github.io/cluster-api-operator",
+}
+
+
+def assert_single_registry_per_helm_package(result) -> list[str]:
+    """Check the packageRules shape that avoids the #187 duplicate registry merge.
+
+    This guards the fix even though the custom-regex harness cannot reproduce the
+    full dry-run warning by itself because it runs only the regex manager and never
+    combines the flux manager with the regex-extracted dep inputs for the same chart.
+    """
+    errors = []
+    for package_file in ["bootstrap.toml", "pivot.sh"]:
+        for dep in result.deps_by_file.get(package_file, []):
+            dep_name = dep.get("depName")
+            if dep_name not in REQUIRED_SINGLE_REGISTRY:
+                continue
+            expected = REQUIRED_SINGLE_REGISTRY[dep_name]
+            registry_urls = dep.get("registryUrls") or []
+            registry_url = dep.get("registryUrl")
+
+            if registry_urls:
+                normalized = [url.rstrip("/") for url in registry_urls]
+            elif registry_url:
+                normalized = [registry_url.rstrip("/")]
+            else:
+                errors.append(
+                    f"{package_file}: {dep_name} has no registryUrl/registryUrls (expected {expected})"
+                )
+                continue
+
+            if len(normalized) != 1 or normalized[0] != expected.rstrip("/"):
+                errors.append(
+                    f"{package_file}: {dep_name} registry values={normalized!r}, expected [{expected}]"
+                )
+    return errors
+
+
+def assert_no_repo_registry_warnings() -> list[str]:
+    """Regression for the full repo dry-run that triggered #187.
+
+    The custom-regex harness cannot see the merge warning because it never enables
+    the full repo config mode. This check ensures the repo-level dry-run remains
+    free of "Excess registryUrls found for datasource lookup".
+    """
+    env = os.environ.copy()
+    env.setdefault("LOG_LEVEL", "debug")
+    if "GITHUB_COM_TOKEN" in env and "RENOVATE_TOKEN" not in env:
+        env["RENOVATE_TOKEN"] = env["GITHUB_COM_TOKEN"]
+    if "RENOVATE_GITHUB_COM_TOKEN" in env and "GITHUB_COM_TOKEN" not in env:
+        env["GITHUB_COM_TOKEN"] = env["RENOVATE_GITHUB_COM_TOKEN"]
+    if "GITHUB_COM_TOKEN" in env and "RENOVATE_GITHUB_COM_TOKEN" not in env:
+        env["RENOVATE_GITHUB_COM_TOKEN"] = env["GITHUB_COM_TOKEN"]
+
+    completed = subprocess.run(
+        ["renovate", "--platform=local", "--dry-run=full"],
+        cwd=str(Path(__file__).resolve().parents[1]),
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        check=False,
+    )
+    output = completed.stdout
+    errors = []
+    if "Excess registryUrls found for datasource lookup" in output:
+        errors.append("full dry-run: Excess registryUrls found for datasource lookup")
+    if completed.returncode not in (0, 1):
+        errors.append(f"full dry-run: unexpected exit code {completed.returncode}")
+    return errors
+
 
 def main() -> int:
     result = run_renovate(EXPECTED)
@@ -49,17 +129,25 @@ def main() -> int:
         for path, deps in EXPECTED.items()
         if deps - result.dep_names(path)
     }
-    if result.returncode or missing:
+    registry_errors = assert_single_registry_per_helm_package(result)
+    repo_registry_errors = assert_no_repo_registry_warnings()
+    if result.returncode or missing or registry_errors or repo_registry_errors:
         print("Renovate coverage check failed", file=sys.stderr)
         print(f"exit code: {result.returncode}", file=sys.stderr)
         if missing:
             for path, deps in sorted(missing.items()):
                 print(f"{path}: missing detection for {deps}", file=sys.stderr)
+        for message in registry_errors:
+            print(message, file=sys.stderr)
+        for message in repo_registry_errors:
+            print(message, file=sys.stderr)
         result.print_diagnostics()
         return 1
 
     for path in sorted(EXPECTED):
         print(f"{path}: pin(s) detected: {sorted(result.dep_names(path))}")
+    print("helm registry URLs: single registry per tracked chart pin")
+    print("repo-level dry-run: no duplicate registry warnings")
     return 0
 
 


### PR DESCRIPTION
## Summary
- remove duplicate Helm registry assignments in Renovate
- centralize the registry per chart in packageRules
- add a regression check for single registry URL per tracked chart pin

## Why
Renovate was logging the duplicate registry warning because the same Helm package was assigned the same registry multiple times.
