### PR TITLE
refactor: rename knr-ops to krops; pin air-gap image digests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,7 @@
 # ── GitOps source (GitHub-synced environments) ────────────────────────────────
 # HTTPS URL of THIS repository. The aws and local-talos environments use it for
 # Flux sync. Flux syncs the mgmt/ path from here.
-GIT_REPO_URL="https://github.com/polarsquad/knr-ops"
+GIT_REPO_URL="https://github.com/polarsquad/krops"
 
 # ── GitHub PAT for Flux (GitHub-synced environments) ──────────────────────────
 # Create a fine-grained token with read-only Contents access, or a classic token

--- a/.github/workflows/air-gapped.yml
+++ b/.github/workflows/air-gapped.yml
@@ -50,17 +50,17 @@ jobs:
         env:
           AIRGAP_CLUSTER_NAME: airgap-wl
           OCI_REGISTRY: localhost:5001
-          WORKLOAD_REGISTRY_HOST: knr-registry-airgap
+          WORKLOAD_REGISTRY_HOST: krops-registry-airgap
           ZARF_KEYLESS_SIGNING: "1"
 
       - name: Store air-gap bundle
         uses: actions/upload-artifact@v7.0.1
         with:
-          name: knr-ops-airgap-arm64
+          name: krops-airgap-arm64
           path: |
             airgap/archives/
             airgap/config-artifact/
-            airgap/zarf-package-knr-ops-airgap-*.tar.zst
+            airgap/zarf-package-krops-airgap-*.tar.zst
           if-no-files-found: error
           retention-days: 1
           compression-level: 0
@@ -84,7 +84,7 @@ jobs:
       - name: Download air-gap bundle
         uses: actions/download-artifact@v8.0.0
         with:
-          name: knr-ops-airgap-arm64
+          name: krops-airgap-arm64
           path: airgap
 
       - name: Deploy with external egress blocked
@@ -94,7 +94,7 @@ jobs:
           set -uo pipefail
 
           capture=/tmp/airgap-public-egress.pcap
-          firewall_comment=knr-airgap-egress
+          firewall_comment=krops-airgap-egress
           bridge_interface=
           tcpdump_pid=
 
@@ -148,7 +148,7 @@ jobs:
           fi
 
           if airgap/scripts/offline-run.sh \
-            airgap/zarf-package-knr-ops-airgap-*.tar.zst; then
+            airgap/zarf-package-krops-airgap-*.tar.zst; then
             deploy_result=0
           else
             deploy_result=$?
@@ -170,7 +170,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7.0.1
         with:
-          name: knr-ops-airgap-isolated-results
+          name: krops-airgap-isolated-results
           path: |
             /tmp/airgap-offline-run.log
             /tmp/airgap-offline-summary.txt
@@ -199,7 +199,7 @@ jobs:
       - name: Download air-gap bundle
         uses: actions/download-artifact@v8.0.0
         with:
-          name: knr-ops-airgap-arm64
+          name: krops-airgap-arm64
           path: airgap
 
       - name: Deploy and monitor public traffic
@@ -238,7 +238,7 @@ jobs:
           fi
 
           if airgap/scripts/offline-run.sh \
-            airgap/zarf-package-knr-ops-airgap-*.tar.zst; then
+            airgap/zarf-package-krops-airgap-*.tar.zst; then
             deploy_result=0
           else
             deploy_result=$?
@@ -260,7 +260,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7.0.1
         with:
-          name: knr-ops-airgap-monitored-results
+          name: krops-airgap-monitored-results
           path: |
             /tmp/airgap-offline-run.log
             /tmp/airgap-offline-summary.txt

--- a/.github/workflows/bootstrap-rs.yml
+++ b/.github/workflows/bootstrap-rs.yml
@@ -87,7 +87,7 @@ jobs:
           platforms: linux/arm64
           push: false
           load: true
-          tags: knr-ops-toolbox:ci
+          tags: krops-toolbox:ci
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -96,8 +96,8 @@ jobs:
           # /workspace has no bootstrap.toml in CI (the repo is mounted
           # there at runtime); --help must be probed from the checkout.
           docker run --rm --entrypoint sh -v "$PWD:/workspace:ro" \
-            -w /workspace knr-ops-toolbox:ci -c '
+            -w /workspace krops-toolbox:ci -c '
             for t in kind kubectl helm clusterctl flux sops age aws docker xargs git curl; do
               command -v "$t" >/dev/null || { echo "::error::$t missing on PATH"; exit 1; }
             done
-            knr-bootstrap --help >/dev/null'
+            krops-bootstrap --help >/dev/null'

--- a/.github/workflows/konflate.yml
+++ b/.github/workflows/konflate.yml
@@ -41,7 +41,7 @@ jobs:
         ports:
           - 8080:8080
         env:
-          KONFLATE_REPO: github://polarsquad/knr-ops
+          KONFLATE_REPO: github://polarsquad/krops
           KONFLATE_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Render only the PR that triggered this run.
           KONFLATE_PR_FILTER_EXPR: pr.number == ${{ github.event.pull_request.number }}

--- a/.github/workflows/toolbox-release.yml
+++ b/.github/workflows/toolbox-release.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 name: toolbox-release
 
-# Publishes ghcr.io/polarsquad/knr-ops-toolbox on semver tags (issue #104).
+# Publishes ghcr.io/polarsquad/krops-toolbox on semver tags (issue #104).
 # The tag must equal the version in bootstrap-rs/Cargo.toml; the gate job
 # fails the release when they disagree. Signing is cosign keyless via the
 # workflow's GitHub OIDC identity (same identity model as the air-gapped
@@ -61,7 +61,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v6.2.0
         with:
-          images: ghcr.io/polarsquad/knr-ops-toolbox
+          images: ghcr.io/polarsquad/krops-toolbox
           # The default latest=auto flavor adds latest for stable semver
           # tags without moving it for prereleases.
           tags: |
@@ -101,9 +101,9 @@ jobs:
         run: |
           # Sign each tag's digest; verification is against the workflow
           # identity (certificate issuer/subject per cosign docs):
-          #   cosign verify ghcr.io/polarsquad/knr-ops-toolbox:X.Y.Z \
+          #   cosign verify ghcr.io/polarsquad/krops-toolbox:X.Y.Z \
           #     --certificate-identity-regexp \
-          #       '^https://github.com/polarsquad/knr-ops/.github/workflows/toolbox-release.yml@refs/tags/vX.Y.Z$' \
+          #       '^https://github.com/polarsquad/krops/.github/workflows/toolbox-release.yml@refs/tags/vX.Y.Z$' \
           #     --certificate-oidc-issuer https://token.actions.githubusercontent.com
           digest="${{ steps.build.outputs.digest }}"
           IFS=',' read -ra tag_list <<< "$TAGS"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# AGENTS.md: knr-ops
+# AGENTS.md: krops
 
 Guidance for AI coding agents working in this repository.
 
@@ -27,7 +27,7 @@ resources. There is no app source code here, only declarative infrastructure.
   #105). Same component layout as `mgmt/aws/` minus addons
   (`infrastructure/`, `capi-providers/`, `clusters/management/`), synced
   from the GitHub GitRepository source like `mgmt/aws`, NOT the laptop OCI
-  registry (a physical machine cannot reach knr-registry). Providers are
+  registry (a physical machine cannot reach krops-registry). Providers are
   Talos + Tinkerbell (CABPT/CACPPT from sidero-community releases, CAPT)
   instead of CAPD; the cluster definition is imperative (explicit
   controlPlaneRef, no ClusterClass) with committed site-specific values
@@ -57,7 +57,7 @@ resources. There is no app source code here, only declarative infrastructure.
   attempted). Both deploy evidence artifacts are uploaded. Running both is
   a temporary comparison of validation accuracy and performance; the less
   effective job will be removed after enough runs are evaluated.
-- `bootstrap-rs/`: `knr-bootstrap`, the Rust CLI that ports the imperative
+- `bootstrap-rs/`: `krops-bootstrap`, the Rust CLI that ports the imperative
   lifecycle (bootstrap + pivot; teardown under issue #100). Behavioral port:
   same step order, messages, and env interface as the scripts, plus
   rerun-safe-by-default semantics. Chart versions it installs imperatively
@@ -67,7 +67,7 @@ resources. There is no app source code here, only declarative infrastructure.
 - `bootstrap.sh` / `pivot.sh` / `teardown.sh`: the shell equivalents of the
   CLI's phases. Kept until the binary completes full parity runs per
   environment, then retired (issues #92/#95/#100). The lifecycle mise tasks
-  (`bootstrap`/`pivot`/`teardown`) run the knr-ops-toolbox container via
+  (`bootstrap`/`pivot`/`teardown`) run the krops-toolbox container via
   `scripts/toolbox-run.sh` (issue #104); the scripts remain the native path
   for development.
 - `docs/`: detailed documentation (see the table in README.md).
@@ -194,7 +194,7 @@ audit, including untouched legacy files.
 Load these only when the task touches their domain:
 
 - `docs/architecture.md`: reconciliation order, how workload apps are delivered.
-- `docs/bootstrap-cli.md`: the `knr-bootstrap` Rust CLI: interface, env knobs, pivot, parity status.
+- `docs/bootstrap-cli.md`: the `krops-bootstrap` Rust CLI: interface, env knobs, pivot, parity status.
 - `docs/extending.md`: adding a workload cluster, adding apps, adding other providers (Azure, Talos, k0smotron).
 - `docs/secrets.md`: SOPS + age setup, credential rotation.
 - `docs/konflate.md`: rendered PR review, CI gate, tokens, write-back.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to knr-ops
+# Contributing to krops
 
-knr-ops is a working reference implementation, not a product: it shows how to
+krops is a working reference implementation, not a product: it shows how to
 run cloud infrastructure through the Kubernetes API with CAPI, Flux, and
 provider operators, and nothing else. Contributions that sharpen that
 demonstration, make it reproducible on more platforms, or make it safer to
@@ -18,7 +18,7 @@ Work is organized into numbered milestones that build on each other.
 | Milestone | State | What it delivered or still owes |
 |---|---|---|
 | 1-renovate-foundations | closed | Renovate as the hosted GitHub App, the central version catalog retired, a shared integration-test harness (`tests/renovate_harness.py`) |
-| 2-rust-bootstrap | closed | `knr-bootstrap`, the Rust CLI covering bootstrap, pivot, and teardown; `bootstrap.toml` as the repository-owned configuration; the toolbox container image |
+| 2-rust-bootstrap | closed | `krops-bootstrap`, the Rust CLI covering bootstrap, pivot, and teardown; `bootstrap.toml` as the repository-owned configuration; the toolbox container image |
 | 3-environments | open | `local-talos` wiring and docs are on `main`; the hardware acceptance run (#105) is pending. Azure via ASO (#71) and GCP via Config Connector (#72) are unstarted |
 | 4-hardening | open | Air-gap supply chain (#80): digest pins everywhere, signed SBOMs, offline verification, transactional updates. The build, signing, and publication model needs a design decision first (#138) |
 
@@ -43,10 +43,10 @@ the best places to start if you are new to the repository.
 
 Labels mark the entry points:
 
-- [`good first issue`](https://github.com/polarsquad/knr-ops/labels/good%20first%20issue):
+- [`good first issue`](https://github.com/polarsquad/krops/labels/good%20first%20issue):
   scoped, self-contained, no cloud account or hardware needed. Mostly
   documentation and script fixes.
-- [`help wanted`](https://github.com/polarsquad/knr-ops/labels/help%20wanted):
+- [`help wanted`](https://github.com/polarsquad/krops/labels/help%20wanted):
   larger items the maintainers are not actively working on, including the
   Azure and GCP providers and the Python test tooling.
 - `bug`, `documentation`, `enhancement` classify the change type.
@@ -81,12 +81,12 @@ The toolbox container is the primary lifecycle interface; native tools are
 for development and validation.
 
 ```sh
-git clone https://github.com/polarsquad/knr-ops.git
-cd knr-ops
+git clone https://github.com/polarsquad/krops.git
+cd krops
 mise trust
 mise install                 # kubectl, kind, flux, sops, age, kustomize, ...
-docker build -f bootstrap-rs/Dockerfile -t knr-ops-toolbox:dev .
-export TOOLBOX_IMAGE=knr-ops-toolbox:dev
+docker build -f bootstrap-rs/Dockerfile -t krops-toolbox:dev .
+export TOOLBOX_IMAGE=krops-toolbox:dev
 mise run validate            # must pass on a clean checkout before you change anything
 ```
 
@@ -228,6 +228,6 @@ Run the checks that match what you touched. CI runs all of them.
 
 ## License
 
-knr-ops is licensed under the Apache License 2.0 (`LICENSE`). By submitting a
+krops is licensed under the Apache License 2.0 (`LICENSE`). By submitting a
 contribution you agree that it is licensed under the same terms. The project
 does not currently require a Developer Certificate of Origin sign-off.

--- a/LICENSE
+++ b/LICENSE
@@ -202,7 +202,7 @@
    limitations under the License.
 
 
-   Copyright 2026 knr-ops contributors
+   Copyright 2026 krops contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# knr-ops
+# krops
 ## kubernetes-native resource operations
 
-![knr-ops logo](docs/knr-ops-logo.svg)
+![krops logo](docs/krops-logo.svg)
 
 A GitOps pattern for managing cloud infrastructure through the Kubernetes API:
 no Terraform, no DSLs, no state files, no second toolchain. This repository is
@@ -40,7 +40,7 @@ the self-managed management plane, syncing from GitHub like `aws`. Scope
 fence: management-only, no workload cluster.
 
 The imperative part of the lifecycle (bootstrap, pivot, and teardown) is a
-single Rust CLI, [`knr-bootstrap`](docs/bootstrap-cli.md), that replaces the
+single Rust CLI, [`krops-bootstrap`](docs/bootstrap-cli.md), that replaces the
 shell scripts as they complete parity runs. After the one-time bootstrap and
 pivot, **everything is declared in Git as YAML**. The `aws` environment
 declares 2 CAPI workload clusters: 4 node pools (ARM and GPU) across 2
@@ -77,11 +77,11 @@ not a developer self-service portal; you are the consumer.
   pivot the management cluster manages itself through the same GitOps flow it
   drives.
 
-![knr-ops aws architecture](docs/aws-infra.svg)
+![krops aws architecture](docs/aws-infra.svg)
 
-![knr-ops local-host architecture](docs/local-host-infra.svg)
+![krops local-host architecture](docs/local-host-infra.svg)
 
-![knr-ops air-gap architecture](docs/air-gap-infra.svg)
+![krops air-gap architecture](docs/air-gap-infra.svg)
 
 ## Prerequisites
 
@@ -92,10 +92,10 @@ needs only the repository checkout and a running engine:
   socket
 - The toolbox image. No semver release has been published yet, so build the
   current checkout with
-  `docker build -f bootstrap-rs/Dockerfile -t knr-ops-toolbox:dev .`
+  `docker build -f bootstrap-rs/Dockerfile -t krops-toolbox:dev .`
 
 A future matching `v*` tag publishes
-`ghcr.io/polarsquad/knr-ops-toolbox` for Linux amd64 and arm64 as `X.Y.Z`,
+`ghcr.io/polarsquad/krops-toolbox` for Linux amd64 and arm64 as `X.Y.Z`,
 `X.Y`, and stable `latest`, with a keyless signature and SPDX SBOM
 attestation. The `aws` environment additionally requires a GitHub PAT with
 read access, AWS credentials and service quotas, and an age private key. The
@@ -116,14 +116,14 @@ Build the current checkout and run the complete local-host lifecycle with only
 Docker installed:
 
 ```sh
-docker build -f bootstrap-rs/Dockerfile -t knr-ops-toolbox:dev .
+docker build -f bootstrap-rs/Dockerfile -t krops-toolbox:dev .
 mkdir -p .kube
 docker run --rm -it \
   -v "$PWD:/workspace" -w /workspace \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v "$PWD/.kube:/root/.kube" \
   -e KUBECONFIG=/workspace/.kube/kind.yaml \
-  knr-ops-toolbox:dev local-host
+  krops-toolbox:dev local-host
 
 # Teardown uses the same mounts and the teardown subcommand:
 docker run --rm -it \
@@ -131,10 +131,10 @@ docker run --rm -it \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v "$PWD/.kube:/root/.kube" \
   -e KUBECONFIG=/workspace/.kube/kind.yaml \
-  knr-ops-toolbox:dev teardown local-host
+  krops-toolbox:dev teardown local-host
 ```
 
-Use `ghcr.io/polarsquad/knr-ops-toolbox:<version>` instead of the local image
+Use `ghcr.io/polarsquad/krops-toolbox:<version>` instead of the local image
 for a published release. The AWS form must also pass the Git source, PAT, age
 key path, and any AWS credential variables. Podman socket paths vary by host.
 `scripts/toolbox-run.sh` handles those mounts, loads `.env` without preserving
@@ -145,14 +145,14 @@ For hosts with mise, the lifecycle tasks call that wrapper. Installing the
 pinned native tools also enables key generation, validation, and inspection:
 
 ```sh
-docker build -f bootstrap-rs/Dockerfile -t knr-ops-toolbox:dev .
-export TOOLBOX_IMAGE=knr-ops-toolbox:dev
+docker build -f bootstrap-rs/Dockerfile -t krops-toolbox:dev .
+export TOOLBOX_IMAGE=krops-toolbox:dev
 mise trust
 mise install
 cp .env.example .env        # aws and local-talos: fill in the Git source and PAT
 mise run sops-keygen         # first time only: age key for SOPS
 mise run bootstrap           # toolbox: bootstrap, Flux handoff, then pivot
-export KUBECONFIG="$PWD/.kube/knr-ops-mgmt.yaml"
+export KUBECONFIG="$PWD/.kube/krops-mgmt.yaml"
 flux get kustomizations --watch
 mise run validate            # shell syntax, bootstrap.toml cross-check, overlays
 mise run teardown            # toolbox: reverse-order lifecycle cleanup
@@ -169,7 +169,7 @@ The shared toolchain is defined in `mise.toml`. AWS-specific tools are layered
 through `mise.aws.toml`; use the `aws` environment when those tools are
 needed. The `local-host` environment creates the management kind cluster, a
 local OCI registry, and the Flux Operator and FluxInstance. It publishes the
-`mgmt/local-host/` and `workload/local-host/` folders as the `knr-ops:latest`
+`mgmt/local-host/` and `workload/local-host/` folders as the `krops:latest`
 OCI artifact. Flux installs CAPI with its Docker infrastructure provider (CAPD),
 provisions a local one-control-plane/one-worker workload cluster, and installs
 a separate Flux instance there. That workload Flux instance reconciles Podinfo,
@@ -178,11 +178,11 @@ workload delivery and application access. This covers the complete GitOps and
 CAPI lifecycle without provisioning AWS resources:
 
 ```sh
-docker build -f bootstrap-rs/Dockerfile -t knr-ops-toolbox:dev .
-export TOOLBOX_IMAGE=knr-ops-toolbox:dev
+docker build -f bootstrap-rs/Dockerfile -t krops-toolbox:dev .
+export TOOLBOX_IMAGE=krops-toolbox:dev
 mise -E local-host install
 mise -E local-host run bootstrap
-export KUBECONFIG="$PWD/.kube/knr-ops-mgmt.yaml"
+export KUBECONFIG="$PWD/.kube/krops-mgmt.yaml"
 mise -E local-host run oci-push  # republish local management and workload paths
 mise -E local-host run kubeconfigs
 mise -E local-host run podinfo-port-forward  # http://localhost:9898
@@ -215,15 +215,15 @@ machine, and the site values in
 ```sh
 mise -E local-talos install  # adds talosctl
 mise -E local-talos run bootstrap
-export KUBECONFIG="$PWD/.kube/knr-ops-mgmt.yaml"
+export KUBECONFIG="$PWD/.kube/krops-mgmt.yaml"
 mise -E local-talos run kubeconfigs
 mise -E local-talos run teardown  # releases the Hardware; never wipes the machine
 ```
 
 ## The bootstrap CLI
 
-The single `knr-bootstrap` binary implements bootstrap, the default pivot, and
-`knr-bootstrap teardown`. Repository-owned cluster names, paths, chart
+The single `krops-bootstrap` binary implements bootstrap, the default pivot, and
+`krops-bootstrap teardown`. Repository-owned cluster names, paths, chart
 versions, provider manifests, and teardown targets come from
 [`bootstrap.toml`](bootstrap.toml); `mise run validate` cross-checks that file
 against the Git manifests. Sequence-level behavior and generic fallback
@@ -240,10 +240,10 @@ teardown controls, toolbox release, and current parity status.
 
 | Page | Contents |
 |---|---|
-| [docs/bootstrap-cli.md](docs/bootstrap-cli.md) | The `knr-bootstrap` lifecycle CLI: toolbox distribution, interface, `bootstrap.toml`, pivot, teardown, parity status |
+| [docs/bootstrap-cli.md](docs/bootstrap-cli.md) | The `krops-bootstrap` lifecycle CLI: toolbox distribution, interface, `bootstrap.toml`, pivot, teardown, parity status |
 | [docs/dependencies.md](docs/dependencies.md) | Renovate-managed dependency updates: covered surfaces, update procedure, intentional differences |
 | [docs/architecture.md](docs/architecture.md) | Architecture diagram, reconciliation order, how workload apps are delivered |
-| [docs/aws-iam.md](docs/aws-iam.md) | EKS Pod Identity, ACK controller IAM roles, per-cluster reader roles, the `knr-ops-reader` console user |
+| [docs/aws-iam.md](docs/aws-iam.md) | EKS Pod Identity, ACK controller IAM roles, per-cluster reader roles, the `krops-reader` console user |
 | [docs/workload-resources.md](docs/workload-resources.md) | S3 bucket security posture, RDS instances, known limitations |
 | [docs/konflate.md](docs/konflate.md) | Rendered Flux PR review: GitHub Actions gate, in-cluster instance, write-back to PRs, tokens |
 | [docs/secrets.md](docs/secrets.md) | SOPS + age secret management, key setup, credential rotation |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security policy
 
-knr-ops is a reference implementation of a GitOps pattern for managing cloud
+krops is a reference implementation of a GitOps pattern for managing cloud
 infrastructure through the Kubernetes API. It is not a product with a
 release cadence, but its manifests, scripts, CLI, container image, and CI
 workflows provision real cloud resources and handle real credentials, so
@@ -9,7 +9,7 @@ security reports are taken seriously.
 ## Reporting a vulnerability
 
 Report privately through GitHub:
-[Report a vulnerability](https://github.com/polarsquad/knr-ops/security/advisories/new).
+[Report a vulnerability](https://github.com/polarsquad/krops/security/advisories/new).
 This opens a draft security advisory visible only to the repository
 maintainers.
 
@@ -36,7 +36,7 @@ is merged.
 ## Supported versions
 
 Only `main` is supported. There are no release branches. The toolbox image
-`ghcr.io/polarsquad/knr-ops-toolbox` is published from `v*` tags when they
+`ghcr.io/polarsquad/krops-toolbox` is published from `v*` tags when they
 exist; the newest tag is the only supported image version, and fixes land
 on `main` first.
 
@@ -63,13 +63,13 @@ Out of scope:
 - Vulnerabilities in upstream projects the repository consumes (Flux,
   Cluster API and its providers, ACK controllers, konflate, Zarf, Talos,
   Tinkerbell, kind). Report those upstream; a report here is welcome only
-  if knr-ops configures the component in a way that makes the issue worse
+  if krops configures the component in a way that makes the issue worse
   or bypasses a mitigation.
 - The AWS service side (EKS, IAM, S3, RDS) itself.
 - Deployments made from forks or adapted copies of this repository. The
   README states the intended use: fork it and adapt it. Once adapted, the
   security posture is the operator's.
-- The demo `knr-ops-reader` console user password, which is set
+- The demo `krops-reader` console user password, which is set
   imperatively by the operator and never stored in Git.
 
 ## What the repository already does
@@ -85,7 +85,7 @@ a gap.
   on them. The management cluster holds the CAPA and ACK credentials as
   SOPS-encrypted secrets. See `docs/aws-iam.md`.
 - Read access to AWS is scoped: one IAM user whose only permission is
-  `sts:AssumeRole` into per-cluster `knr-ops-*-reader` roles.
+  `sts:AssumeRole` into per-cluster `krops-*-reader` roles.
 - S3 buckets block all public access, enforce SSE, enable versioning,
   disable ACLs, and deny non-TLS requests. See `docs/workload-resources.md`.
 - The `konflate` PR review workflow uses only the workflow `GITHUB_TOKEN`
@@ -95,9 +95,9 @@ a gap.
   identity) and carries an SPDX SBOM attestation. Verify with:
 
   ```sh
-  cosign verify ghcr.io/polarsquad/knr-ops-toolbox:X.Y.Z \
+  cosign verify ghcr.io/polarsquad/krops-toolbox:X.Y.Z \
     --certificate-identity-regexp \
-      '^https://github.com/polarsquad/knr-ops/.github/workflows/toolbox-release.yml@refs/tags/vX.Y.Z$' \
+      '^https://github.com/polarsquad/krops/.github/workflows/toolbox-release.yml@refs/tags/vX.Y.Z$' \
     --certificate-oidc-issuer https://token.actions.githubusercontent.com
   ```
 

--- a/airgap/images.txt
+++ b/airgap/images.txt
@@ -1,4 +1,4 @@
-# knr-ops airgap image inventory (local-host / CAPD profile)
+# krops airgap image inventory (local-host / CAPD profile)
 # Source: live connected baseline, harvested 2026-08-17.
 #   mgmt pod images   : kubectl -n <ns> get pods -o json (kind-mgmt context)
 #   mgmt node store   : docker exec mgmt-control-plane crictl images
@@ -62,7 +62,7 @@ registry.k8s.io/kube-proxy:v1.37.0
 registry.k8s.io/etcd:3.7.1-0
 registry.k8s.io/kube-scheduler:v1.37.0
 registry.k8s.io/pause:3.10.2
-# workload cluster runs its own Flux (synced from knr-registry:5000)
+# workload cluster runs its own Flux (synced from krops-registry:5000)
 ghcr.io/controlplaneio-fluxcd/flux-operator:v0.58.0
 ghcr.io/fluxcd/helm-controller:v1.6.3
 ghcr.io/fluxcd/kustomize-controller:v1.9.4

--- a/airgap/images.txt
+++ b/airgap/images.txt
@@ -10,61 +10,61 @@
 #   [H] host Docker daemon image, consumed by kind + CAPD (NOT agent-rewriteable)
 #   [W] workload-node containerd store (separate from host daemon)
 #
-# NOTE: workload and management CAPD node images are kindest/node:v1.37.0;
+# NOTE: workload and management CAPD node images are kindest/node:v1.37.0@sha256:a1ed56cfb0e7b93589bdf97c8cd566405a265939e3620fc4f5de89adff580ae5;
 #       the kind bootstrap mgmt node still runs v1.36.1 pending recreation
 #       (KIND_NODE_IMAGE now defaults to v1.37.0). Their embedded component
 #       versions differ (kindnetd, coredns, etcd, k8s).
 
 # ── Management cluster pod images [M] ─────────────────────────────────────────
-ghcr.io/controlplaneio-fluxcd/flux-operator:v0.58.0
-ghcr.io/fluxcd/helm-controller:v1.6.3
-ghcr.io/fluxcd/kustomize-controller:v1.9.4
-ghcr.io/fluxcd/notification-controller:v1.9.3
-ghcr.io/fluxcd/source-controller:v1.9.4
-quay.io/jetstack/cert-manager-controller:v1.21.1
-quay.io/jetstack/cert-manager-cainjector:v1.21.1
-quay.io/jetstack/cert-manager-webhook:v1.21.1
-quay.io/jetstack/cert-manager-startupapicheck:v1.21.1
-registry.k8s.io/capi-operator/cluster-api-operator:v0.29.0
-registry.k8s.io/cluster-api/cluster-api-controller:v1.14.0
-registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.14.0
-registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.14.0
-registry.k8s.io/cluster-api-helm/cluster-api-helm-controller:v0.6.4
-gcr.io/k8s-staging-cluster-api/capd-manager:v1.14.0
-registry.k8s.io/coredns/coredns:v1.14.7
-registry.k8s.io/kube-apiserver:v1.37.0
-registry.k8s.io/kube-controller-manager:v1.37.0
-registry.k8s.io/kube-proxy:v1.36.1
-registry.k8s.io/etcd:3.7.1-0
-registry.k8s.io/kube-scheduler:v1.37.0
-registry.k8s.io/pause:3.10
-docker.io/kindest/kindnetd:v20260528-9350166c
-docker.io/kindest/local-path-provisioner:v20260521-9fb22683
-docker.io/kindest/local-path-helper:v20260131-7181c60a
+ghcr.io/controlplaneio-fluxcd/flux-operator:v0.58.0@sha256:1c919ce1e28716f817ded65c06df0b7a8269542387d5a2ce50212450473c6209
+ghcr.io/fluxcd/helm-controller:v1.6.3@sha256:16ada99456385100698a5d7adf90aba8a2089d987ab541c9566b6d7b0e897038
+ghcr.io/fluxcd/kustomize-controller:v1.9.4@sha256:2b8bec54ffb6caf421bd2a6c005d27f567d5dd4db7feb55794fb51fcabd69b8f
+ghcr.io/fluxcd/notification-controller:v1.9.3@sha256:071c351a0fb163eeb6a2bb82f1e894f51b6b0734216d2e97d3d99c9ab9d710b9
+ghcr.io/fluxcd/source-controller:v1.9.4@sha256:8a8ed0a57b8b86f561d5a4309a69f65e62f0cebe4de8801593c5ff35a3bc3c23
+quay.io/jetstack/cert-manager-controller:v1.21.1@sha256:416a2d76870d996460e62bd7f521bf14fa017be9e3e904aab92163a331fcb61a
+quay.io/jetstack/cert-manager-cainjector:v1.21.1@sha256:ccf6b919ec0500745a47a910118f834f9636d0aac1ff221245cd2557ed8c7c98
+quay.io/jetstack/cert-manager-webhook:v1.21.1@sha256:d8b3961b51c8c7320633f8208dc46bf88aa13804d0f7cbe48a096b2c523cee42
+quay.io/jetstack/cert-manager-startupapicheck:v1.21.1@sha256:d8ab6416e6e7303a86fa0a8daa82c94a8001f21c9d78eb2e7db20534e5d07ae8
+registry.k8s.io/capi-operator/cluster-api-operator:v0.29.0@sha256:465e72f8b06ae96de7c142d552f898fb4d0d92ab5d71c8691e431a19d1b4955c
+registry.k8s.io/cluster-api/cluster-api-controller:v1.14.0@sha256:4f57cf35b7de52e568eb85295f2a505268f29f1c7b76e7b12ce7cf6d2034f8f4
+registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.14.0@sha256:3209310007d8f015545f5cd621b110cc1af2bcf2538d91bbac81aaf989451102
+registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.14.0@sha256:bab6f68839cef892102427f03599dd4d7b433bcae0e4794724ba80253fb8aa98
+registry.k8s.io/cluster-api-helm/cluster-api-helm-controller:v0.6.4@sha256:97d2a86f8e35d23bb4656b26f4564b35f109e47a0dc4860b71089e52eb6e6a24
+gcr.io/k8s-staging-cluster-api/capd-manager:v1.14.0@sha256:9b68fc45b6d564804d7a32c1d800751daa5d556e40c4c303d1ec4b8d610afa5a
+registry.k8s.io/coredns/coredns:v1.14.7@sha256:7efd3c635b03efd68c4e8398fc45f0d993d0e9ab016f72c1cefb0fd6d01aa286
+registry.k8s.io/kube-apiserver:v1.37.0@sha256:d1045e5c6d2f016797d22143eba7502e1bb712a4681836a7c35763a9c192dd70
+registry.k8s.io/kube-controller-manager:v1.37.0@sha256:997c997924eb8574f63f204a0b0af133aaf33c10df84009c32d34037f4e0e077
+registry.k8s.io/kube-proxy:v1.36.1@sha256:a96b6e12863ef766d18f69afaad7a5329220c37ce21cb232bcb58362d284f3f7
+registry.k8s.io/etcd:3.7.1-0@sha256:a9983dd6d9283138ab926daa307c6c25623636703ecf5645d5df4d666ce9eba2
+registry.k8s.io/kube-scheduler:v1.37.0@sha256:a27622f132aa09cf2461ba077894a070c0186ec607366d14e805912d4804d11f
+registry.k8s.io/pause:3.10@sha256:ee6521f290b2168b6e0935a181d4cff9be1ac3f505666ef0e3c98fae8199917a
+docker.io/kindest/kindnetd:v20260528-9350166c@sha256:92f49a1b2c9242058481fc3e13412c19a62cfeb090717dad4598719d32351f1f
+docker.io/kindest/local-path-provisioner:v20260521-9fb22683@sha256:b1de813bcdde9737a283ff1961725d66c412b235fe08f2a3dc707fece91674b8
+docker.io/kindest/local-path-helper:v20260131-7181c60a@sha256:ac7c7f08e86f7bef7d2ad6dee944ed89d3d2e7de0ebc00490d7ddf6c26628a06
 
 # ── Host Docker daemon images [H] (kind nodes + CAPD containers) ─────────────
-kindest/node:v1.37.0
-kindest/node:v1.37.0
-kindest/haproxy:v20230606-42a2262b
-docker.io/library/registry:2
+kindest/node:v1.37.0@sha256:a1ed56cfb0e7b93589bdf97c8cd566405a265939e3620fc4f5de89adff580ae5
+kindest/node:v1.37.0@sha256:a1ed56cfb0e7b93589bdf97c8cd566405a265939e3620fc4f5de89adff580ae5
+kindest/haproxy:v20230606-42a2262b@sha256:001a06433666046dea44567c7d7c6adfc2ac0edb556576f6da507ff0b0f063d3
+docker.io/library/registry:2@sha256:a3d8aaa63ed8681a604f1dea0aa03f100d5895b6a58ace528858a7b332415373
 
 # ── Workload node containerd store [W] (v1.37.0 generation) ──────────────────
 # Pulled by the workload node's OWN containerd; must be pre-seeded or reachable
 # from a registry the workload node can reach over the kind docker network.
-docker.io/kindest/kindnetd:v20260820-69b56db7
-docker.io/kindest/kindnetd:v20260528-9350166c
-docker.io/kindest/local-path-provisioner:v20260820-69b56db7
-docker.io/kindest/local-path-helper:v20260131-7181c60a
-registry.k8s.io/coredns/coredns:v1.14.6
-registry.k8s.io/kube-apiserver:v1.37.0
-registry.k8s.io/kube-controller-manager:v1.37.0
-registry.k8s.io/kube-proxy:v1.37.0
-registry.k8s.io/etcd:3.7.1-0
-registry.k8s.io/kube-scheduler:v1.37.0
-registry.k8s.io/pause:3.10.2
+docker.io/kindest/kindnetd:v20260820-69b56db7@sha256:526969f0a1a7a788a7a96f53a4ad3b51607bde7bb2841edf52a02916e8d52650
+docker.io/kindest/kindnetd:v20260528-9350166c@sha256:92f49a1b2c9242058481fc3e13412c19a62cfeb090717dad4598719d32351f1f
+docker.io/kindest/local-path-provisioner:v20260820-69b56db7@sha256:fdb5360219dcca6acc7967326f9e04c89b038e2c1e924463b2a41cad2dc752ab
+docker.io/kindest/local-path-helper:v20260131-7181c60a@sha256:ac7c7f08e86f7bef7d2ad6dee944ed89d3d2e7de0ebc00490d7ddf6c26628a06
+registry.k8s.io/coredns/coredns:v1.14.6@sha256:900f9c109f7a33545d3c811516e8376df9019147b750f5ce3e254468769176ea
+registry.k8s.io/kube-apiserver:v1.37.0@sha256:d1045e5c6d2f016797d22143eba7502e1bb712a4681836a7c35763a9c192dd70
+registry.k8s.io/kube-controller-manager:v1.37.0@sha256:997c997924eb8574f63f204a0b0af133aaf33c10df84009c32d34037f4e0e077
+registry.k8s.io/kube-proxy:v1.37.0@sha256:77bf2b08ff8ac1a4a446cffaa85e79e87379c8cb54fcf60f2cb6c62c966829c8
+registry.k8s.io/etcd:3.7.1-0@sha256:a9983dd6d9283138ab926daa307c6c25623636703ecf5645d5df4d666ce9eba2
+registry.k8s.io/kube-scheduler:v1.37.0@sha256:a27622f132aa09cf2461ba077894a070c0186ec607366d14e805912d4804d11f
+registry.k8s.io/pause:3.10.2@sha256:f548e0e8e3dc1896ca956272154dde3314e8cc4fde0a57577ee9fa1c63f5baf4
 # workload cluster runs its own Flux (synced from krops-registry:5000)
-ghcr.io/controlplaneio-fluxcd/flux-operator:v0.58.0
-ghcr.io/fluxcd/helm-controller:v1.6.3
-ghcr.io/fluxcd/kustomize-controller:v1.9.4
-ghcr.io/fluxcd/notification-controller:v1.9.3
-ghcr.io/fluxcd/source-controller:v1.9.4
+ghcr.io/controlplaneio-fluxcd/flux-operator:v0.58.0@sha256:1c919ce1e28716f817ded65c06df0b7a8269542387d5a2ce50212450473c6209
+ghcr.io/fluxcd/helm-controller:v1.6.3@sha256:16ada99456385100698a5d7adf90aba8a2089d987ab541c9566b6d7b0e897038
+ghcr.io/fluxcd/kustomize-controller:v1.9.4@sha256:2b8bec54ffb6caf421bd2a6c005d27f567d5dd4db7feb55794fb51fcabd69b8f
+ghcr.io/fluxcd/notification-controller:v1.9.3@sha256:071c351a0fb163eeb6a2bb82f1e894f51b6b0734216d2e97d3d99c9ab9d710b9
+ghcr.io/fluxcd/source-controller:v1.9.4@sha256:8a8ed0a57b8b86f561d5a4309a69f65e62f0cebe4de8801593c5ff35a3bc3c23

--- a/airgap/images.txt
+++ b/airgap/images.txt
@@ -10,7 +10,7 @@
 #   [H] host Docker daemon image, consumed by kind + CAPD (NOT agent-rewriteable)
 #   [W] workload-node containerd store (separate from host daemon)
 #
-# NOTE: workload and management CAPD node images are kindest/node:v1.37.0@sha256:a1ed56cfb0e7b93589bdf97c8cd566405a265939e3620fc4f5de89adff580ae5;
+# NOTE: workload and management CAPD node images are kindest/node:v1.37.0;
 #       the kind bootstrap mgmt node still runs v1.36.1 pending recreation
 #       (KIND_NODE_IMAGE now defaults to v1.37.0). Their embedded component
 #       versions differ (kindnetd, coredns, etcd, k8s).

--- a/airgap/manifests/flux-instance.yaml
+++ b/airgap/manifests/flux-instance.yaml
@@ -52,7 +52,7 @@ spec:
   sync:
     interval: 1m
     kind: OCIRepository
-    url: oci://###ZARF_CONST_REGISTRY_INTERNAL###/knr-ops-airgap
+    url: oci://###ZARF_CONST_REGISTRY_INTERNAL###/krops-airgap
     ref: latest
     path: mgmt/local-host
     pullSecret: private-registry

--- a/airgap/scripts/build-config-artifact.sh
+++ b/airgap/scripts/build-config-artifact.sh
@@ -126,28 +126,28 @@ data:
           - patch: |
               - op: replace
                 path: /spec/template/spec/containers/0/image
-                value: ghcr.io/fluxcd/source-controller:v1.9.4
+                value: ghcr.io/fluxcd/source-controller:v1.9.4@sha256:8a8ed0a57b8b86f561d5a4309a69f65e62f0cebe4de8801593c5ff35a3bc3c23
             target:
               kind: Deployment
               name: source-controller
           - patch: |
               - op: replace
                 path: /spec/template/spec/containers/0/image
-                value: ghcr.io/fluxcd/kustomize-controller:v1.9.4
+                value: ghcr.io/fluxcd/kustomize-controller:v1.9.4@sha256:2b8bec54ffb6caf421bd2a6c005d27f567d5dd4db7feb55794fb51fcabd69b8f
             target:
               kind: Deployment
               name: kustomize-controller
           - patch: |
               - op: replace
                 path: /spec/template/spec/containers/0/image
-                value: ghcr.io/fluxcd/helm-controller:v1.6.3
+                value: ghcr.io/fluxcd/helm-controller:v1.6.3@sha256:16ada99456385100698a5d7adf90aba8a2089d987ab541c9566b6d7b0e897038
             target:
               kind: Deployment
               name: helm-controller
           - patch: |
               - op: replace
                 path: /spec/template/spec/containers/0/image
-                value: ghcr.io/fluxcd/notification-controller:v1.9.3
+                value: ghcr.io/fluxcd/notification-controller:v1.9.3@sha256:071c351a0fb163eeb6a2bb82f1e894f51b6b0734216d2e97d3d99c9ab9d710b9
             target:
               kind: Deployment
               name: notification-controller
@@ -185,16 +185,16 @@ import sys
 path = sys.argv[1]
 txt = open(path).read()
 preload = """          preLoadImages:
-            - registry.k8s.io/pause:3.10.1
-            - docker.io/kindest/kindnetd:v20260528-9350166c
-            - ghcr.io/controlplaneio-fluxcd/flux-operator:v0.58.0
-            - ghcr.io/fluxcd/source-controller:v1.9.4
-            - ghcr.io/fluxcd/kustomize-controller:v1.9.4
-            - ghcr.io/fluxcd/helm-controller:v1.6.3
-            - ghcr.io/fluxcd/notification-controller:v1.9.3
-            - ghcr.io/stefanprodan/podinfo:6.14.0
+            - registry.k8s.io/pause:3.10.1@sha256:278fb9dbcca9518083ad1e11276933a2e96f23de604a3a08cc3c80002767d24c
+            - docker.io/kindest/kindnetd:v20260528-9350166c@sha256:92f49a1b2c9242058481fc3e13412c19a62cfeb090717dad4598719d32351f1f
+            - ghcr.io/controlplaneio-fluxcd/flux-operator:v0.58.0@sha256:1c919ce1e28716f817ded65c06df0b7a8269542387d5a2ce50212450473c6209
+            - ghcr.io/fluxcd/source-controller:v1.9.4@sha256:8a8ed0a57b8b86f561d5a4309a69f65e62f0cebe4de8801593c5ff35a3bc3c23
+            - ghcr.io/fluxcd/kustomize-controller:v1.9.4@sha256:2b8bec54ffb6caf421bd2a6c005d27f567d5dd4db7feb55794fb51fcabd69b8f
+            - ghcr.io/fluxcd/helm-controller:v1.6.3@sha256:16ada99456385100698a5d7adf90aba8a2089d987ab541c9566b6d7b0e897038
+            - ghcr.io/fluxcd/notification-controller:v1.9.3@sha256:071c351a0fb163eeb6a2bb82f1e894f51b6b0734216d2e97d3d99c9ab9d710b9
+            - ghcr.io/stefanprodan/podinfo:6.14.0@sha256:0a8aa037137c010a75aed8d3fe56931d0edd3bcd0e55acfb96db11e1e96397b1
 """
-anchor = "          customImage: kindest/node:v1.37.0\n"
+anchor = "          customImage: kindest/node:v1.37.0@sha256:a1ed56cfb0e7b93589bdf97c8cd566405a265939e3620fc4f5de89adff580ae5\n"
 count = txt.count(anchor)
 if count != 2:
     sys.exit(f"ERROR: expected 2 DevMachineTemplate customImage anchors, found {count}")

--- a/airgap/scripts/build-config-artifact.sh
+++ b/airgap/scripts/build-config-artifact.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
-# build-config-artifact.sh — build the airgap-trimmed knr-ops config tree and
+# build-config-artifact.sh — build the airgap-trimmed krops config tree and
 # push it to the connected-side OCI registry, ready to be baked into the
-# Zarf package (zarf.yaml lists it under the knr-ops-config component images).
+# Zarf package (zarf.yaml lists it under the krops-config component images).
 #
 # Connected-side only. Requires: flux CLI and an OCI registry. By default it
-# uses the knr-registry container from `mise -E local-host run bootstrap`.
+# uses the krops-registry container from `mise -E local-host run bootstrap`.
 #
 # Why a trimmed tree: in the gap the substrate (cert-manager, CAPI, CAAPH,
 # flux-operator) is deployed by Zarf, and the capi-operator HelmRelease /
@@ -18,12 +18,12 @@ REPO_ROOT=$(git rev-parse --show-toplevel)
 cd "$REPO_ROOT"
 
 REGISTRY_PORT="${REGISTRY_PORT:-5001}"
-OCI_REPOSITORY="${OCI_REPOSITORY:-knr-ops-airgap}"
+OCI_REPOSITORY="${OCI_REPOSITORY:-krops-airgap}"
 OCI_TAG="${OCI_TAG:-latest}"
 OCI_REGISTRY="${OCI_REGISTRY:-localhost:${REGISTRY_PORT}}"
 OCI_URL="oci://${OCI_REGISTRY}/${OCI_REPOSITORY}:${OCI_TAG}"
 
-ARTIFACT_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/knr-ops-airgap-oci.XXXXXX")
+ARTIFACT_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/krops-airgap-oci.XXXXXX")
 cleanup() { rm -rf "$ARTIFACT_ROOT"; }
 trap cleanup EXIT
 
@@ -38,7 +38,7 @@ cp mgmt/local-host/addons/cni/flux-ks.yaml "$LH/addons/cni/flux-ks.yaml"
 cp mgmt/local-host/addons/flux-apps/kustomization.yaml "$LH/addons/flux-apps/kustomization.yaml"
 
 # Airgap variant of the per-cluster flux-operator HelmChartProxy: fetch the
-# chart from knr-registry (seeded by stage-and-create-cluster.sh) instead of
+# chart from krops-registry (seeded by stage-and-create-cluster.sh) instead of
 # ghcr.io, which is unreachable in the gap.
 cat > "$LH/addons/flux-apps/flux-operator.yaml" <<'EOF'
 apiVersion: addons.cluster.x-k8s.io/v1alpha1
@@ -50,8 +50,8 @@ spec:
   clusterSelector:
     matchLabels:
       fluxcd: enabled
-      knr-ops.polarsquad.com/environment: local-host
-  repoURL: oci://knr-registry:5000/charts
+      krops.polarsquad.com/environment: local-host
+  repoURL: oci://krops-registry:5000/charts
   chartName: flux-operator
   version: "0.58.0"
   # Pinned release name, matching mgmt/*/addons/flux-apps/flux-operator.yaml:
@@ -72,7 +72,7 @@ EOF
 # tags (the embedded distribution's manifest-list digests do not resolve in a
 # single-arch registry). The tag images are pre-loaded into the CAPD node
 # stores via preLoadImages (see the cluster-class patch below), so no workload
-# pod ever needs the internet. sync.url keeps pointing at knr-registry, which
+# pod ever needs the internet. sync.url keeps pointing at krops-registry, which
 # stage-and-create-cluster.sh recreates and seeds in the gap.
 cat > "$LH/addons/flux-apps/flux-instance.yaml" <<'EOF'
 apiVersion: v1
@@ -112,7 +112,7 @@ data:
         domain: cluster.local
       sync:
         kind: OCIRepository
-        url: oci://knr-registry:5000/knr-ops
+        url: oci://krops-registry:5000/krops
         ref: latest
         path: workload/local-host
       kustomize:
@@ -161,7 +161,7 @@ spec:
   clusterSelector:
     matchLabels:
       fluxcd: enabled
-      knr-ops.polarsquad.com/environment: local-host
+      krops.polarsquad.com/environment: local-host
   strategy: ApplyOnce
   resources:
     - kind: ConfigMap
@@ -203,7 +203,7 @@ open(path, "w").write(txt)
 print(f"patched {path}: preLoadImages added to {count} DevMachineTemplates")
 PY
 
-# Workload tree: rewrite the podinfo chart OCI URL to knr-registry (seeded in
+# Workload tree: rewrite the podinfo chart OCI URL to krops-registry (seeded in
 # the gap) and mark the OCIRepository insecure (plain HTTP). The FluxInstance
 # insecure patch only covers the operator-generated sync source, not
 # tree-defined OCIRepositories. Everything else ships verbatim.
@@ -214,23 +214,23 @@ path = sys.argv[1]
 txt = open(path).read()
 txt = txt.replace(
     "oci://ghcr.io/stefanprodan/charts/podinfo",
-    "oci://knr-registry:5000/stefanprodan/charts/podinfo",
+    "oci://krops-registry:5000/stefanprodan/charts/podinfo",
 )
 if "insecure: true" not in txt:
     txt = txt.replace("spec:\n  interval: 1h\n  url:", "spec:\n  interval: 1h\n  insecure: true\n  url:", 1)
 open(path, "w").write(txt)
-assert "insecure: true" in txt and "knr-registry" in txt
-print(f"patched {path}: podinfo chart -> knr-registry, insecure: true")
+assert "insecure: true" in txt and "krops-registry" in txt
+print(f"patched {path}: podinfo chart -> krops-registry, insecure: true")
 PY
 
-# Optional registry override: WORKLOAD_REGISTRY_HOST (default knr-registry)
+# Optional registry override: WORKLOAD_REGISTRY_HOST (default krops-registry)
 # rewrites the workload-side registry references. Use a distinct name when
 # rehearsing on a host that already runs a live baseline, so the rehearsal's
-# seeded registry never touches the baseline's knr-ops:latest.
-if [ -n "${WORKLOAD_REGISTRY_HOST:-}" ] && [ "$WORKLOAD_REGISTRY_HOST" != "knr-registry" ]; then
+# seeded registry never touches the baseline's krops:latest.
+if [ -n "${WORKLOAD_REGISTRY_HOST:-}" ] && [ "$WORKLOAD_REGISTRY_HOST" != "krops-registry" ]; then
   echo "==> Rewriting workload registry references to '${WORKLOAD_REGISTRY_HOST}'"
-  grep -rl "knr-registry" "$ARTIFACT_ROOT" | while IFS= read -r f; do
-    sed -i.bak "s|knr-registry|${WORKLOAD_REGISTRY_HOST}|g" "$f"
+  grep -rl "krops-registry" "$ARTIFACT_ROOT" | while IFS= read -r f; do
+    sed -i.bak "s|krops-registry|${WORKLOAD_REGISTRY_HOST}|g" "$f"
     rm -f "${f}.bak"
   done
 fi
@@ -334,7 +334,7 @@ fi
 flux push artifact "${PUSH_ARGS[@]}"
 
 # Keep a plain-directory copy of the tree in the bundle: the gap-side stage
-# script re-pushes it into knr-registry as knr-ops:latest for the workload
+# script re-pushes it into krops-registry as krops:latest for the workload
 # cluster's Flux (which does not talk to the Zarf registry).
 rm -rf "$REPO_ROOT/airgap/config-artifact"
 cp -R "$ARTIFACT_ROOT" "$REPO_ROOT/airgap/config-artifact"

--- a/airgap/scripts/build-package.sh
+++ b/airgap/scripts/build-package.sh
@@ -68,29 +68,29 @@ mise x -- zarf tools download-init \
   --output-directory airgap/archives
 
 HOST_IMAGES=(
-  kindest/node:v1.37.0
-  kindest/node:v1.37.0
-  kindest/haproxy:v20230606-42a2262b
-  docker.io/library/registry:2
+  kindest/node:v1.37.0@sha256:a1ed56cfb0e7b93589bdf97c8cd566405a265939e3620fc4f5de89adff580ae5
+  kindest/node:v1.37.0@sha256:a1ed56cfb0e7b93589bdf97c8cd566405a265939e3620fc4f5de89adff580ae5
+  kindest/haproxy:v20230606-42a2262b@sha256:001a06433666046dea44567c7d7c6adfc2ac0edb556576f6da507ff0b0f063d3
+  docker.io/library/registry:2@sha256:a3d8aaa63ed8681a604f1dea0aa03f100d5895b6a58ace528858a7b332415373
 )
 for img in "${HOST_IMAGES[@]}"; do
   docker pull --platform linux/arm64 "$img" >/dev/null
 done
-docker save -o airgap/archives/kindest_node_v1.37.0_mgmt.tar kindest/node:v1.37.0
-docker save -o airgap/archives/kindest_node_v1.37.0.tar kindest/node:v1.37.0
-docker save -o airgap/archives/kindest_haproxy_v20230606-42a2262b.tar kindest/haproxy:v20230606-42a2262b
-docker save -o airgap/archives/docker.io_library_registry_2.tar docker.io/library/registry:2
+docker save -o airgap/archives/kindest_node_v1.37.0_mgmt.tar kindest/node:v1.37.0@sha256:a1ed56cfb0e7b93589bdf97c8cd566405a265939e3620fc4f5de89adff580ae5
+docker save -o airgap/archives/kindest_node_v1.37.0.tar kindest/node:v1.37.0@sha256:a1ed56cfb0e7b93589bdf97c8cd566405a265939e3620fc4f5de89adff580ae5
+docker save -o airgap/archives/kindest_haproxy_v20230606-42a2262b.tar kindest/haproxy:v20230606-42a2262b@sha256:001a06433666046dea44567c7d7c6adfc2ac0edb556576f6da507ff0b0f063d3
+docker save -o airgap/archives/docker.io_library_registry_2.tar docker.io/library/registry:2@sha256:a3d8aaa63ed8681a604f1dea0aa03f100d5895b6a58ace528858a7b332415373
 echo "    saved Zarf init package and host-daemon image archives"
 
 WORKLOAD_IMAGES=(
-  registry.k8s.io/pause:3.10.1
-  docker.io/kindest/kindnetd:v20260528-9350166c
-  ghcr.io/controlplaneio-fluxcd/flux-operator:v0.58.0
-  ghcr.io/fluxcd/source-controller:v1.9.4
-  ghcr.io/fluxcd/kustomize-controller:v1.9.4
-  ghcr.io/fluxcd/helm-controller:v1.6.3
-  ghcr.io/fluxcd/notification-controller:v1.9.3
-  ghcr.io/stefanprodan/podinfo:6.14.0
+  registry.k8s.io/pause:3.10.1@sha256:278fb9dbcca9518083ad1e11276933a2e96f23de604a3a08cc3c80002767d24c
+  docker.io/kindest/kindnetd:v20260528-9350166c@sha256:92f49a1b2c9242058481fc3e13412c19a62cfeb090717dad4598719d32351f1f
+  ghcr.io/controlplaneio-fluxcd/flux-operator:v0.58.0@sha256:1c919ce1e28716f817ded65c06df0b7a8269542387d5a2ce50212450473c6209
+  ghcr.io/fluxcd/source-controller:v1.9.4@sha256:8a8ed0a57b8b86f561d5a4309a69f65e62f0cebe4de8801593c5ff35a3bc3c23
+  ghcr.io/fluxcd/kustomize-controller:v1.9.4@sha256:2b8bec54ffb6caf421bd2a6c005d27f567d5dd4db7feb55794fb51fcabd69b8f
+  ghcr.io/fluxcd/helm-controller:v1.6.3@sha256:16ada99456385100698a5d7adf90aba8a2089d987ab541c9566b6d7b0e897038
+  ghcr.io/fluxcd/notification-controller:v1.9.3@sha256:071c351a0fb163eeb6a2bb82f1e894f51b6b0734216d2e97d3d99c9ab9d710b9
+  ghcr.io/stefanprodan/podinfo:6.14.0@sha256:0a8aa037137c010a75aed8d3fe56931d0edd3bcd0e55acfb96db11e1e96397b1
 )
 for img in "${WORKLOAD_IMAGES[@]}"; do
   docker pull --platform linux/arm64 "$img" >/dev/null

--- a/airgap/scripts/build-package.sh
+++ b/airgap/scripts/build-package.sh
@@ -9,7 +9,7 @@
 #   4. zarf package create (including per-component Syft SBOMs)
 #   5. sign the completed package
 #
-# Output: zarf-package-knr-ops-airgap-arm64-0.1.0.tar.zst next to airgap/.
+# Output: zarf-package-krops-airgap-arm64-0.1.0.tar.zst next to airgap/.
 set -euo pipefail
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
@@ -35,10 +35,10 @@ echo "==> 2/5 config artifact"
 # published. Keep zarf.yaml's local-registry default for ordinary builds, but
 # temporarily rewrite its image reference when OCI_REGISTRY is overridden.
 if [ -n "${OCI_REGISTRY:-}" ]; then
-  OCI_REPOSITORY="${OCI_REPOSITORY:-knr-ops-airgap}"
+  OCI_REPOSITORY="${OCI_REPOSITORY:-krops-airgap}"
   OCI_TAG="${OCI_TAG:-latest}"
   ZARF_CONFIG="$REPO_ROOT/airgap/zarf.yaml"
-  ZARF_CONFIG_BACKUP=$(mktemp "${TMPDIR:-/tmp}/knr-ops-zarf.XXXXXX")
+  ZARF_CONFIG_BACKUP=$(mktemp "${TMPDIR:-/tmp}/krops-zarf.XXXXXX")
   cp "$ZARF_CONFIG" "$ZARF_CONFIG_BACKUP"
   restore_zarf_config() {
     cp "$ZARF_CONFIG_BACKUP" "$ZARF_CONFIG"
@@ -48,7 +48,7 @@ if [ -n "${OCI_REGISTRY:-}" ]; then
   trap 'exit 130' INT
   trap 'exit 143' TERM
 
-  EXPECTED_ARTIFACT="localhost:5001/knr-ops-airgap:latest"
+  EXPECTED_ARTIFACT="localhost:5001/krops-airgap:latest"
   CONFIG_ARTIFACT="${OCI_REGISTRY}/${OCI_REPOSITORY}:${OCI_TAG}"
   MATCH_COUNT=$(grep -Fc "$EXPECTED_ARTIFACT" "$ZARF_CONFIG" || true)
   if [ "$MATCH_COUNT" -ne 1 ]; then
@@ -98,7 +98,7 @@ done
 docker save -o airgap/archives/workload-pod-images.tar "${WORKLOAD_IMAGES[@]}"
 echo "    saved airgap/archives/workload-pod-images.tar"
 
-# OCI charts the workload cluster needs in the gap (seeded into knr-registry
+# OCI charts the workload cluster needs in the gap (seeded into krops-registry
 # by the stage script): the per-cluster flux-operator chart (HelmChartProxy)
 # and the podinfo chart (workload HelmRelease).
 mkdir -p airgap/archives/charts
@@ -110,7 +110,7 @@ echo "==> 4/5 zarf package create (SBOM generation enabled)"
 cd airgap
 mise x -- zarf package create . --confirm
 
-PACKAGE="$PWD/zarf-package-knr-ops-airgap-arm64-0.1.0.tar.zst"
+PACKAGE="$PWD/zarf-package-krops-airgap-arm64-0.1.0.tar.zst"
 if [ ! -f "$PACKAGE" ]; then
   echo "ERROR: expected Zarf package was not created: $PACKAGE" >&2
   exit 1

--- a/airgap/scripts/offline-run.sh
+++ b/airgap/scripts/offline-run.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# offline-run.sh — autonomous Wi-Fi-off validation of the knr-ops airgap bundle.
+# offline-run.sh — autonomous Wi-Fi-off validation of the krops airgap bundle.
 #
 # This script is designed to run with NO operator and NO LLM/agent attached:
 # it waits until the internet is unreachable, runs the full deploy, verifies,
@@ -21,7 +21,7 @@ LOG=/tmp/airgap-offline-run.log
 SUMMARY=/tmp/airgap-offline-summary.txt
 AIRGAP_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 ARCHIVES="$AIRGAP_DIR/archives"
-PACKAGE_INPUT="${1:-$ARCHIVES/zarf-package-knr-ops-airgap-arm64-0.1.0.tar.zst}"
+PACKAGE_INPUT="${1:-$ARCHIVES/zarf-package-krops-airgap-arm64-0.1.0.tar.zst}"
 PACKAGE_DIR=$(cd "$(dirname "$PACKAGE_INPUT")" && pwd)
 PACKAGE="$PACKAGE_DIR/$(basename "$PACKAGE_INPUT")"
 if [ ! -f "$PACKAGE" ]; then
@@ -45,14 +45,14 @@ if [ -n "${ZARF_VERIFY_KEY:-}" ]; then
 else
   VERIFY_ARGS+=(
     --certificate-identity
-    'https://github.com/polarsquad/knr-ops/.github/workflows/air-gapped.yml@refs/heads/main'
+    'https://github.com/polarsquad/krops/.github/workflows/air-gapped.yml@refs/heads/main'
     --certificate-oidc-issuer
     'https://token.actions.githubusercontent.com'
   )
 fi
 
 export CLUSTER_NAME=airgap-mgmt
-export REGISTRY_NAME=knr-registry-airgap
+export REGISTRY_NAME=krops-registry-airgap
 export REGISTRY_PORT=5002
 MGMT_CTX="kind-airgap-mgmt"
 WL_KCFG=/tmp/airgap-wl.kubeconfig
@@ -200,7 +200,7 @@ if [ -n "$port" ]; then
     wlf=$("$KUBECTL" --kubeconfig="$WL_KCFG" -n flux-system get ocirepository flux-system \
       -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null)
   done
-  [ "$wlf" = "True" ] && pass "workload Flux sync Ready from knr-registry" || fail "workload Flux sync ready=$wlf"
+  [ "$wlf" = "True" ] && pass "workload Flux sync Ready from krops-registry" || fail "workload Flux sync ready=$wlf"
 
   podinfo=$("$KUBECTL" --kubeconfig="$WL_KCFG" -n podinfo get pods --no-headers 2>/dev/null | grep -c " Running ")
   for i in $(seq 1 20); do

--- a/airgap/scripts/stage-and-create-cluster.sh
+++ b/airgap/scripts/stage-and-create-cluster.sh
@@ -6,7 +6,7 @@
 #      - kindest/node v1.37.0 (mgmt kind node and CAPD workload/management
 #        nodes) — kind and CAPD `docker run` these directly from the host
 #        daemon, outside kubelet, so the Zarf agent cannot rewrite them.
-#      - kindest/haproxy (CAPD load balancer) and registry:2@sha256:a3d8aaa63ed8681a604f1dea0aa03f100d5895b6a58ace528858a7b332415373 (krops-registry,
+#      - kindest/haproxy (CAPD load balancer) and registry:2 (krops-registry,
 #        recreated in Phase 5 for the workload cluster's Flux).
 #      - workload-pod-images.tar: flux-operator, flux controllers, podinfo —
 #        consumed via preLoadImages by CAPD DevMachineTemplates (Phase 5).

--- a/airgap/scripts/stage-and-create-cluster.sh
+++ b/airgap/scripts/stage-and-create-cluster.sh
@@ -6,7 +6,7 @@
 #      - kindest/node v1.37.0 (mgmt kind node and CAPD workload/management
 #        nodes) — kind and CAPD `docker run` these directly from the host
 #        daemon, outside kubelet, so the Zarf agent cannot rewrite them.
-#      - kindest/haproxy (CAPD load balancer) and registry:2 (krops-registry,
+#      - kindest/haproxy (CAPD load balancer) and registry:2@sha256:a3d8aaa63ed8681a604f1dea0aa03f100d5895b6a58ace528858a7b332415373 (krops-registry,
 #        recreated in Phase 5 for the workload cluster's Flux).
 #      - workload-pod-images.tar: flux-operator, flux controllers, podinfo —
 #        consumed via preLoadImages by CAPD DevMachineTemplates (Phase 5).
@@ -23,7 +23,7 @@ AIRGAP_DIR=$(cd "$SCRIPT_DIR/.." && pwd)
 ARCHIVES="$AIRGAP_DIR/archives"
 
 CLUSTER_NAME="${CLUSTER_NAME:-mgmt}"
-KIND_NODE_IMAGE="${KIND_NODE_IMAGE:-kindest/node:v1.37.0}"
+KIND_NODE_IMAGE="${KIND_NODE_IMAGE:-kindest/node:v1.37.0@sha256:a1ed56cfb0e7b93589bdf97c8cd566405a265939e3620fc4f5de89adff580ae5}"
 DOCKER_SOCKET_PATH="${DOCKER_SOCKET_PATH:-/var/run/docker.sock}"
 
 if [ ! -S "$DOCKER_SOCKET_PATH" ]; then
@@ -75,7 +75,7 @@ if ! docker ps --filter "name=^${REGISTRY_NAME}$" --format '{{.Names}}' | grep -
     --health-interval=1s \
     --health-timeout=2s \
     --health-retries=15 \
-    registry:2 >/dev/null
+    registry:2@sha256:a3d8aaa63ed8681a604f1dea0aa03f100d5895b6a58ace528858a7b332415373 >/dev/null
 fi
 
 registry_health=$(docker inspect --format \

--- a/airgap/scripts/stage-and-create-cluster.sh
+++ b/airgap/scripts/stage-and-create-cluster.sh
@@ -6,7 +6,7 @@
 #      - kindest/node v1.37.0 (mgmt kind node and CAPD workload/management
 #        nodes) — kind and CAPD `docker run` these directly from the host
 #        daemon, outside kubelet, so the Zarf agent cannot rewrite them.
-#      - kindest/haproxy (CAPD load balancer) and registry:2 (knr-registry,
+#      - kindest/haproxy (CAPD load balancer) and registry:2 (krops-registry,
 #        recreated in Phase 5 for the workload cluster's Flux).
 #      - workload-pod-images.tar: flux-operator, flux controllers, podinfo —
 #        consumed via preLoadImages by CAPD DevMachineTemplates (Phase 5).
@@ -55,9 +55,9 @@ fi
 kubectl config use-context "kind-${CLUSTER_NAME}" >/dev/null
 kubectl wait --for=condition=Ready node --all --timeout=180s
 
-# Recreate knr-registry (the workload cluster's Flux and CAAPH fetch from it;
+# Recreate krops-registry (the workload cluster's Flux and CAAPH fetch from it;
 # the Zarf internal registry is only reachable inside the mgmt cluster).
-REGISTRY_NAME="${REGISTRY_NAME:-knr-registry}"
+REGISTRY_NAME="${REGISTRY_NAME:-krops-registry}"
 REGISTRY_PORT="${REGISTRY_PORT:-5001}"
 registry_failure() {
   echo "ERROR: registry '${REGISTRY_NAME}' $*" >&2
@@ -100,11 +100,11 @@ if ! curl --fail --show-error --silent --connect-timeout 1 --max-time 2 \
   registry_failure "is not reachable through localhost:${REGISTRY_PORT}"
 fi
 
-# Seed knr-registry: the knr-ops config artifact (workload/local-host syncs
+# Seed krops-registry: the krops config artifact (workload/local-host syncs
 # from it) and the two OCI charts (flux-operator for the HelmChartProxy,
 # podinfo for the workload HelmRelease).
 echo ">>> Seeding ${REGISTRY_NAME} with the config artifact + charts..."
-flux push artifact "oci://localhost:${REGISTRY_PORT}/knr-ops:latest" \
+flux push artifact "oci://localhost:${REGISTRY_PORT}/krops:latest" \
   --path="$AIRGAP_DIR/config-artifact" \
   --source="airgap-bundle" \
   --revision="airgap@sha1:$(git -C "$AIRGAP_DIR" rev-parse HEAD 2>/dev/null || echo unknown)" \
@@ -115,4 +115,4 @@ helm push "$ARCHIVES/charts/podinfo-6.14.0.tgz" "oci://localhost:${REGISTRY_PORT
 
 echo ">>> Staged. Next:"
 echo "      zarf init archives/zarf-init-arm64-v0.83.0.tar.zst --registry-mode=nodeport --components=\"\" --confirm"
-echo "      zarf package deploy zarf-package-knr-ops-airgap-arm64-0.1.0.tar.zst --confirm"
+echo "      zarf package deploy zarf-package-krops-airgap-arm64-0.1.0.tar.zst --confirm"

--- a/airgap/tests/test-airgap-image-digests.py
+++ b/airgap/tests/test-airgap-image-digests.py
@@ -14,7 +14,7 @@ INVENTORY_FILES = {
     "airgap/zarf.yaml",
 }
 LOCAL_EXCEPTIONS = {
-    "localhost:5001/knr-ops-airgap:latest": (
+    "localhost:5001/krops-airgap:latest": (
         "built immediately before packaging; the build script substitutes the "
         "selected OCI registry and tag"
     ),

--- a/airgap/tests/test-renovate-digest-pinning.py
+++ b/airgap/tests/test-renovate-digest-pinning.py
@@ -16,7 +16,7 @@ EXPECTED_FILES = [
     "airgap/zarf.yaml",
 ]
 DIGEST = re.compile(r"@sha256:[a-f0-9]{64}")
-EXCLUDED_DEP_NAMES = {"localhost:5001/knr-ops-airgap"}
+EXCLUDED_DEP_NAMES = {"localhost:5001/krops-airgap"}
 REQUIRED_DEP_NAMES = {
     "airgap/images.txt": {"ghcr.io/fluxcd/source-controller"},
     "airgap/scripts/build-config-artifact.sh": {"registry.k8s.io/pause"},

--- a/airgap/zarf.yaml
+++ b/airgap/zarf.yaml
@@ -1,11 +1,11 @@
-# Zarf package: air-gapped knr-ops prototype (local-host / CAPD profile).
+# Zarf package: air-gapped krops prototype (local-host / CAPD profile).
 #
 # Ownership split:
 #   Zarf deploys the substrate  : cert-manager, flux-operator, FluxInstance,
 #                                 CAPI core, kubeadm bootstrap/control-plane,
-#                                 CAPD, CAAPH, and the knr-ops config artifact.
+#                                 CAPD, CAAPH, and the krops config artifact.
 #   Flux reconciles the workload: the trimmed mgmt/local-host tree carried as
-#                                 the knr-ops-airgap OCI artifact (clusters/,
+#                                 the krops-airgap OCI artifact (clusters/,
 #                                 addons/cni/, addons/flux-apps/).
 #
 # The kind node images and the workload-node pod images are NOT in this
@@ -14,9 +14,9 @@
 # before any cluster exists.
 kind: ZarfPackageConfig
 metadata:
-  name: knr-ops-airgap
+  name: krops-airgap
   version: 0.1.0
-  description: Air-gapped knr-ops prototype (local-host CAPD profile)
+  description: Air-gapped krops prototype (local-host CAPD profile)
   architecture: arm64
 constants:
   # In-cluster DNS name of the Zarf internal registry. In-cluster fetchers
@@ -73,15 +73,15 @@ components:
         name: flux-operator
         namespace: flux-system
 
-  # knr-ops GitOps config artifact. Built connected-side by
+  # krops GitOps config artifact. Built connected-side by
   # scripts/build-config-artifact.sh (trimmed airgap tree, pushed to the local
   # registry), then carried across the gap inside this package and pushed into
   # the Zarf internal registry at deploy time by Zarf's image pipeline.
-  - name: knr-ops-config
+  - name: krops-config
     required: true
-    description: knr-ops mgmt/local-host (airgap-trimmed) as an OCI artifact
+    description: krops mgmt/local-host (airgap-trimmed) as an OCI artifact
     images:
-      - localhost:5001/knr-ops-airgap:latest
+      - localhost:5001/krops-airgap:latest
 
   # FluxInstance: points the management Flux at the config artifact in the
   # Zarf internal registry. distribution.artifact is omitted so the operator
@@ -97,12 +97,12 @@ components:
     required: true
     files:
       - source: manifests/flux-instance.yaml
-        target: /tmp/knr-ops-airgap/flux-instance.yaml
+        target: /tmp/krops-airgap/flux-instance.yaml
     actions:
       onDeploy:
         after:
           - description: Apply the FluxInstance (kubectl, ambient context)
-            cmd: kubectl apply -f /tmp/knr-ops-airgap/flux-instance.yaml
+            cmd: kubectl apply -f /tmp/krops-airgap/flux-instance.yaml
             maxTotalSeconds: 120
           - description: Wait for Flux to be Ready (controllers + sync)
             cmd: kubectl -n flux-system wait --for=condition=Ready fluxinstance/flux --timeout=10m

--- a/airgap/zarf.yaml
+++ b/airgap/zarf.yaml
@@ -39,10 +39,10 @@ components:
         valuesFiles:
           - values/cert-manager.yaml
     images:
-      - quay.io/jetstack/cert-manager-controller:v1.21.1
-      - quay.io/jetstack/cert-manager-cainjector:v1.21.1
-      - quay.io/jetstack/cert-manager-webhook:v1.21.1
-      - quay.io/jetstack/cert-manager-startupapicheck:v1.21.1
+      - quay.io/jetstack/cert-manager-controller:v1.21.1@sha256:416a2d76870d996460e62bd7f521bf14fa017be9e3e904aab92163a331fcb61a
+      - quay.io/jetstack/cert-manager-cainjector:v1.21.1@sha256:ccf6b919ec0500745a47a910118f834f9636d0aac1ff221245cd2557ed8c7c98
+      - quay.io/jetstack/cert-manager-webhook:v1.21.1@sha256:d8b3961b51c8c7320633f8208dc46bf88aa13804d0f7cbe48a096b2c523cee42
+      - quay.io/jetstack/cert-manager-startupapicheck:v1.21.1@sha256:d8ab6416e6e7303a86fa0a8daa82c94a8001f21c9d78eb2e7db20534e5d07ae8
     healthChecks:
       - apiVersion: apps/v1
         kind: Deployment
@@ -66,7 +66,7 @@ components:
         url: oci://ghcr.io/controlplaneio-fluxcd/charts/flux-operator
         version: 0.58.0
     images:
-      - ghcr.io/controlplaneio-fluxcd/flux-operator:v0.58.0
+      - ghcr.io/controlplaneio-fluxcd/flux-operator:v0.58.0@sha256:1c919ce1e28716f817ded65c06df0b7a8269542387d5a2ce50212450473c6209
     healthChecks:
       - apiVersion: apps/v1
         kind: Deployment
@@ -108,10 +108,10 @@ components:
             cmd: kubectl -n flux-system wait --for=condition=Ready fluxinstance/flux --timeout=10m
             maxTotalSeconds: 640
     images:
-      - ghcr.io/fluxcd/source-controller:v1.9.4
-      - ghcr.io/fluxcd/kustomize-controller:v1.9.4
-      - ghcr.io/fluxcd/helm-controller:v1.6.3
-      - ghcr.io/fluxcd/notification-controller:v1.9.3
+      - ghcr.io/fluxcd/source-controller:v1.9.4@sha256:8a8ed0a57b8b86f561d5a4309a69f65e62f0cebe4de8801593c5ff35a3bc3c23
+      - ghcr.io/fluxcd/kustomize-controller:v1.9.4@sha256:2b8bec54ffb6caf421bd2a6c005d27f567d5dd4db7feb55794fb51fcabd69b8f
+      - ghcr.io/fluxcd/helm-controller:v1.6.3@sha256:16ada99456385100698a5d7adf90aba8a2089d987ab541c9566b6d7b0e897038
+      - ghcr.io/fluxcd/notification-controller:v1.9.3@sha256:071c351a0fb163eeb6a2bb82f1e894f51b6b0734216d2e97d3d99c9ab9d710b9
 
   # CAPI core: 13 CRDs (Cluster, Machine, MachineDeployment, ClusterClass,
   # ClusterResourceSet, ...) + the capi-controller-manager. Captured from the
@@ -124,7 +124,7 @@ components:
         files:
           - manifests/core-cluster-api.components.yaml
     images:
-      - registry.k8s.io/cluster-api/cluster-api-controller:v1.14.0
+      - registry.k8s.io/cluster-api/cluster-api-controller:v1.14.0@sha256:4f57cf35b7de52e568eb85295f2a505268f29f1c7b76e7b12ce7cf6d2034f8f4
     healthChecks:
       - apiVersion: apps/v1
         kind: Deployment
@@ -146,9 +146,9 @@ components:
         files:
           - manifests/infrastructure-docker.components.yaml
     images:
-      - registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.14.0
-      - registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.14.0
-      - gcr.io/k8s-staging-cluster-api/capd-manager:v1.14.0
+      - registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.14.0@sha256:3209310007d8f015545f5cd621b110cc1af2bcf2538d91bbac81aaf989451102
+      - registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.14.0@sha256:bab6f68839cef892102427f03599dd4d7b433bcae0e4794724ba80253fb8aa98
+      - gcr.io/k8s-staging-cluster-api/capd-manager:v1.14.0@sha256:9b68fc45b6d564804d7a32c1d800751daa5d556e40c4c303d1ec4b8d610afa5a
     healthChecks:
       - apiVersion: apps/v1
         kind: Deployment
@@ -172,7 +172,7 @@ components:
         files:
           - manifests/addon-helm.components.yaml
     images:
-      - registry.k8s.io/cluster-api-helm/cluster-api-helm-controller:v0.6.4
+      - registry.k8s.io/cluster-api-helm/cluster-api-helm-controller:v0.6.4@sha256:97d2a86f8e35d23bb4656b26f4564b35f109e47a0dc4860b71089e52eb6e6a24
     healthChecks:
       - apiVersion: apps/v1
         kind: Deployment

--- a/bootstrap-common.sh
+++ b/bootstrap-common.sh
@@ -154,7 +154,7 @@ seed_helm() {
 seed_flux() {
   SEED_KUBECONFIG="${1:-}"
 
-  local registry_name="${REGISTRY_NAME:-knr-registry}"
+  local registry_name="${REGISTRY_NAME:-krops-registry}"
   local registry_port="${REGISTRY_PORT:-5001}"
   local anon_registry_config
   anon_registry_config="$(mktemp)"
@@ -218,7 +218,7 @@ seed_flux() {
   else
     FLUX_INSTANCE_ARGS+=(
       --set instance.sync.kind=OCIRepository
-      --set instance.sync.url="oci://${registry_name}:5000/${OCI_REPOSITORY:-knr-ops}"
+      --set instance.sync.url="oci://${registry_name}:5000/${OCI_REPOSITORY:-krops}"
       --set instance.sync.ref="${OCI_TAG:-latest}"
       --set instance.sync.path=mgmt/local-host
       --set-json 'instance.kustomize.patches=[{"patch":"- op: add\n  path: /spec/insecure\n  value: true","target":{"kind":"OCIRepository"}}]'

--- a/bootstrap-rs/Cargo.lock
+++ b/bootstrap-rs/Cargo.lock
@@ -540,7 +540,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "knr-bootstrap"
+name = "krops-bootstrap"
 version = "0.2.0"
 dependencies = [
  "anyhow",

--- a/bootstrap-rs/Cargo.toml
+++ b/bootstrap-rs/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
-name = "knr-bootstrap"
+name = "krops-bootstrap"
 version = "0.2.0"
 edition = "2021"
 rust-version = "1.96"
-description = "One-time imperative bootstrap for the knr-ops management cluster (Rust port of bootstrap.sh)"
+description = "One-time imperative bootstrap for the krops management cluster (Rust port of bootstrap.sh)"
 license = "Apache-2.0"
 
 [dependencies]

--- a/bootstrap-rs/Dockerfile
+++ b/bootstrap-rs/Dockerfile
@@ -1,19 +1,19 @@
-# knr-ops toolbox image (issue #104).
+# krops toolbox image (issue #104).
 #
-# Ships knr-bootstrap plus the full pinned tool layer so a host needs only
+# Ships krops-bootstrap plus the full pinned tool layer so a host needs only
 # a container engine to run the whole bootstrap lifecycle. Tool versions
 # are single-sourced from the committed mise configs (Renovate-managed
 # there, never duplicated into this file); the CLI is compiled with the
 # toolchain pinned in bootstrap-rs/rust-toolchain.toml.
 #
 # Build (from the repository root; the context is the repo root):
-#   docker build -f bootstrap-rs/Dockerfile -t knr-ops-toolbox:dev .
+#   docker build -f bootstrap-rs/Dockerfile -t krops-toolbox:dev .
 #
 # Base image digests and the mise CLI pin are Renovate-managed
 # (dockerfile manager with pinDigests, and the jdx/mise custom manager
 # extended to this file's ARG MISE_VERSION line).
 
-# ── Stage 1: compile knr-bootstrap with the pinned toolchain ──────────────
+# ── Stage 1: compile krops-bootstrap with the pinned toolchain ──────────────
 # slim-bookworm matches the runtime stage's glibc (bookworm, 2.36): a
 # binary built on the default rust image (trixie, glibc 2.39) fails on
 # bookworm with "GLIBC_2.39 not found".
@@ -22,7 +22,7 @@ FROM rust:1.98.0-slim-bookworm@sha256:1469a27c125cb5a3aebfa4f4e4665d935b02fb72cc
 WORKDIR /build
 COPY bootstrap-rs/ ./bootstrap-rs/
 RUN cd bootstrap-rs && cargo build --locked --release \
-    && cp target/release/knr-bootstrap /usr/local/bin/knr-bootstrap
+    && cp target/release/krops-bootstrap /usr/local/bin/krops-bootstrap
 
 # ── Stage 2: runtime with the pinned tool layer ───────────────────────────
 FROM debian:bookworm-slim@sha256:88200866dfff7ea7f5cbcb6ec7c8a701889efe6fe859fe64d6990e4b07ea4171
@@ -36,7 +36,7 @@ ARG TARGETARCH
 # standalone docker-cli package, and docker.io would drag in the whole
 # engine. The client floats with the repo (client/server API is backward
 # compatible; the daemon always runs on the host). The podman remote client
-# (static build) provides the podman provider path kind and knr-bootstrap
+# (static build) provides the podman provider path kind and krops-bootstrap
 # exec (CONTAINER_ENGINE=podman); it talks to the host socket the run
 # invocation mounts.
 # renovate: datasource=github-releases depName=containers/podman extractVersion=^v(?<version>.+) versioning=semver
@@ -73,9 +73,9 @@ ENV MISE_DATA_DIR=/usr/local/share/mise \
     MISE_YES=1 \
     PATH=/usr/local/share/mise/shims:/usr/local/bin:/usr/bin:/sbin:/bin
 
-COPY --from=build /usr/local/bin/knr-bootstrap /usr/local/bin/knr-bootstrap
+COPY --from=build /usr/local/bin/krops-bootstrap /usr/local/bin/krops-bootstrap
 COPY bootstrap-rs/toolbox-entrypoint.sh /usr/local/bin/toolbox-entrypoint.sh
-COPY mise.toml mise.aws.toml /opt/knr-ops/
+COPY mise.toml mise.aws.toml /opt/krops/
 
 RUN chmod +x /usr/local/bin/toolbox-entrypoint.sh
 
@@ -83,7 +83,7 @@ RUN chmod +x /usr/local/bin/toolbox-entrypoint.sh
 # lifecycle never invokes (go, python, zarf: airgap builds run on the
 # host, not inside the toolbox). The aws layer (aws-cli, clusterawsadm)
 # installs too; credentials arrive at runtime.
-RUN cd /opt/knr-ops \
+RUN cd /opt/krops \
     && mise install -y kind helm kubectl clusterctl flux2 sops age \
     && mise -E aws install -y aws-cli clusterawsadm \
     && mise reshim

--- a/bootstrap-rs/src/config.rs
+++ b/bootstrap-rs/src/config.rs
@@ -1,6 +1,6 @@
 //! Repository-owned bootstrap configuration (`bootstrap.toml`, issue #98).
 //!
-//! Everything knr-ops-specific the binary needs is declared in this file;
+//! Everything krops-specific the binary needs is declared in this file;
 //! the binary itself is a generic bootstrap engine. The environment knobs
 //! (`Config::from_env`, see main.rs) keep their precedence over these
 //! values at runtime. The file is located via `BOOTSTRAP_CONFIG` or
@@ -20,7 +20,7 @@ pub struct BootstrapConfig {
     pub charts: IndexMap<String, String>,
     /// Teardown constants (issue #100): AWS orphan-sweep names and the
     /// post-pivot controller-host removal rules. Optional so minimal test
-    /// fixtures and non-knr-ops consumers keep parsing.
+    /// fixtures and non-krops consumers keep parsing.
     #[serde(default)]
     pub teardown: TeardownSection,
     /// Environments keyed by section name, in file order (error messages
@@ -120,7 +120,7 @@ pub struct AwsWorkload {
     /// EKS cluster name: CAPA creates it with dashes converted to
     /// underscores (e.g. `default_eu-north-1-workload-control-plane`).
     pub eks_cluster_name: String,
-    /// RDS instance identifier (e.g. `knr-ops-eu-north-1-workload-db`).
+    /// RDS instance identifier (e.g. `krops-eu-north-1-workload-db`).
     pub rds_instance: String,
 }
 
@@ -204,7 +204,7 @@ impl BootstrapConfig {
         Ok(())
     }
 
-    /// Resolve an environment by name (KNR_OPS_PROFILE value or positional
+    /// Resolve an environment by name (KROPS_PROFILE value or positional
     /// argument); the error lists the valid names in file order.
     pub fn environment(&self, name: &str) -> Result<&Environment> {
         self.environments
@@ -233,12 +233,12 @@ default-environment = "aws"
 git-branch = "main"
 kind-cluster = "mgmt"
 kind-context = "kind-mgmt"
-registry-name = "knr-registry"
+registry-name = "krops-registry"
 flux-namespace = "flux-system"
 github-pat-secret = "flux-github-pat"
 sops-age-secret = "sops-age"
 mgmt-namespace = "default"
-mgmt-context = "knr-ops-mgmt"
+mgmt-context = "krops-mgmt"
 
 [charts]
 flux-operator = "0.58.0"

--- a/bootstrap-rs/src/main.rs
+++ b/bootstrap-rs/src/main.rs
@@ -1,4 +1,4 @@
-//! knr-bootstrap – One-time imperative bootstrap for the management cluster.
+//! krops-bootstrap – One-time imperative bootstrap for the management cluster.
 //! Everything after this program runs is driven by GitOps (Flux).
 //!
 //! Rust port of `bootstrap.sh` including its default exit: unless
@@ -15,7 +15,7 @@
 //!
 //! Everything repository-specific (names, paths, chart pins, environments)
 //! comes from `bootstrap.toml` (see `config.rs`, issue #98); the binary is
-//! a generic bootstrap engine and knr-ops is its first consumer.
+//! a generic bootstrap engine and krops is its first consumer.
 
 mod config;
 mod teardown;
@@ -44,21 +44,21 @@ const DEFAULT_REGISTRY_READY_RETRIES: u32 = 120;
 const DEFAULT_LOCAL_RECONCILE_TIMEOUT: &str = "15m";
 const DEFAULT_GITHUB_USER: &str = "git";
 const DEFAULT_AGE_KEY_FILE: &str = "age.agekey";
-const DEFAULT_OCI_REPOSITORY: &str = "knr-ops";
+const DEFAULT_OCI_REPOSITORY: &str = "krops";
 const DEFAULT_OCI_TAG: &str = "latest";
 const NODE_READY_TIMEOUT: &str = "120s";
 
 // Pivot defaults mirroring pivot.sh's `${VAR:-default}` values. The
 // repository-specific defaults (mgmt cluster names, ready timeouts, kind
 // names, contexts, namespaces) come from bootstrap.toml instead.
-const DEFAULT_MGMT_KUBECONFIG_RELATIVE: &str = ".kube/knr-ops-mgmt.yaml";
+const DEFAULT_MGMT_KUBECONFIG_RELATIVE: &str = ".kube/krops-mgmt.yaml";
 const DEFAULT_MGMT_POLL_INTERVAL: u64 = 10;
 
 // ── CLI ───────────────────────────────────────────────────────────────────────
 
 /// Resolve the active environment name the way bootstrap.sh does
-/// (`PROFILE="${KNR_OPS_PROFILE:-${1:-aws}}"`): a non-empty
-/// KNR_OPS_PROFILE wins over the positional argument, then the config's
+/// (`PROFILE="${KROPS_PROFILE:-${1:-aws}}"`): a non-empty
+/// KROPS_PROFILE wins over the positional argument, then the config's
 /// bootstrap.default-environment. clap resolves positional-over-env (the
 /// opposite), so the env var is read manually instead of #[arg(env)].
 /// The name must be an [environments.*] section of bootstrap.toml; the
@@ -76,7 +76,7 @@ fn resolve_environment(
     config.environment(name).map(|_| name.to_string())
 }
 
-/// One-time imperative bootstrap for the knr-ops management cluster.
+/// One-time imperative bootstrap for the krops management cluster.
 ///
 /// Behavioral port of bootstrap.sh: the CLI surface is the script's
 /// surface — a positional profile, `--recreate`, and the environment.
@@ -84,9 +84,9 @@ fn resolve_environment(
 /// (see `Config`); the expanded flag interface is deferred for separate
 /// review in a follow-up.
 #[derive(Parser, Debug)]
-#[command(name = "knr-bootstrap", version, about)]
+#[command(name = "krops-bootstrap", version, about)]
 struct Cli {
-    /// Deployment profile (a non-empty KNR_OPS_PROFILE takes precedence
+    /// Deployment profile (a non-empty KROPS_PROFILE takes precedence
     /// over this argument, matching bootstrap.sh; default: the config's
     /// bootstrap.default-environment). Valid names are the
     /// [environments.*] sections of bootstrap.toml.
@@ -110,7 +110,7 @@ struct Cli {
 enum SubCommand {
     /// Destroy all infrastructure the bootstrap created, in reverse order.
     Teardown {
-        /// Deployment profile (KNR_OPS_PROFILE takes precedence, as
+        /// Deployment profile (KROPS_PROFILE takes precedence, as
         /// everywhere else; default: bootstrap.default-environment).
         profile: Option<String>,
     },
@@ -191,7 +191,7 @@ impl Config {
         let with_default =
             |name: &str, default: &str| value(name).unwrap_or_else(|| default.to_string());
         let profile = resolve_environment(
-            value("KNR_OPS_PROFILE").as_deref(),
+            value("KROPS_PROFILE").as_deref(),
             cli.profile.as_deref(),
             &repo,
         )?;
@@ -235,7 +235,7 @@ impl Config {
             ),
             container_engine: value("CONTAINER_ENGINE"),
             engine_sock: value("ENGINE_SOCK"),
-            toolbox: with_default("KNR_TOOLBOX", "0") == "1",
+            toolbox: with_default("KROPS_TOOLBOX", "0") == "1",
             git_repo_url: value("GIT_REPO_URL"),
             github_token: value("GITHUB_TOKEN"),
             github_user: with_default("GITHUB_USER", DEFAULT_GITHUB_USER),
@@ -264,7 +264,7 @@ impl Config {
     }
 }
 
-/// Default management kubeconfig path: `$HOME/.kube/knr-ops-mgmt.yaml`
+/// Default management kubeconfig path: `$HOME/.kube/krops-mgmt.yaml`
 /// (pivot.sh `MGMT_KUBECONFIG` default).
 fn default_mgmt_kubeconfig() -> PathBuf {
     std::env::var_os("HOME")
@@ -327,10 +327,10 @@ fn toolbox_kubeconfig_path(toolbox: bool, kubeconfig: Option<&str>) -> Result<Op
     }
     let path = kubeconfig
         .filter(|value| !value.is_empty())
-        .context("KUBECONFIG must name one writable file when KNR_TOOLBOX=1")?;
+        .context("KUBECONFIG must name one writable file when KROPS_TOOLBOX=1")?;
     ensure!(
         !path.contains(':'),
-        "KUBECONFIG must name a single file when KNR_TOOLBOX=1"
+        "KUBECONFIG must name a single file when KROPS_TOOLBOX=1"
     );
     Ok(Some(PathBuf::from(path)))
 }
@@ -766,7 +766,7 @@ fn toolbox_container_id() -> Option<String> {
 }
 
 /// Attach the toolbox container to the kind network so kind-network
-/// endpoints (the internal API server, knr-registry:5000) resolve.
+/// endpoints (the internal API server, krops-registry:5000) resolve.
 /// Idempotent: docker exits 0 on re-attach, but podman errors with "is
 /// already connected", so failures are retried against a captured-error
 /// check instead of string-matching the (inherited) stderr.
@@ -775,7 +775,7 @@ pub(crate) async fn toolbox_join_kind_network(cfg: &Config, engine: &str) -> Res
         return Ok(());
     }
     let Some(id) = toolbox_container_id() else {
-        bail!("KNR_TOOLBOX=1 but /etc/hostname is unreadable; cannot join the kind network");
+        bail!("KROPS_TOOLBOX=1 but /etc/hostname is unreadable; cannot join the kind network");
     };
     let out = Command::new(engine)
         .args(["network", "connect", "kind", &id])
@@ -2281,7 +2281,7 @@ async fn main() -> Result<()> {
     // bootstrap Config resolution (which validates bootstrap/pivot knobs).
     if let Some(SubCommand::Teardown { profile }) = &cli.command {
         let name = resolve_environment(
-            std::env::var("KNR_OPS_PROFILE")
+            std::env::var("KROPS_PROFILE")
                 .ok()
                 .filter(|v| !v.is_empty())
                 .as_deref(),
@@ -2304,7 +2304,7 @@ async fn main() -> Result<()> {
             local_reconcile_timeout: DEFAULT_LOCAL_RECONCILE_TIMEOUT.to_string(),
             container_engine: std::env::var("CONTAINER_ENGINE").ok(),
             engine_sock: std::env::var("ENGINE_SOCK").ok(),
-            toolbox: std::env::var("KNR_TOOLBOX").is_ok_and(|value| value == "1"),
+            toolbox: std::env::var("KROPS_TOOLBOX").is_ok_and(|value| value == "1"),
             git_repo_url: None,
             github_token: None,
             github_user: DEFAULT_GITHUB_USER.to_string(),
@@ -2326,7 +2326,7 @@ async fn main() -> Result<()> {
 
     let cfg = Config::load(&cli, repo)?;
     let http = reqwest::Client::builder()
-        .user_agent(concat!("knr-bootstrap/", env!("CARGO_PKG_VERSION")))
+        .user_agent(concat!("krops-bootstrap/", env!("CARGO_PKG_VERSION")))
         .connect_timeout(HTTP_CONNECT_TIMEOUT)
         .timeout(HTTP_REQUEST_TIMEOUT)
         .build()
@@ -2443,7 +2443,7 @@ mod tests {
 
     // A Config skeleton for tests that only exercise profile-gated logic.
     fn teardown_minimal_config() -> Config {
-        let cli = Cli::try_parse_from(["knr-bootstrap", "aws"]).unwrap();
+        let cli = Cli::try_parse_from(["krops-bootstrap", "aws"]).unwrap();
         Config::from_env(&cli, repo_config(), |_| None).unwrap()
     }
 
@@ -2458,7 +2458,7 @@ mod tests {
     fn cli_rejects_unknown_profile() {
         // Positional profile names are validated against bootstrap.toml at
         // resolution time (they name [environments.*] sections), not by clap.
-        let cli = Cli::try_parse_from(["knr-bootstrap", "bogus"]).unwrap();
+        let cli = Cli::try_parse_from(["krops-bootstrap", "bogus"]).unwrap();
         assert!(Config::from_env(&cli, repo_config(), |_| None).is_err());
     }
 
@@ -2467,19 +2467,19 @@ mod tests {
         // The expanded flag interface is deferred (review follow-up): the
         // CLI accepts only the positional profile and --recreate.
         for rejected in [
-            ["knr-bootstrap", "--registry-port", "5500"],
-            ["knr-bootstrap", "--github-token", "x"],
-            ["knr-bootstrap", "--oci-tag", "dev"],
-            ["knr-bootstrap", "--container-engine", "docker"],
+            ["krops-bootstrap", "--registry-port", "5500"],
+            ["krops-bootstrap", "--github-token", "x"],
+            ["krops-bootstrap", "--oci-tag", "dev"],
+            ["krops-bootstrap", "--container-engine", "docker"],
             // Pivot knobs are env-only (BOOTSTRAP_PIVOT / PIVOT_SKIP_DELETE),
             // per the #95 entry-point decision: no new CLI surface.
-            ["knr-bootstrap", "aws", "--no-pivot"],
-            ["knr-bootstrap", "aws", "--pivot"],
-            ["knr-bootstrap", "--mgmt-kubeconfig", "/tmp/x.yaml"],
+            ["krops-bootstrap", "aws", "--no-pivot"],
+            ["krops-bootstrap", "aws", "--pivot"],
+            ["krops-bootstrap", "--mgmt-kubeconfig", "/tmp/x.yaml"],
             // Teardown knobs are env-only too (AWS_ONLY /
             // FORCE_KIND_DELETE), matching teardown.sh's interface.
-            ["knr-bootstrap", "teardown", "--aws-only"],
-            ["knr-bootstrap", "teardown", "--force-kind-delete"],
+            ["krops-bootstrap", "teardown", "--aws-only"],
+            ["krops-bootstrap", "teardown", "--force-kind-delete"],
         ] {
             assert!(
                 Cli::try_parse_from(rejected).is_err(),
@@ -2491,7 +2491,7 @@ mod tests {
     #[test]
     fn config_defaults_match_script() {
         let cfg = config_from(
-            &Cli::try_parse_from(["knr-bootstrap", "local-host"]).unwrap(),
+            &Cli::try_parse_from(["krops-bootstrap", "local-host"]).unwrap(),
             |_| None,
         );
         assert_eq!(cfg.profile, "local-host");
@@ -2501,7 +2501,7 @@ mod tests {
         assert_eq!(cfg.local_reconcile_timeout, "15m");
         assert_eq!(cfg.github_user, "git");
         assert_eq!(cfg.age_key_file, PathBuf::from("age.agekey"));
-        assert_eq!(cfg.oci_repository, "knr-ops");
+        assert_eq!(cfg.oci_repository, "krops");
         assert_eq!(cfg.oci_tag, "latest");
         assert!(cfg.container_engine.is_none());
         assert!(cfg.git_repo_url.is_none());
@@ -2526,7 +2526,7 @@ mod tests {
             ),
             ("capd-system", "docker")
         );
-        assert_eq!(cfg.repo.bootstrap.registry_name, "knr-registry");
+        assert_eq!(cfg.repo.bootstrap.registry_name, "krops-registry");
         assert_eq!(cfg.repo.bootstrap.flux_namespace, "flux-system");
         assert_eq!(cfg.repo.bootstrap.mgmt_namespace, "default");
         assert_eq!(cfg.repo.charts["flux-operator"], "0.58.0");
@@ -2534,7 +2534,7 @@ mod tests {
 
     #[test]
     fn config_reads_env_knobs_with_script_semantics() {
-        let cli = Cli::try_parse_from(["knr-bootstrap"]).unwrap();
+        let cli = Cli::try_parse_from(["krops-bootstrap"]).unwrap();
         let get = |name: &str| -> Option<String> {
             match name {
                 "REGISTRY_PORT" => Some("5500".into()),
@@ -2555,7 +2555,7 @@ mod tests {
 
     #[test]
     fn config_reads_pivot_knobs_with_script_semantics() {
-        let cli = Cli::try_parse_from(["knr-bootstrap", "aws"]).unwrap();
+        let cli = Cli::try_parse_from(["krops-bootstrap", "aws"]).unwrap();
         let get = |name: &str| -> Option<String> {
             match name {
                 "BOOTSTRAP_PIVOT" => Some("0".into()),
@@ -2578,9 +2578,9 @@ mod tests {
 
     #[test]
     fn config_reads_toolbox_runtime_knobs() {
-        let cli = Cli::try_parse_from(["knr-bootstrap", "local-host"]).unwrap();
+        let cli = Cli::try_parse_from(["krops-bootstrap", "local-host"]).unwrap();
         let cfg = config_from(&cli, |name| match name {
-            "KNR_TOOLBOX" => Some("1".into()),
+            "KROPS_TOOLBOX" => Some("1".into()),
             "ENGINE_SOCK" => Some("/run/user/501/podman/podman.sock".into()),
             _ => None,
         });
@@ -2590,14 +2590,14 @@ mod tests {
             cfg.engine_sock.as_deref(),
             Some("/run/user/501/podman/podman.sock")
         );
-        assert_eq!(cfg.registry_endpoint(), ("knr-registry".into(), 5000));
+        assert_eq!(cfg.registry_endpoint(), ("krops-registry".into(), 5000));
         assert!(!cfg.should_rewrite_capd_endpoint());
     }
 
     #[test]
     fn host_runtime_keeps_localhost_endpoints() {
         let cfg = config_from(
-            &Cli::try_parse_from(["knr-bootstrap", "local-host"]).unwrap(),
+            &Cli::try_parse_from(["krops-bootstrap", "local-host"]).unwrap(),
             |_| None,
         );
 
@@ -2702,7 +2702,7 @@ mod tests {
 
     #[test]
     fn config_rejects_invalid_poll_interval() {
-        let cli = Cli::try_parse_from(["knr-bootstrap", "aws"]).unwrap();
+        let cli = Cli::try_parse_from(["krops-bootstrap", "aws"]).unwrap();
         let err = Config::from_env(&cli, repo_config(), |name| match name {
             "MGMT_POLL_INTERVAL" => Some("often".into()),
             _ => None,
@@ -2715,7 +2715,7 @@ mod tests {
     fn config_rejects_zero_poll_interval() {
         // 0 parses as u64 but divides by zero in the Phase 1 attempt
         // arithmetic; reject it at startup like any other invalid value.
-        let cli = Cli::try_parse_from(["knr-bootstrap", "aws"]).unwrap();
+        let cli = Cli::try_parse_from(["krops-bootstrap", "aws"]).unwrap();
         let err = Config::from_env(&cli, repo_config(), |name| match name {
             "MGMT_POLL_INTERVAL" => Some("0".into()),
             _ => None,
@@ -2726,7 +2726,7 @@ mod tests {
 
     #[test]
     fn config_rejects_invalid_ready_timeout() {
-        let cli = Cli::try_parse_from(["knr-bootstrap", "aws"]).unwrap();
+        let cli = Cli::try_parse_from(["krops-bootstrap", "aws"]).unwrap();
         let err = Config::from_env(&cli, repo_config(), |name| match name {
             "MGMT_READY_TIMEOUT" => Some("abc".into()),
             _ => None,
@@ -2755,7 +2755,7 @@ mod tests {
         // the Python cross-check (mise run validate) additionally verifies
         // every declared path exists on disk.
         let cfg = config_from(
-            &Cli::try_parse_from(["knr-bootstrap", "aws"]).unwrap(),
+            &Cli::try_parse_from(["krops-bootstrap", "aws"]).unwrap(),
             |_| None,
         );
         assert_eq!(cfg.environment.mgmt_cluster, "eu-north-1-management");
@@ -2779,7 +2779,7 @@ mod tests {
         );
 
         let cfg = config_from(
-            &Cli::try_parse_from(["knr-bootstrap", "local-host"]).unwrap(),
+            &Cli::try_parse_from(["krops-bootstrap", "local-host"]).unwrap(),
             |_| None,
         );
         assert_eq!(cfg.environment.mgmt_cluster, "local-management");
@@ -2806,7 +2806,7 @@ mod tests {
 
     #[test]
     fn config_rejects_non_numeric_registry_port() {
-        let cli = Cli::try_parse_from(["knr-bootstrap", "local-host"]).unwrap();
+        let cli = Cli::try_parse_from(["krops-bootstrap", "local-host"]).unwrap();
         let err = Config::from_env(&cli, repo_config(), |name| match name {
             "REGISTRY_PORT" => Some("not-a-port".into()),
             _ => None,
@@ -2818,7 +2818,7 @@ mod tests {
     #[test]
     fn environment_resolution_matches_script_precedence() {
         let repo = repo_config();
-        // Non-empty env wins over the positional, like ${KNR_OPS_PROFILE:-${1:-aws}}.
+        // Non-empty env wins over the positional, like ${KROPS_PROFILE:-${1:-aws}}.
         assert_eq!(
             resolve_environment(Some("aws"), Some("local-host"), &repo).unwrap(),
             "aws"
@@ -2850,28 +2850,28 @@ mod tests {
 
     #[test]
     fn cli_accepts_recreate_flag() {
-        let cli = Cli::try_parse_from(["knr-bootstrap", "aws", "--recreate"]).unwrap();
+        let cli = Cli::try_parse_from(["krops-bootstrap", "aws", "--recreate"]).unwrap();
         assert!(cli.recreate);
     }
 
     #[test]
     fn parse_github_repo_accepts_https_urls() {
         for url in [
-            "https://github.com/polarsquad/knr-ops",
-            "https://github.com/polarsquad/knr-ops/",
-            "https://github.com/polarsquad/knr-ops.git",
+            "https://github.com/polarsquad/krops",
+            "https://github.com/polarsquad/krops/",
+            "https://github.com/polarsquad/krops.git",
         ] {
-            assert_eq!(parse_github_repo(url), Some("polarsquad/knr-ops"), "{url}");
+            assert_eq!(parse_github_repo(url), Some("polarsquad/krops"), "{url}");
         }
     }
 
     #[test]
     fn parse_github_repo_rejects_bad_urls() {
         for url in [
-            "git@github.com:polarsquad/knr-ops.git",
-            "https://gitlab.com/polarsquad/knr-ops",
+            "git@github.com:polarsquad/krops.git",
+            "https://gitlab.com/polarsquad/krops",
             "https://github.com/polarsquad",
-            "https://github.com//knr-ops",
+            "https://github.com//krops",
             "https://github.com/polarsquad/",
             "",
         ] {
@@ -2920,13 +2920,13 @@ mod tests {
 
     #[test]
     fn kind_config_includes_registry_patch_for_local_host_only() {
-        let local = render_kind_config(true, 5001, "/var/run/docker.sock", "knr-registry");
+        let local = render_kind_config(true, 5001, "/var/run/docker.sock", "krops-registry");
         assert!(local.contains("containerdConfigPatches"));
         assert!(local.contains("localhost:5001"));
-        assert!(local.contains("http://knr-registry:5000"));
+        assert!(local.contains("http://krops-registry:5000"));
         assert!(local.contains("hostPath: /var/run/docker.sock"));
 
-        let aws = render_kind_config(false, 5001, "/var/run/docker.sock", "knr-registry");
+        let aws = render_kind_config(false, 5001, "/var/run/docker.sock", "krops-registry");
         assert!(!aws.contains("containerdConfigPatches"));
         assert!(aws.contains("kind: Cluster"));
         assert!(aws.contains("role: control-plane"));

--- a/bootstrap-rs/src/teardown.rs
+++ b/bootstrap-rs/src/teardown.rs
@@ -59,7 +59,7 @@ impl TeardownConfig {
             .context("HOME is not set; cannot locate the management kubeconfig")?;
         let mgmt_kubeconfig = value("MGMT_KUBECONFIG")
             .map(PathBuf::from)
-            .unwrap_or_else(|| home.join(".kube/knr-ops-mgmt.yaml"));
+            .unwrap_or_else(|| home.join(".kube/krops-mgmt.yaml"));
         Ok(Self {
             // Literal "1" enables (shell boolean gate parity).
             aws_only: flag("AWS_ONLY", "1"),
@@ -429,7 +429,7 @@ impl AwsSweepTarget {
             eks_cluster_name: eks_cluster_name.to_string(),
             // The management cluster runs no workload ACK controllers,
             // so it owns no RDS instance; the sweep unit skips absent ids.
-            rds_instance: format!("knr-ops-{cluster_name}-db"),
+            rds_instance: format!("krops-{cluster_name}-db"),
         }
     }
 
@@ -1009,7 +1009,7 @@ pub async fn cleanup_cfn_stack(stack: &str, region: &str) {
     }
 }
 
-/// 4e. VPC resources, gated on the CAPA ownership tag (knr-ops scope
+/// 4e. VPC resources, gated on the CAPA ownership tag (krops scope
 /// only): NAT gateways + their EIPs, subnets, IGWs, route tables,
 /// security groups (rules first, then the groups), the VPC itself.
 pub async fn cleanup_vpc_resources(target: &AwsSweepTarget) {
@@ -2080,11 +2080,11 @@ mod tests {
     fn s3_bucket_name_substitutes_the_config_pattern() {
         assert_eq!(
             s3_bucket_name(
-                "knr-ops-{account_id}-{cluster_name}-data",
+                "krops-{account_id}-{cluster_name}-data",
                 "123456789012",
                 "eu-north-1-workload"
             ),
-            "knr-ops-123456789012-eu-north-1-workload-data"
+            "krops-123456789012-eu-north-1-workload-data"
         );
     }
 
@@ -2145,8 +2145,8 @@ mod tests {
         );
         assert_eq!(t.capa_tag_key(), capa_tag_key("eu-north-1-management"));
         assert_eq!(
-            t.bucket_name("knr-ops-{account_id}-{cluster_name}-data", "acct"),
-            "knr-ops-acct-eu-north-1-management-data"
+            t.bucket_name("krops-{account_id}-{cluster_name}-data", "acct"),
+            "krops-acct-eu-north-1-management-data"
         );
     }
 }

--- a/bootstrap-rs/toolbox-entrypoint.sh
+++ b/bootstrap-rs/toolbox-entrypoint.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
-# toolbox-entrypoint.sh – launcher for the knr-ops toolbox image (issue #104).
+# toolbox-entrypoint.sh – launcher for the krops toolbox image (issue #104).
 #
-# The image's ENTRYPOINT runs knr-bootstrap directly; this launcher is the
+# The image's ENTRYPOINT runs krops-bootstrap directly; this launcher is the
 # documented `docker run`/`podman run` command's inner command when the
 # operator wants a shell or a custom argv, and the wiring point for the
-# toolbox runtime knobs the binary reads (KNR_TOOLBOX, ENGINE_SOCK,
+# toolbox runtime knobs the binary reads (KROPS_TOOLBOX, ENGINE_SOCK,
 # CONTAINER_ENGINE, KUBECONFIG).
 #
 # Usage inside the image (set by the run invocation):
@@ -16,7 +16,7 @@
 #   2. resolves the ENGINE_SOCK source path the daemon-side kind network
 #      needs (macOS Docker Desktop and remote Podman sockets do not live at
 #      /var/run/docker.sock);
-#   3. exports the toolbox knobs and execs knr-bootstrap (PID 1 semantics:
+#   3. exports the toolbox knobs and execs krops-bootstrap (PID 1 semantics:
 #      signals reach the CLI directly).
 set -eu
 
@@ -78,7 +78,7 @@ fi
 # ── 3. Join the kind network (best-effort) ────────────────────────────────────
 # Every `docker run` starts a NEW container, so the network attachment must
 # happen per container start, not once per cluster. The kind network exists
-# after the first bootstrap; joining makes knr-registry and kind-network
+# after the first bootstrap; joining makes krops-registry and kind-network
 # endpoints resolve for ANY invocation (oci-push, kubectl, a shell). Failure
 # is expected and silent before the first bootstrap creates the network; the
 # bootstrap itself joins explicitly after cluster creation.
@@ -91,6 +91,6 @@ if [ -n "$HOSTNAME_ID" ]; then
 fi
 
 # ── 4. Toolbox mode + exec ────────────────────────────────────────────────────
-export KNR_TOOLBOX=1
+export KROPS_TOOLBOX=1
 
-exec knr-bootstrap "$@"
+exec krops-bootstrap "$@"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -5,9 +5,9 @@ set -euo pipefail
 
 source "$(dirname "$0")/bootstrap-common.sh"
 
-PROFILE="${KNR_OPS_PROFILE:-${1:-aws}}"
+PROFILE="${KROPS_PROFILE:-${1:-aws}}"
 GIT_BRANCH="main"
-REGISTRY_NAME="knr-registry"
+REGISTRY_NAME="krops-registry"
 REGISTRY_PORT="${REGISTRY_PORT:-5001}"
 REGISTRY_READY_RETRIES="${REGISTRY_READY_RETRIES:-120}"
 LOCAL_RECONCILE_TIMEOUT="${LOCAL_RECONCILE_TIMEOUT:-15m}"
@@ -117,7 +117,7 @@ if [ "$PROFILE" = local-host ]; then
 
   echo ">>> Publishing initial OCI artifact from the local Git checkout..."
   mise -E local-host run oci-push
-  echo ">>> Initial OCI artifact is available at oci://localhost:${REGISTRY_PORT}/${OCI_REPOSITORY:-knr-ops}:${OCI_TAG:-latest}"
+  echo ">>> Initial OCI artifact is available at oci://localhost:${REGISTRY_PORT}/${OCI_REPOSITORY:-krops}:${OCI_TAG:-latest}"
 fi
 
 # ── Steps 2–4: Seed Flux (operator, secrets, FluxInstance) ────────────────────
@@ -242,7 +242,7 @@ if [ "$PROFILE" = aws ]; then
 else
   echo ">>> Local-host profile complete: Flux is reconciling from the local OCI artifact"
   echo ">>> Local registry: localhost:${REGISTRY_PORT} (cluster endpoint: ${REGISTRY_NAME}:5000)"
-  echo ">>> OCI source: oci://${REGISTRY_NAME}:5000/${OCI_REPOSITORY:-knr-ops}:${OCI_TAG:-latest} (path: mgmt/local-host)"
+  echo ">>> OCI source: oci://${REGISTRY_NAME}:5000/${OCI_REPOSITORY:-krops}:${OCI_TAG:-latest} (path: mgmt/local-host)"
   echo ">>> Watch progress with: flux get sources oci --watch"
   echo ">>> No AWS resources were provisioned"
 fi
@@ -253,7 +253,7 @@ fi
 # cluster via CAPA/CAPD), then pivot.sh moves the CAPI inventory into it and
 # deletes the kind cluster. Opt out with BOOTSTRAP_PIVOT=0 to keep the kind
 # bootstrap cluster as the management cluster (pre-#79 behavior).
-export KNR_OPS_PROFILE="$PROFILE"
+export KROPS_PROFILE="$PROFILE"
 if [ "${BOOTSTRAP_PIVOT:-1}" = 1 ]; then
   # EXIT traps do not fire across exec; clean up the seed temp files first.
   cleanup_bootstrap

--- a/bootstrap.toml
+++ b/bootstrap.toml
@@ -1,6 +1,6 @@
-# Repository-owned configuration for knr-bootstrap (issue #98).
+# Repository-owned configuration for krops-bootstrap (issue #98).
 #
-# Everything knr-ops-specific the binary needs is declared here; the binary
+# Everything krops-specific the binary needs is declared here; the binary
 # itself is a generic bootstrap engine. Environment variables (REGISTRY_PORT,
 # GIT_REPO_URL, BOOTSTRAP_KUBECONTEXT, ...) keep their precedence over these
 # values at runtime. Locate this file with BOOTSTRAP_CONFIG when not running
@@ -10,7 +10,7 @@
 # to preserve bootstrap.sh's exact wording ('local-host' before 'aws').
 #
 # Profile resolution: the [environments.*] section name is authoritative;
-# KNR_OPS_PROFILE matches it exactly. Each environment's `kind` restates
+# KROPS_PROFILE matches it exactly. Each environment's `kind` restates
 # the section name, and the cross-check fails if the two disagree.
 
 [bootstrap]
@@ -18,12 +18,12 @@ default-environment = "aws"
 git-branch = "main"
 kind-cluster = "mgmt"
 kind-context = "kind-mgmt"
-registry-name = "knr-registry"
+registry-name = "krops-registry"
 flux-namespace = "flux-system"
 github-pat-secret = "flux-github-pat"
 sops-age-secret = "sops-age"
 mgmt-namespace = "default"
-mgmt-context = "knr-ops-mgmt"
+mgmt-context = "krops-mgmt"
 
 [charts]
 # Chart versions installed imperatively before Flux exists. Keep in sync
@@ -40,7 +40,7 @@ cert-manager = "1.21.1"
 capi-operator = "0.28.0"
 
 [teardown]
-# Constants for `knr-bootstrap teardown` (issue #100), mirroring the literal
+# Constants for `krops-bootstrap teardown` (issue #100), mirroring the literal
 # lists in teardown.sh; tests/test-bootstrap-config.py cross-checks them
 # against the Git manifests that define the same names.
 # CloudFormation stack created by `clusterawsadm bootstrap iam`.
@@ -49,17 +49,17 @@ cfn-stack-name = "cluster-api-provider-aws-sigs-k8s-io"
 # (mgmt/aws/infrastructure/ack-pod-identity/) and the per-cluster reader
 # roles created by the workload ACK IAM controllers.
 global-iam-roles = [
-  "knr-ops-ack-s3-controller",
-  "knr-ops-ack-rds-controller",
-  "knr-ops-ack-iam-controller",
-  "knr-ops-eu-north-1-workload-reader",
-  "knr-ops-eu-west-1-workload-reader",
+  "krops-ack-s3-controller",
+  "krops-ack-rds-controller",
+  "krops-ack-iam-controller",
+  "krops-eu-north-1-workload-reader",
+  "krops-eu-west-1-workload-reader",
 ]
 # The console reader user created by the management cluster's ACK IAM
 # controller (mgmt/aws/infrastructure/aws-global-iam/reader-user.yaml).
-global-iam-users = ["knr-ops-reader"]
+global-iam-users = ["krops-reader"]
 # S3 bucket pattern (workload/base/s3-buckets/bucket.yaml).
-s3-bucket-pattern = "knr-ops-{account_id}-{cluster_name}-data"
+s3-bucket-pattern = "krops-{account_id}-{cluster_name}-data"
 
 [environments.local-host]
 kind = "local-host"
@@ -126,13 +126,13 @@ mgmt-iam-role-prefix = "eu-north-1-management"
 region = "eu-north-1"
 cluster-name = "eu-north-1-workload"
 eks-cluster-name = "default_eu-north-1-workload-control-plane"
-rds-instance = "knr-ops-eu-north-1-workload-db"
+rds-instance = "krops-eu-north-1-workload-db"
 
 [[environments.aws.teardown.aws-workloads]]
 region = "eu-west-1"
 cluster-name = "eu-west-1-workload"
 eks-cluster-name = "default_eu-west-1-workload-control-plane"
-rds-instance = "knr-ops-eu-west-1-workload-db"
+rds-instance = "krops-eu-west-1-workload-db"
 
 [environments.local-talos]
 kind = "local-talos"

--- a/docs/air-gap-infra.svg
+++ b/docs/air-gap-infra.svg
@@ -18,7 +18,7 @@
   <rect width="1600" height="1150" fill="#0f0f0f"/>
 
   <!-- ===== title block ===== -->
-  <text x="800" y="60" text-anchor="middle" font-family="DejaVu Sans" font-size="40" font-weight="bold" fill="#ff78c9">knr-ops &#183; Zarf Air-Gap Bundle &#183; Radio Off, Chain Intact</text>
+  <text x="800" y="60" text-anchor="middle" font-family="DejaVu Sans" font-size="40" font-weight="bold" fill="#ff78c9">krops &#183; Zarf Air-Gap Bundle &#183; Radio Off, Chain Intact</text>
   <text x="800" y="96" text-anchor="middle" font-family="DejaVu Sans" font-size="19" fill="#8f8f8f">Zarf packages the local-host environment &#183; build connected, deploy with no internet &#183; two registries, one package</text>
 
   <!-- ===== section headers ===== -->
@@ -42,11 +42,11 @@
   <rect x="636" y="158" width="368" height="5" rx="2.5" fill="#ab9fd6"/>
   <text x="820" y="198" text-anchor="middle" font-family="DejaVu Sans" font-size="25" font-weight="bold" fill="#ab9fd6">The Bundle</text>
   <text x="820" y="222" text-anchor="middle" font-family="DejaVu Sans" font-size="16" fill="#8f8f8f">(what crosses the gap)</text>
-  <text x="656" y="258" font-family="DejaVu Sans Mono" font-size="15" fill="#d6d6d6">zarf-package-knr-ops-airgap-*.tar.zst</text>
+  <text x="656" y="258" font-family="DejaVu Sans Mono" font-size="15" fill="#d6d6d6">zarf-package-krops-airgap-*.tar.zst</text>
   <text x="656" y="286" font-family="DejaVu Sans Mono" font-size="15" fill="#d6d6d6">zarf-init tarball + zarf CLI</text>
   <text x="656" y="314" font-family="DejaVu Sans Mono" font-size="15" fill="#d6d6d6">archives/*.tar <tspan font-family="DejaVu Sans" fill="#8f8f8f">(kind nodes, images)</tspan></text>
   <text x="656" y="342" font-family="DejaVu Sans Mono" font-size="15" fill="#d6d6d6">charts/*.tgz <tspan font-family="DejaVu Sans" fill="#8f8f8f">(flux-operator, podinfo)</tspan></text>
-  <text x="656" y="370" font-family="DejaVu Sans Mono" font-size="15" fill="#d6d6d6">config-artifact/ <tspan font-family="DejaVu Sans" fill="#8f8f8f">&#8594; knr-ops:latest</tspan></text>
+  <text x="656" y="370" font-family="DejaVu Sans Mono" font-size="15" fill="#d6d6d6">config-artifact/ <tspan font-family="DejaVu Sans" fill="#8f8f8f">&#8594; krops:latest</tspan></text>
 
   <!-- build -> bundle arrow -->
   <line x1="508" y1="278" x2="612" y2="278" stroke="#85c7bb" stroke-width="2.5" marker-end="url(#arrow-teal)"/>
@@ -104,7 +104,7 @@
   <text x="776" y="635" font-family="DejaVu Sans" font-size="13" fill="#8f8f8f">(local)</text>
   <rect x="700" y="672" width="306" height="66" rx="8" fill="#1d1d30" stroke="#d693b1" stroke-opacity="0.6" stroke-width="1.2"/>
   <text x="853" y="697" text-anchor="middle" font-family="DejaVu Sans" font-size="12.5" fill="#d6d6d6">syncs config + charts from</text>
-  <text x="853" y="721" text-anchor="middle" font-family="DejaVu Sans Mono" font-size="15" fill="#d693b1">knr-registry:5000</text>
+  <text x="853" y="721" text-anchor="middle" font-family="DejaVu Sans Mono" font-size="15" fill="#d693b1">krops-registry:5000</text>
   <!-- podinfo chip -->
   <rect x="700" y="762" width="306" height="70" rx="10" fill="#1d1d30" stroke="#3d3d55" stroke-width="1.2"/>
   <g stroke="#cfa07e" stroke-width="1.8" fill="none">
@@ -140,7 +140,7 @@
   <text x="1140" y="344" text-anchor="middle" font-family="DejaVu Sans" font-size="15" font-weight="bold" fill="#0f0f0f">2</text>
   <text x="1168" y="334" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">The bundle crosses the gap. Offline:</text>
   <text x="1168" y="360" font-family="DejaVu Sans Mono" font-size="15.5" fill="#ab9fd6">docker load archives; create kind</text>
-  <text x="1168" y="386" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">mgmt cluster, seed knr-registry.</text>
+  <text x="1168" y="386" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">mgmt cluster, seed krops-registry.</text>
   <line x1="1122" y1="420" x2="1504" y2="420" stroke="#34344a" stroke-width="1.2"/>
 
   <!-- step 3 -->
@@ -165,7 +165,7 @@
   <circle cx="1140" cy="780" r="15" fill="#d693b1"/>
   <text x="1140" y="786" text-anchor="middle" font-family="DejaVu Sans" font-size="15" font-weight="bold" fill="#0f0f0f">5</text>
   <text x="1168" y="776" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">Workload Flux pulls config + charts</text>
-  <text x="1168" y="802" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">from knr-registry; podinfo runs</text>
+  <text x="1168" y="802" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">from krops-registry; podinfo runs</text>
   <text x="1168" y="828" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">from pre-loaded images. Zero pulls,</text>
   <text x="1168" y="854" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">zero public packets.</text>
   <line x1="1122" y1="888" x2="1504" y2="888" stroke="#34344a" stroke-width="1.2"/>
@@ -173,7 +173,7 @@
   <!-- update drill -->
   <text x="1122" y="930" font-family="DejaVu Sans" font-size="22" font-weight="bold" fill="#f2c464">Update drill</text>
   <text x="1122" y="962" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">Config-only change: rebuild + re-push</text>
-  <text x="1122" y="988" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6"><tspan font-family="DejaVu Sans Mono" font-size="16" fill="#fafafa">knr-ops:latest</tspan>, no package rebuild.</text>
+  <text x="1122" y="988" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6"><tspan font-family="DejaVu Sans Mono" font-size="16" fill="#fafafa">krops:latest</tspan>, no package rebuild.</text>
   <text x="1122" y="1014" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">Substrate change: new package +</text>
   <text x="1122" y="1040" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">fresh <tspan font-family="DejaVu Sans Mono" font-size="16" fill="#fafafa">zarf package deploy</tspan>.</text>
 

--- a/docs/airgap.md
+++ b/docs/airgap.md
@@ -1,6 +1,6 @@
-# Air-gapped knr-ops with Zarf (local-host / CAPD environment)
+# Air-gapped krops with Zarf (local-host / CAPD environment)
 
-This document describes how knr-ops is packaged with [Zarf](https://zarf.dev)
+This document describes how krops is packaged with [Zarf](https://zarf.dev)
 on a connected machine and deployed end-to-end with **no internet access**:
 the management cluster, Flux, CAPI, and a CAPD workload cluster, all from one
 package plus a small set of image archives.
@@ -39,7 +39,7 @@ to check relevant working-tree changes without registry or network access.
 Run `python3 airgap/tests/test-airgap-image-digests.py --all` in a clone to
 audit every air-gap inventory and shell script, including untouched legacy
 files.
-The locally built `localhost:5001/knr-ops-airgap:latest` config artifact is the
+The locally built `localhost:5001/krops-airgap:latest` config artifact is the
 only documented exception because it is created immediately before packaging.
 
 Every package build must be signed. For an operator build, generate or obtain
@@ -65,7 +65,7 @@ airgap/scripts/build-package.sh               airgap/scripts/offline-run.sh
   zarf package sign                            4. zarf init + package deploy
         |                                      zarf init --registry-mode=nodeport
         v                                      zarf package deploy
-zarf-package-knr-ops-airgap-*.tar.zst               |
+zarf-package-krops-airgap-*.tar.zst               |
 archives/ (node images, workload images,           v
   charts, zarf-init tarball)                 Zarf internal registry (127.0.0.1:31999)
                                                     + agent (mutating webhook)
@@ -73,19 +73,19 @@ archives/ (node images, workload images,           v
                                                CAPI core+providers, CAPD, CAAPH
                                              FluxInstance -> sync from Zarf registry
                                              Flux -> clusters/docker (CAPD) -> workload
-                                             workload Flux <- knr-registry (config+charts)
+                                             workload Flux <- krops-registry (config+charts)
 ```
 
 **Ownership split.** Zarf owns the *substrate* (internal registry, agent,
 cert-manager, the flux-operator chart, CAPI core + kubeadm bootstrap /
-control-plane + CAPD + CAAPH component manifests, and the knr-ops config
+control-plane + CAPD + CAAPH component manifests, and the krops config
 artifact). Flux owns the *workload definitions* (the CAPD cluster, the kindnet
 CNI addon, the per-cluster Flux addon), reconciled from the config artifact.
 The `mgmt/` and `workload/` trees in git are **not** modified; the airgap
 variant is generated at build time by `build-config-artifact.sh`.
 
 **Why OCI, not Gitea.** The local-host environment moved from a GitHub
-`GitRepository` to an OCI-artifact sync (`oci://knr-registry:5000/knr-ops`)
+`GitRepository` to an OCI-artifact sync (`oci://krops-registry:5000/krops`)
 in PRs #30/#31/#33. There is no `GitRepository` left to rewrite, so the Zarf
 git-server is unused; the config crosses the gap as an OCI artifact inside the
 Zarf package and is published into Zarf's internal registry at deploy time.
@@ -98,14 +98,14 @@ The verification linchpin is the agent's **image rewrite** plus a Ready
 |---|---|
 | `zarf` CLI binary | runs the deploy |
 | `archives/zarf-init-arm64-v0.83.0.tar.zst` | `zarf init` (registry + agent) |
-| `zarf-package-knr-ops-airgap-arm64-0.1.0.tar.zst` | signed package, including per-component Syft JSON/HTML SBOMs and the Sigstore signature bundle |
+| `zarf-package-krops-airgap-arm64-0.1.0.tar.zst` | signed package, including per-component Syft JSON/HTML SBOMs and the Sigstore signature bundle |
 | `archives/kindest_node_v1.37.0_mgmt.tar` | mgmt kind node (host daemon) |
 | `archives/kindest_node_v1.37.0.tar` | CAPD workload and management nodes (host daemon) |
 | `archives/kindest_haproxy_*.tar` | CAPD load balancer |
-| `archives/docker.io_library_registry_2.tar` | knr-registry container |
+| `archives/docker.io_library_registry_2.tar` | krops-registry container |
 | `archives/workload-pod-images.tar` | flux controllers + podinfo for `preLoadImages` |
-| `archives/charts/{flux-operator,podinfo}-*.tgz` | OCI charts seeded into knr-registry |
-| `config-artifact/` | trimmed GitOps tree, re-pushed as `knr-ops:latest` |
+| `archives/charts/{flux-operator,podinfo}-*.tgz` | OCI charts seeded into krops-registry |
+| `config-artifact/` | trimmed GitOps tree, re-pushed as `krops:latest` |
 
 The CI artifact excludes the `zarf` CLI; fetch it via mise or the Zarf release
 for the deploy host's target OS before crossing the gap.
@@ -155,11 +155,11 @@ Gap (deploy) — from `airgap/`:
 
 ```sh
 # CI keyless-signed package (default trusted workflow identity)
-scripts/offline-run.sh zarf-package-knr-ops-airgap-arm64-0.1.0.tar.zst
+scripts/offline-run.sh zarf-package-krops-airgap-arm64-0.1.0.tar.zst
 
 # Operator key-signed package
 ZARF_VERIFY_KEY=/transfer/cosign.pub \
-  scripts/offline-run.sh zarf-package-knr-ops-airgap-arm64-0.1.0.tar.zst
+  scripts/offline-run.sh zarf-package-krops-airgap-arm64-0.1.0.tar.zst
 ```
 
 Before it creates or changes a cluster, `offline-run.sh` verifies the package
@@ -185,7 +185,7 @@ daemon): `CLUSTER_NAME`, `AIRGAP_CLUSTER_NAME`, `WORKLOAD_REGISTRY_HOST`,
 - `kubectl get pods -A -o jsonpath=...`: every non-kind-baked image is
   prefixed `127.0.0.1:31999/` (the Zarf internal registry).
 - `kubectl -n flux-system get ocirepository`: `url` is
-  `oci://zarf-docker-registry.zarf.svc.cluster.local:5000/knr-ops-airgap`,
+  `oci://zarf-docker-registry.zarf.svc.cluster.local:5000/krops-airgap`,
   Ready with a stored digest equal to the connected-side push.
 - `flux get kustomizations`: all Ready, from the artifact.
 - `kubectl get clusters.cluster.x-k8s.io -A`: workload cluster `Provisioned` /
@@ -226,7 +226,7 @@ daemon): `CLUSTER_NAME`, `AIRGAP_CLUSTER_NAME`, `WORKLOAD_REGISTRY_HOST`,
 
 ## Known limitations / follow-ups
 
-- The `knr-ops-toolbox` image is not included in `airgap/images.txt` or the
+- The `krops-toolbox` image is not included in `airgap/images.txt` or the
   current Zarf package. Offline deployment still uses the dedicated
   `airgap/scripts/` flow and its pinned tool and image inventory; the connected
   toolbox lifecycle does not replace that flow yet.
@@ -236,7 +236,7 @@ daemon): `CLUSTER_NAME`, `AIRGAP_CLUSTER_NAME`, `WORKLOAD_REGISTRY_HOST`,
   replaces kind; not prototyped here.
 - **Single architecture** (arm64). Multi-arch is a `--architecture` follow-up.
 - The **flux-operator chart for the HelmChartProxy** and the podinfo chart are
-  seeded into knr-registry as OCI charts; CAAPH fetches them over plain HTTP
+  seeded into krops-registry as OCI charts; CAAPH fetches them over plain HTTP
   (verified). The workload-cluster FluxInstance omits `distribution.artifact`
   the same way as the mgmt one.
 - **AWS flavor is out of scope** here but shapes the design: in a disconnected
@@ -246,6 +246,6 @@ daemon): `CLUSTER_NAME`, `AIRGAP_CLUSTER_NAME`, `WORKLOAD_REGISTRY_HOST`,
 ## Update drill
 
 A config-only change (edit the tree, re-run `build-config-artifact.sh`,
-re-push `knr-ops:latest` to knr-registry) moves the workload Flux to a new
+re-push `krops:latest` to krops-registry) moves the workload Flux to a new
 digest without rebuilding the package. A substrate change (images/components)
 requires `build-package.sh` and a fresh `zarf package deploy`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,14 +13,14 @@ managing secure S3 buckets, PostgreSQL instances, and read-only IAM roles)
 running on each workload cluster.
 
 The operator normally runs the imperative lifecycle through the
-`knr-ops-toolbox` container. It mounts the host engine socket, joins the kind
+`krops-toolbox` container. It mounts the host engine socket, joins the kind
 network while the bootstrap cluster exists, and leaves no toolbox workload in
 the managed clusters. This packaging changes the host tool boundary, not the
 Flux or CAPI reconciliation architecture.
 
 ```mermaid
 flowchart TD
-    subgraph bootstrap["Bootstrap (one-time, knr-bootstrap CLI)"]
+    subgraph bootstrap["Bootstrap (one-time, krops-bootstrap CLI)"]
         KIND[kind cluster: mgmt, disposable]
         HELM[Helm: flux-operator + FluxInstance]
         SEC[Secrets: flux-github-pat + sops-age]
@@ -28,7 +28,7 @@ flowchart TD
         KIND --> SEC
     end
 
-    subgraph git["Git: github.com/polarsquad/knr-ops"]
+    subgraph git["Git: github.com/polarsquad/krops"]
         REPO[(main branch)]
     end
 
@@ -46,7 +46,7 @@ flowchart TD
         CAAPH[caaph-system]
         ACKC["ack-controllers (SOPS creds)<br/>ACK IAM + EKS controllers"]
         ACKPI["ack-pod-identity<br/>IAM Role + PodIdentityAssociations"]
-        AWSIAM["aws-iam<br/>knr-ops-reader console user"]
+        AWSIAM["aws-iam<br/>krops-reader console user"]
         KONF["konflate (SOPS token)<br/>rendered Flux PR review"]
         EUN[eu-north-1 cluster def]
         EUW[eu-west-1 cluster def]
@@ -68,16 +68,16 @@ flowchart TD
     subgraph aws["AWS"]
         EKS1[EKS: eu-north-1-workload<br/>ARM + GPU node pools<br/>pod-identity agent addon]
         EKS2[EKS: eu-west-1-workload<br/>ARM + GPU node pools<br/>pod-identity agent addon]
-        ROLE[IAM Role: knr-ops-ack-s3-controller<br/>trust: pods.eks.amazonaws.com]
-        RDSROLE[IAM Role: knr-ops-ack-rds-controller<br/>trust: pods.eks.amazonaws.com]
-        IAMROLE[IAM Role: knr-ops-ack-iam-controller<br/>trust: pods.eks.amazonaws.com]
-        B1[(S3: knr-ops-...-eu-north-1-workload-data)]
-        B2[(S3: knr-ops-...-eu-west-1-workload-data)]
-        DB1[(RDS: knr-ops-eu-north-1-workload-db)]
-        DB2[(RDS: knr-ops-eu-west-1-workload-db)]
-        RD1[IAM Role: knr-ops-eu-north-1-workload-reader<br/>trust: account root]
-        RD2[IAM Role: knr-ops-eu-west-1-workload-reader<br/>trust: account root]
-        RUSER[IAM User: knr-ops-reader<br/>console login, assumes reader roles]
+        ROLE[IAM Role: krops-ack-s3-controller<br/>trust: pods.eks.amazonaws.com]
+        RDSROLE[IAM Role: krops-ack-rds-controller<br/>trust: pods.eks.amazonaws.com]
+        IAMROLE[IAM Role: krops-ack-iam-controller<br/>trust: pods.eks.amazonaws.com]
+        B1[(S3: krops-...-eu-north-1-workload-data)]
+        B2[(S3: krops-...-eu-west-1-workload-data)]
+        DB1[(RDS: krops-eu-north-1-workload-db)]
+        DB2[(RDS: krops-eu-west-1-workload-db)]
+        RD1[IAM Role: krops-eu-north-1-workload-reader<br/>trust: account root]
+        RD2[IAM Role: krops-eu-west-1-workload-reader<br/>trust: account root]
+        RUSER[IAM User: krops-reader<br/>console login, assumes reader roles]
     end
 
     EUN -->|CAPA provisions| EKS1
@@ -156,7 +156,7 @@ laptop.
 The management cluster also runs a single
 [konflate](https://github.com/home-operations/konflate) instance
 (`mgmt/aws/infrastructure/konflate/`), pointed at this repo
-(`github://polarsquad/knr-ops`, rendering from the repo root). It renders each
+(`github://polarsquad/krops`, rendering from the repo root). It renders each
 open PR at its merge-base and head and shows the diff of the *rendered* Flux
 output — blast radius, image changes, render failures, and danger lint —
 instead of the raw file diff. Results reach the PR two ways: a GitHub Actions

--- a/docs/aws-iam.md
+++ b/docs/aws-iam.md
@@ -11,8 +11,8 @@ The ACK S3, RDS, and IAM controllers on the workload clusters carry
   (`mgmt/aws/infrastructure/ack-controllers/`, authenticated with the same
   SOPS-encrypted credential pattern as CAPA) which declaratively create:
   - an IAM `Role` per controller, trusted by `pods.eks.amazonaws.com`:
-    - `knr-ops-ack-s3-controller` — scoped to `knr-ops-*` buckets only
-    - `knr-ops-ack-rds-controller` — RDS management scoped to `knr-ops-*`
+    - `krops-ack-s3-controller` — scoped to `krops-*` buckets only
+    - `krops-ack-rds-controller` — RDS management scoped to `krops-*`
       RDS resources (plus read-only `rds:Describe*`), the
       `secretsmanager:CreateSecret`/`TagResource`/`RotateSecret` actions on
       `rds!*` secrets required by `manageMasterUserPassword`,
@@ -22,11 +22,11 @@ The ACK S3, RDS, and IAM controllers on the workload clusters carry
       these `CreateDBInstance` fails with `KMSKeyNotAccessibleFault` — and
       `iam:CreateServiceLinkedRole` for `AWSServiceRoleForRDS` (needed the
       first time an RDS instance is created in the account)
-    - `knr-ops-ack-iam-controller` — IAM role management scoped to
-      `knr-ops-*` roles only. Known trade-off: name-scoped `iam:CreateRole`
+    - `krops-ack-iam-controller` — IAM role management scoped to
+      `krops-*` roles only. Known trade-off: name-scoped `iam:CreateRole`
       + `iam:PutRolePolicy` is still a privilege-escalation surface (any
       permission can be granted to a role, as long as it is named
-      `knr-ops-*`), consistent with the pragmatic name-based scoping used
+      `krops-*`), consistent with the pragmatic name-based scoping used
       for the other controllers
   - a `PodIdentityAssociation` per cluster and controller binding the
     `ack-s3-controller` / `ack-rds-controller` / `ack-iam-controller`
@@ -40,7 +40,7 @@ finished provisioning the EKS clusters.
 ## Per-cluster read-only IAM roles
 
 `workload/base/iam-roles/role.yaml` has each cluster's ACK IAM controller create
-one read-only IAM role (`knr-ops-<cluster>-reader`) — IAM is global, so the
+one read-only IAM role (`krops-<cluster>-reader`) — IAM is global, so the
 cluster name is part of the role name to keep the two clusters from fighting
 over one role:
 
@@ -48,16 +48,16 @@ over one role:
   `sts:AssumeRole`) — any principal in the account that is itself allowed to
   assume the role can use it
 - read-only permissions covering the resources this repo creates on **both**
-  clusters: `knr-ops-*` S3 buckets (bucket + object reads) and `knr-ops-*`
+  clusters: `krops-*` S3 buckets (bucket + object reads) and `krops-*`
   RDS instances (`rds:DescribeDBInstances`, `rds:ListTagsForResource` —
   only Describe actions that support resource-level scoping)
 
-## Console access: the `knr-ops-reader` IAM user
+## Console access: the `krops-reader` IAM user
 
 `mgmt/aws/infrastructure/aws-global-iam/reader-user.yaml` has the
 **management** cluster's ACK IAM controller create one IAM `User`
-(`knr-ops-reader`) whose only permission is `sts:AssumeRole` on
-`arn:aws:iam::*:role/knr-ops-*-reader` — it can see nothing directly and is
+(`krops-reader`) whose only permission is `sts:AssumeRole` on
+`arn:aws:iam::*:role/krops-*-reader` — it can see nothing directly and is
 just a doorway into the per-cluster reader roles above.
 
 The ACK IAM controller has no `LoginProfile` resource, so the console
@@ -65,22 +65,22 @@ password cannot be declared in Git. Set it **once** imperatively after the
 user has been reconciled:
 
 ```sh
-aws iam create-login-profile --user-name knr-ops-reader \
+aws iam create-login-profile --user-name krops-reader \
   --password '<initial-password>' --password-reset-required
 ```
 
 Then, to browse the repo-created resources in the AWS console:
 
 1. Sign in at `https://<account-id>.signin.aws.amazon.com/console` as
-   `knr-ops-reader` (you will be prompted to set a new password on first
+   `krops-reader` (you will be prompted to set a new password on first
    login).
 2. Use **Switch Role** (account menu, top right) with the account ID and role
-   name `knr-ops-eu-north-1-workload-reader` or
-   `knr-ops-eu-west-1-workload-reader` — or use the direct link:
+   name `krops-eu-north-1-workload-reader` or
+   `krops-eu-west-1-workload-reader` — or use the direct link:
 
    ```
-   https://signin.aws.amazon.com/switchrole?roleName=knr-ops-eu-north-1-workload-reader&account=<account-id>
+   https://signin.aws.amazon.com/switchrole?roleName=krops-eu-north-1-workload-reader&account=<account-id>
    ```
 
-3. Browse the `knr-ops-*` S3 buckets and RDS instances (switch the console
+3. Browse the `krops-*` S3 buckets and RDS instances (switch the console
    region to eu-north-1/eu-west-1 for the databases).

--- a/docs/aws-infra.svg
+++ b/docs/aws-infra.svg
@@ -12,7 +12,7 @@
   <rect width="1600" height="1150" fill="#0f0f0f"/>
 
   <!-- ===== title block ===== -->
-  <text x="800" y="60" text-anchor="middle" font-family="DejaVu Sans" font-size="40" font-weight="bold" fill="#ff78c9">knr-ops &#183; GitOps Architecture &#183; 1 Repo &#215; 2 Lifecycles</text>
+  <text x="800" y="60" text-anchor="middle" font-family="DejaVu Sans" font-size="40" font-weight="bold" fill="#ff78c9">krops &#183; GitOps Architecture &#183; 1 Repo &#215; 2 Lifecycles</text>
   <text x="800" y="96" text-anchor="middle" font-family="DejaVu Sans" font-size="19" fill="#8f8f8f">Flux + CAPI/CAPA + ACK &#183; the management plane provisions clusters &#183; workload planes reconcile apps</text>
 
   <!-- ===== section headers ===== -->
@@ -71,7 +71,7 @@
   <rect x="620" y="150" width="400" height="330" rx="14" fill="#131320" stroke="#3d3d55" stroke-width="1.5"/>
   <rect x="636" y="158" width="368" height="5" rx="2.5" fill="#ab9fd6"/>
   <text x="820" y="198" text-anchor="middle" font-family="DejaVu Sans" font-size="25" font-weight="bold" fill="#ab9fd6">Git Repository</text>
-  <text x="820" y="222" text-anchor="middle" font-family="DejaVu Sans" font-size="16" fill="#8f8f8f">(polarsquad/knr-ops)</text>
+  <text x="820" y="222" text-anchor="middle" font-family="DejaVu Sans" font-size="16" fill="#8f8f8f">(polarsquad/krops)</text>
   <!-- folder tree -->
   <g fill="none" stroke-width="1.7">
     <path d="M660,250 h9 l4,5 h15 v16 h-28 z" stroke="#85c7bb"/>

--- a/docs/bootstrap-cli.md
+++ b/docs/bootstrap-cli.md
@@ -1,6 +1,6 @@
-# The bootstrap CLI (`knr-bootstrap`)
+# The bootstrap CLI (`krops-bootstrap`)
 
-The imperative part of knr-ops lives in one Rust binary under
+The imperative part of krops lives in one Rust binary under
 [`bootstrap-rs/`](../bootstrap-rs/). It implements the initial bootstrap, the
 default CAPI pivot into the self-managed management cluster, and teardown.
 After bootstrap and pivot finish, Flux owns the declared state until teardown.
@@ -19,7 +19,7 @@ interface, and safety guards, with two deliberate upgrades:
 ## Distribution and build
 
 The primary distribution is the toolbox image,
-`ghcr.io/polarsquad/knr-ops-toolbox`. It contains `knr-bootstrap` and the
+`ghcr.io/polarsquad/krops-toolbox`. It contains `krops-bootstrap` and the
 pinned tools required by the lifecycle. See [Operations](./operations.md) for
 the container invocation and host runtime contract.
 
@@ -38,8 +38,8 @@ Build the CLI directly for native development:
 cd bootstrap-rs
 cargo build --locked
 cd ..
-./bootstrap-rs/target/debug/knr-bootstrap --help
-./bootstrap-rs/target/debug/knr-bootstrap teardown --help
+./bootstrap-rs/target/debug/krops-bootstrap --help
+./bootstrap-rs/target/debug/krops-bootstrap teardown --help
 ```
 
 Run the binary from the repository root so its default `./bootstrap.toml` path
@@ -52,25 +52,25 @@ crate dependencies are locked in `Cargo.lock`.
 ## Interface
 
 ```text
-knr-bootstrap [OPTIONS] [PROFILE] [COMMAND]
-knr-bootstrap teardown [PROFILE]
+krops-bootstrap [OPTIONS] [PROFILE] [COMMAND]
+krops-bootstrap teardown [PROFILE]
 ```
 
 Common examples:
 
 ```sh
-knr-bootstrap                         # aws bootstrap, then pivot
-knr-bootstrap local-host              # local-host bootstrap, then pivot
-knr-bootstrap --recreate local-host   # rebuild the bootstrap kind cluster
-knr-bootstrap teardown                # aws teardown
-knr-bootstrap teardown local-host     # local-host teardown
+krops-bootstrap                         # aws bootstrap, then pivot
+krops-bootstrap local-host              # local-host bootstrap, then pivot
+krops-bootstrap --recreate local-host   # rebuild the bootstrap kind cluster
+krops-bootstrap teardown                # aws teardown
+krops-bootstrap teardown local-host     # local-host teardown
 ```
 
 - `PROFILE` is the CLI's retained positional name. Its value names a section
   under `[environments.*]` in
   [`bootstrap.toml`](../bootstrap.toml). The checked-in environments are `aws`,
   `local-host`, and `local-talos`.
-- A non-empty `KNR_OPS_PROFILE` overrides the positional profile. If
+- A non-empty `KROPS_PROFILE` overrides the positional profile. If
   neither is set, `bootstrap.default-environment` from `bootstrap.toml` is
   used.
 - `--recreate` applies to bootstrap only. Teardown is a subcommand and keeps
@@ -96,7 +96,7 @@ pins together with their declarative counterparts. See
 | Variable | Default | Used by |
 |---|---|---|
 | `BOOTSTRAP_CONFIG` | `./bootstrap.toml` | Repository configuration path |
-| `KNR_OPS_PROFILE` | positional profile, then `bootstrap.default-environment` (`aws` checked in) | Environment selection |
+| `KROPS_PROFILE` | positional profile, then `bootstrap.default-environment` (`aws` checked in) | Environment selection |
 | `REGISTRY_PORT` | `5001` | Local-host registry host port |
 | `REGISTRY_READY_RETRIES` | `120` | Local-host registry readiness attempts |
 | `LOCAL_RECONCILE_TIMEOUT` | `15m` | Local-host management and workload reconciliation waits |
@@ -106,9 +106,9 @@ pins together with their declarative counterparts. See
 | `GITHUB_USER` | `git` | Basic-auth username paired with the PAT |
 | `AGE_KEY_FILE` | `age.agekey` | SOPS age private key loaded into `sops-age` |
 | `AGE_PUBLIC_KEY` | derived from `AGE_KEY_FILE` | Public key override during secret creation |
-| `OCI_REPOSITORY` / `OCI_TAG` | `knr-ops` / `latest` | Local-host OCI artifact name |
+| `OCI_REPOSITORY` / `OCI_TAG` | `krops` / `latest` | Local-host OCI artifact name |
 | `BOOTSTRAP_PIVOT` | `1` | Any value other than literal `1` skips pivot |
-| `MGMT_KUBECONFIG` | `~/.kube/knr-ops-mgmt.yaml` | Exported management kubeconfig for native runs |
+| `MGMT_KUBECONFIG` | `~/.kube/krops-mgmt.yaml` | Exported management kubeconfig for native runs |
 | `MGMT_READY_TIMEOUT` | `40m` for aws, `15m` for local-host, `30m` for local-talos (PXE install + first Talos boot) | Management cluster provisioning wait |
 | `MGMT_POLL_INTERVAL` | `10` seconds | Management cluster provisioning poll |
 | `BOOTSTRAP_KUBECONTEXT` | config value `kind-mgmt` | Source context required by pivot |
@@ -116,7 +116,7 @@ pins together with their declarative counterparts. See
 
 The toolbox runtime adds three contracts:
 
-- `KNR_TOOLBOX=1` enables internal kind networking and disables host-only CAPD
+- `KROPS_TOOLBOX=1` enables internal kind networking and disables host-only CAPD
   endpoint rewrites.
 - `ENGINE_SOCK` names the engine socket path as seen by the daemon. The wrapper
   resolves it for Docker Desktop, Docker contexts, rootful or rootless Podman,
@@ -124,9 +124,9 @@ The toolbox runtime adds three contracts:
 - `KUBECONFIG` must name one writable file, not a colon-separated list. The
   wrapper uses `/workspace/.kube/kind.yaml`.
 
-The container reaches the local registry at `knr-registry:5000`. Its
+The container reaches the local registry at `krops-registry:5000`. Its
 `/root/.kube` mount makes the management kubeconfig persist on the host as
-`./.kube/knr-ops-mgmt.yaml`. The wrapper's environment allowlist and override
+`./.kube/krops-mgmt.yaml`. The wrapper's environment allowlist and override
 limitations are documented in [Operations](./operations.md#toolbox-container-primary-interface).
 
 ## What bootstrap and pivot do
@@ -154,7 +154,7 @@ Recovery details and the warning against deleting moved CAPI objects are in
 ## Teardown controls and behavior
 
 ```sh
-knr-bootstrap teardown [PROFILE]
+krops-bootstrap teardown [PROFILE]
 ```
 
 | Variable | Default | Effect |
@@ -163,7 +163,7 @@ knr-bootstrap teardown [PROFILE]
 | `FORCE_KIND_DELETE` | `0` | Literal `1` removes the controller host even when CAPI cluster deletion was not confirmed |
 | `CLUSTER_DELETE_TIMEOUT` | `1200` seconds | CAPI cluster deletion wait (aws workloads, local-talos management) |
 | `PROVIDER_DELETE_TIMEOUT` | `300` seconds | CAPI provider deletion wait |
-| `MGMT_KUBECONFIG` | `~/.kube/knr-ops-mgmt.yaml` | Post-pivot controller-host kubeconfig |
+| `MGMT_KUBECONFIG` | `~/.kube/krops-mgmt.yaml` | Post-pivot controller-host kubeconfig |
 
 Teardown checks required tools before mutation:
 

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -20,7 +20,7 @@ Renovate discovers and updates versions in:
 - `bootstrap-rs/Cargo.toml` and `bootstrap-rs/Cargo.lock`: Rust crate
   dependencies through Renovate's Cargo manager.
 - `bootstrap.toml`: the Flux Operator, cert-manager, and CAPI Operator chart
-  pins consumed by `knr-bootstrap`. One annotation-driven custom manager reads
+  pins consumed by `krops-bootstrap`. One annotation-driven custom manager reads
   the adjacent `# renovate:` metadata. `mise run validate` cross-checks these
   pins against their declarative Helm releases and proxies.
 - `bootstrap-rs/Dockerfile`: digest-pinned build and runtime base images, plus
@@ -44,7 +44,7 @@ digest-pinned while retaining readable tags. Nothing automerges.
 
 ## Toolbox release version
 
-The `knr-bootstrap` package version lives in `bootstrap-rs/Cargo.toml`. It is a
+The `krops-bootstrap` package version lives in `bootstrap-rs/Cargo.toml`. It is a
 release version, not a dependency pin, so Renovate does not increment it. When
 a `v*` tag is pushed, `.github/workflows/toolbox-release.yml` fails unless the
 tag matches that package version, then publishes the multi-architecture
@@ -79,10 +79,10 @@ verify the pairing during review.
 - EKS addon versions (`*-eksbuild.*`) have no public registry datasource and
   are updated manually.
 - Unversioned local tags such as
-  `localhost:5001/knr-ops-airgap:latest` have no comparable release version
+  `localhost:5001/krops-airgap:latest` have no comparable release version
   and remain untracked.
 - `scripts/toolbox-run.sh` defaults `TOOLBOX_IMAGE` to the mutable
-  `ghcr.io/polarsquad/knr-ops-toolbox:latest`; Renovate does not manage this
+  `ghcr.io/polarsquad/krops-toolbox:latest`; Renovate does not manage this
   runtime default.
 - The toolbox Dockerfile installs `docker-ce-cli` from Docker's apt repository
   without a package-version pin. Its client version intentionally follows that

--- a/docs/konflate.md
+++ b/docs/konflate.md
@@ -35,7 +35,7 @@ A single instance runs on the **management cluster**, deployed from
 |---|---|
 | Chart | OCI artifact `oci://ghcr.io/home-operations/charts/konflate`, pinned tag (see `helm.yaml`) |
 | Namespace | `konflate` |
-| `config.repo` | `github://polarsquad/knr-ops` |
+| `config.repo` | `github://polarsquad/krops` |
 | `config.clusterPath` | `""` — render from the repo root, matching this repo's root-relative Flux Kustomization paths (`./mgmt/aws/...`, `./workload/...`) |
 | `config.prComments` | `true` — post the rendered summary as a PR comment |
 | `config.statusChecks` | `true` — post the `Konflate` commit status with the render verdict |

--- a/docs/krops-logo.svg
+++ b/docs/krops-logo.svg
@@ -4,7 +4,7 @@
      version="1.1"
      width="10in" height="9.07667in"
      viewBox="0 0 3000 2723">
-  <title>knr-ops-logo-color</title>
+  <title>krops-logo-color</title>
   <defs>
   </defs>
   <image id="raster0"

--- a/docs/local-host-infra.svg
+++ b/docs/local-host-infra.svg
@@ -15,7 +15,7 @@
   <rect width="1600" height="1150" fill="#0f0f0f"/>
 
   <!-- ===== title block ===== -->
-  <text x="800" y="60" text-anchor="middle" font-family="DejaVu Sans" font-size="40" font-weight="bold" fill="#ff78c9">knr-ops &#183; local-host Environment &#183; Same Chain, Zero Cloud</text>
+  <text x="800" y="60" text-anchor="middle" font-family="DejaVu Sans" font-size="40" font-weight="bold" fill="#ff78c9">krops &#183; local-host Environment &#183; Same Chain, Zero Cloud</text>
   <text x="800" y="96" text-anchor="middle" font-family="DejaVu Sans" font-size="19" fill="#8f8f8f">Flux + CAPI/CAPD &#183; local OCI registry replaces GitHub &#183; the full GitOps + CAPI lifecycle on one laptop</text>
 
   <!-- ===== section headers ===== -->
@@ -75,11 +75,11 @@
   <rect x="620" y="150" width="400" height="330" rx="14" fill="#131320" stroke="#3d3d55" stroke-width="1.5"/>
   <rect x="636" y="158" width="368" height="5" rx="2.5" fill="#ab9fd6"/>
   <text x="820" y="198" text-anchor="middle" font-family="DejaVu Sans" font-size="25" font-weight="bold" fill="#ab9fd6">Local OCI Registry</text>
-  <text x="820" y="222" text-anchor="middle" font-family="DejaVu Sans Mono" font-size="16" fill="#8f8f8f">knr-registry:5000</text>
+  <text x="820" y="222" text-anchor="middle" font-family="DejaVu Sans Mono" font-size="16" fill="#8f8f8f">krops-registry:5000</text>
   <!-- artifact box -->
   <rect x="652" y="244" width="336" height="60" rx="10" fill="#1d1d30" stroke="#ab9fd6" stroke-opacity="0.6" stroke-width="1.2"/>
-  <text x="820" y="269" text-anchor="middle" font-family="DejaVu Sans Mono" font-size="17" font-weight="bold" fill="#ab9fd6">oci://knr-registry:5000/knr-ops</text>
-  <text x="820" y="292" text-anchor="middle" font-family="DejaVu Sans Mono" font-size="15" fill="#d6d6d6">knr-ops:latest</text>
+  <text x="820" y="269" text-anchor="middle" font-family="DejaVu Sans Mono" font-size="17" font-weight="bold" fill="#ab9fd6">oci://krops-registry:5000/krops</text>
+  <text x="820" y="292" text-anchor="middle" font-family="DejaVu Sans Mono" font-size="15" fill="#d6d6d6">krops:latest</text>
   <!-- folder tree -->
   <g fill="none" stroke-width="1.7">
     <path d="M672,326 h9 l4,5 h15 v16 h-28 z" stroke="#85c7bb"/>
@@ -150,7 +150,7 @@
   <text x="1140" y="214" text-anchor="middle" font-family="DejaVu Sans" font-size="15" font-weight="bold" fill="#0f0f0f">1</text>
   <text x="1168" y="204" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">Toolbox creates kind + registry;</text>
   <text x="1168" y="230" font-family="DejaVu Sans Mono" font-size="15.5" fill="#ab9fd6">oci-push publishes mgmt/ and</text>
-  <text x="1168" y="256" font-family="DejaVu Sans Mono" font-size="15.5" fill="#ab9fd6">workload/ as knr-ops:latest.</text>
+  <text x="1168" y="256" font-family="DejaVu Sans Mono" font-size="15.5" fill="#ab9fd6">workload/ as krops:latest.</text>
   <text x="1168" y="282" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">No GitHub PAT, no AWS account.</text>
   <line x1="1122" y1="316" x2="1504" y2="316" stroke="#34344a" stroke-width="1.2"/>
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -4,8 +4,8 @@
 
 ### Toolbox container (primary interface)
 
-The toolbox image (`ghcr.io/polarsquad/knr-ops-toolbox`) carries
-`knr-bootstrap` plus every tool used by bootstrap, pivot, and teardown. It
+The toolbox image (`ghcr.io/polarsquad/krops-toolbox`) carries
+`krops-bootstrap` plus every tool used by bootstrap, pivot, and teardown. It
 intentionally omits development-only Go and Python toolchains and the Zarf CLI.
 The host needs the repository checkout and a running Docker engine or Podman
 5.5+.
@@ -17,8 +17,8 @@ GitHub OIDC, and attach a Syft SPDX JSON SBOM attestation. Build the current
 checkout locally:
 
 ```sh
-docker build -f bootstrap-rs/Dockerfile -t knr-ops-toolbox:dev .
-export TOOLBOX_IMAGE=knr-ops-toolbox:dev
+docker build -f bootstrap-rs/Dockerfile -t krops-toolbox:dev .
+export TOOLBOX_IMAGE=krops-toolbox:dev
 mkdir -p .kube
 ```
 
@@ -80,7 +80,7 @@ The same wrapper powers `mise run bootstrap`, `mise run pivot`, and
 `mise run teardown`. It detects the engine, loads every `.env` assignment with
 outer quote stripping, and passes only this allowlist into the container:
 
-- Engine and lifecycle: `CONTAINER_ENGINE`, `ENGINE_SOCK`, `KNR_OPS_PROFILE`,
+- Engine and lifecycle: `CONTAINER_ENGINE`, `ENGINE_SOCK`, `KROPS_PROFILE`,
   `REGISTRY_PORT`, `OCI_REPOSITORY`, `OCI_TAG`, `BOOTSTRAP_PIVOT`,
   `PIVOT_SKIP_DELETE`
 - GitHub and age: `GIT_REPO_URL`, `GITHUB_TOKEN`, `GITHUB_USER`, `AGE_KEY_FILE`,
@@ -98,19 +98,19 @@ not require host mise.
 
 Inside the toolbox:
 
-- The entrypoint sets `KNR_TOOLBOX=1` and resolves the daemon-side
+- The entrypoint sets `KROPS_TOOLBOX=1` and resolves the daemon-side
   `ENGINE_SOCK` used by kind's socket mount.
 - Each new toolbox container best-effort joins an existing `kind` network at
   startup. Bootstrap joins explicitly after creating kind; recreate, pivot, and
   teardown detach before deleting the bootstrap cluster.
-- Kind's internal API endpoint and `knr-registry:5000` then resolve by name.
+- Kind's internal API endpoint and `krops-registry:5000` then resolve by name.
 - Host-only CAPD endpoint rewrites are skipped because the recorded endpoints
   already resolve on that network.
 - `KUBECONFIG` must name one writable file. The documented invocation uses
   `/workspace/.kube/kind.yaml`, and the CLI replaces it with kind's internal
   kubeconfig after creation.
 - `/root/.kube` maps to the checkout's `.kube/`, so the exported management
-  kubeconfig persists on the host as `.kube/knr-ops-mgmt.yaml`.
+  kubeconfig persists on the host as `.kube/krops-mgmt.yaml`.
 
 ### Verifying a toolbox release
 
@@ -118,8 +118,8 @@ After the first release is published, replace `X.Y.Z` in these commands with
 the matching Cargo and Git tag version:
 
 ```sh
-IMAGE=ghcr.io/polarsquad/knr-ops-toolbox:X.Y.Z
-IDENTITY=https://github.com/polarsquad/knr-ops/.github/workflows/toolbox-release.yml@refs/tags/vX.Y.Z
+IMAGE=ghcr.io/polarsquad/krops-toolbox:X.Y.Z
+IDENTITY=https://github.com/polarsquad/krops/.github/workflows/toolbox-release.yml@refs/tags/vX.Y.Z
 
 cosign verify \
   --certificate-identity "$IDENTITY" \
@@ -151,7 +151,7 @@ requires a Rust
 toolchain ([rustup](https://rustup.rs/); the pin lives in
 `bootstrap-rs/rust-toolchain.toml`). The lifecycle mise tasks still use the
 toolbox. For a fully native run from the repository root, invoke
-`./bootstrap-rs/target/debug/knr-bootstrap` or call `./bootstrap.sh`,
+`./bootstrap-rs/target/debug/krops-bootstrap` or call `./bootstrap.sh`,
 `./pivot.sh`, and `./teardown.sh` directly.
 
 You also need:
@@ -169,13 +169,13 @@ You also need:
   For the ACK controllers the same principal additionally needs
   `iam:CreateRole`/`PutRolePolicy`/`GetRole`/`TagRole`,
   `iam:CreateUser`/`PutUserPolicy`/`GetUser`/`GetUserPolicy`/`TagUser`
-  (for the `knr-ops-reader` console user), and
+  (for the `krops-reader` console user), and
   `eks:CreatePodIdentityAssociation`/`DescribePodIdentityAssociation`/
   `DeletePodIdentityAssociation`. The `rds:*` management and
   `secretsmanager:CreateSecret`/`TagResource`/`RotateSecret` permissions
   (managed master passwords) used by the workload clusters' ACK RDS
   controllers are granted through the Git-declared
-  `knr-ops-ack-rds-controller` pod-identity role — no extra static
+  `krops-ack-rds-controller` pod-identity role — no extra static
   credentials are required for them.
 - The `clusterawsadm` IAM CloudFormation stack provisioned before bootstrap and
   removed by a full AWS teardown:
@@ -240,7 +240,7 @@ environment.
 
 Repository-owned lifecycle configuration lives in `bootstrap.toml`. It defines
 the environment names, sync paths, management clusters, imperative chart
-versions, provider manifests, and teardown targets. `knr-bootstrap` reads it
+versions, provider manifests, and teardown targets. `krops-bootstrap` reads it
 from the working directory unless `BOOTSTRAP_CONFIG` selects another path.
 Runtime environment variables take precedence over configurable defaults, and
 `mise run validate` cross-checks the file against the manifests.
@@ -275,7 +275,7 @@ steps in the `mgmt` management cluster, but does not create GitHub or SOPS
 secrets. Instead, it bootstraps a local Docker Registry container (`registry:2`)
 running on the host machine (accessible at `localhost:5001` by default),
 publishes the `mgmt/local-host/` and `workload/local-host/` folders as the
-initial `knr-ops:latest` OCI
+initial `krops:latest` OCI
 artifact, and configures Flux to reconcile that path from the artifact. Flux
 then installs the CAPI core, kubeadm, and Docker infrastructure providers and
 creates `local-workload`, a one-control-plane/one-worker Kubernetes cluster in
@@ -322,7 +322,7 @@ OCI_REPOSITORY=my-config OCI_TAG=v1 \
 
 # FluxInstance pulls and reconciles the artifact's mgmt/local-host kustomization.
 # The bootstrap configures kind's containerd to mirror localhost:5001 to the
-# registry's in-cluster endpoint, knr-registry:5000.
+# registry's in-cluster endpoint, krops-registry:5000.
 ```
 
 The artifact contains only `mgmt/local-host/` and `workload/local-host/`,
@@ -338,18 +338,18 @@ Watch reconciliation after a toolbox run with the persisted management
 kubeconfig:
 
 ```sh
-export KUBECONFIG="$PWD/.kube/knr-ops-mgmt.yaml"
+export KUBECONFIG="$PWD/.kube/krops-mgmt.yaml"
 flux get kustomizations --watch
 ```
 
 A native CLI or shell run writes the same context to
-`~/.kube/knr-ops-mgmt.yaml` unless `MGMT_KUBECONFIG` overrides it.
+`~/.kube/krops-mgmt.yaml` unless `MGMT_KUBECONFIG` overrides it.
 
 For the local-host environment, export and verify the CAPD workload kubeconfig
 after `docker-workload-cluster` reports Ready:
 
 ```sh
-export KUBECONFIG="$PWD/.kube/knr-ops-mgmt.yaml"  # toolbox management cluster
+export KUBECONFIG="$PWD/.kube/krops-mgmt.yaml"  # toolbox management cluster
 mise -E local-host run kubeconfigs
 KUBECONFIG=local-workload.kubeconfig kubectl get nodes
 ```
@@ -386,7 +386,7 @@ For the local-host end-to-end chain:
 
 ```sh
 mise -E local-host run bootstrap
-export KUBECONFIG="$PWD/.kube/knr-ops-mgmt.yaml"
+export KUBECONFIG="$PWD/.kube/krops-mgmt.yaml"
 mise -E local-host run kubeconfigs
 KUBECONFIG=local-workload.kubeconfig flux get all --all-namespaces
 mise -E local-host run podinfo-port-forward  # browse to http://localhost:9898
@@ -400,20 +400,20 @@ For the AWS chain:
 
 ```sh
 # Management cluster after a toolbox run
-export KUBECONFIG="$PWD/.kube/knr-ops-mgmt.yaml"
+export KUBECONFIG="$PWD/.kube/krops-mgmt.yaml"
 kubectl get kustomizations -n flux-system            # all Ready
 kubectl get clusters.cluster.x-k8s.io -A             # Provisioned
 kubectl get roles.iam.services.k8s.aws -n ack-system
 kubectl get podidentityassociations.eks.services.k8s.aws -n ack-system
 
 # Workload clusters: export kubeconfigs first
-#   mise -E aws run kubeconfigs && export KUBECONFIG=~/.kube/knr-ops-workloads.yaml
+#   mise -E aws run kubeconfigs && export KUBECONFIG=~/.kube/krops-workloads.yaml
 #   kubectl config use-context eu-north-1-workload   (or eu-west-1-workload)
 kubectl get kustomizations -n flux-system            # aws-operators, s3-buckets, rds-instances, iam-roles
 
 # AWS
-aws s3api get-bucket-encryption    --bucket knr-ops-<account>-eu-north-1-workload-data
-aws s3api get-public-access-block  --bucket knr-ops-<account>-eu-north-1-workload-data
+aws s3api get-bucket-encryption    --bucket krops-<account>-eu-north-1-workload-data
+aws s3api get-public-access-block  --bucket krops-<account>-eu-north-1-workload-data
 ```
 
 ## Pivot recovery
@@ -447,9 +447,9 @@ until the final kind deletion. If a pivot phase fails:
 > to delete.
 
 The management kubeconfig is written to `MGMT_KUBECONFIG`, with context
-`knr-ops-mgmt`. Native runs default to `~/.kube/knr-ops-mgmt.yaml`; the toolbox
-mount makes its `/root/.kube/knr-ops-mgmt.yaml` appear on the host as
-`./.kube/knr-ops-mgmt.yaml`.
+`krops-mgmt`. Native runs default to `~/.kube/krops-mgmt.yaml`; the toolbox
+mount makes its `/root/.kube/krops-mgmt.yaml` appear on the host as
+`./.kube/krops-mgmt.yaml`.
 
 ## Teardown
 
@@ -461,7 +461,7 @@ mise -E local-host run teardown   # local-host
 mise -E local-talos run teardown  # local-talos
 ```
 
-Native equivalents are `knr-bootstrap teardown [PROFILE]` and the retained
+Native equivalents are `krops-bootstrap teardown [PROFILE]` and the retained
 `./teardown.sh` reference path. The positional profile selects an environment
 from `bootstrap.toml`. Teardown reads resource names and targets from
 `bootstrap.toml` and discovers where the CAPI controllers are running:
@@ -479,7 +479,7 @@ The main controls keep the shell interface:
 | `FORCE_KIND_DELETE` | `0` | Literal `1` overrides the final controller-host deletion guard |
 | `CLUSTER_DELETE_TIMEOUT` | `1200` seconds | CAPI cluster deletion wait (aws workloads, local-talos management) |
 | `PROVIDER_DELETE_TIMEOUT` | `300` seconds | CAPI provider deletion wait |
-| `MGMT_KUBECONFIG` | native: `~/.kube/knr-ops-mgmt.yaml` | Post-pivot controller-host kubeconfig |
+| `MGMT_KUBECONFIG` | native: `~/.kube/krops-mgmt.yaml` | Post-pivot controller-host kubeconfig |
 
 The hard preflight depends on the mode:
 
@@ -497,7 +497,7 @@ with explicit `-e` entries or a native run for recovery overrides.
 For `local-host`, teardown suspends the workload Kustomization, deletes the
 CAPD workload cluster, waits for its containers to disappear, removes either
 the pre-pivot kind cluster or the post-pivot self-managed management
-containers, and removes `knr-registry` last.
+containers, and removes `krops-registry` last.
 
 For `local-talos`, teardown suspends Flux and deletes every CAPI Cluster,
 the management cluster included: the deletion IS the release, and CAPT
@@ -513,7 +513,7 @@ controller host. It then runs a best-effort AWS sweep for both workload
 regions and the self-managed management cluster. The sweep removes pod
 identity associations, nodegroups, EKS control planes, orphaned RDS instances,
 CAPA-tagged VPC resources in dependency order, versioned S3 buckets, CAPA and
-ACK IAM roles, the `knr-ops-reader` user, and the `clusterawsadm`
+ACK IAM roles, the `krops-reader` user, and the `clusterawsadm`
 CloudFormation stack. It removes CAPI providers and bootstrap Helm releases
 when the controller host remains reachable.
 

--- a/docs/workload-resources.md
+++ b/docs/workload-resources.md
@@ -7,7 +7,7 @@ see [AWS authentication & IAM](./aws-iam.md).
 ## Bucket security posture
 
 `workload/base/s3-buckets/bucket.yaml` creates one bucket per cluster
-(`knr-ops-<account>-<cluster>-data`) with:
+(`krops-<account>-<cluster>-data`) with:
 
 - all public access blocked
 - server-side encryption enforced (SSE-S3/AES256, bucket keys)
@@ -18,7 +18,7 @@ see [AWS authentication & IAM](./aws-iam.md).
 ## RDS instances
 
 `workload/base/rds-instances/dbinstance.yaml` creates one PostgreSQL 17 instance
-per cluster (`knr-ops-<cluster>-db`) in that cluster's own region — the ACK
+per cluster (`krops-<cluster>-db`) in that cluster's own region — the ACK
 RDS controller runs with `aws.region: ${AWS_REGION}`:
 
 - `db.t4g.micro`, 20 GiB gp3, single-AZ (smallest footprint)

--- a/mgmt/aws/addons/flux-apps/flux-instance.yaml
+++ b/mgmt/aws/addons/flux-apps/flux-instance.yaml
@@ -59,7 +59,7 @@ data:
         domain: "cluster.local"
       sync:
         kind: GitRepository
-        url: "https://github.com/polarsquad/knr-ops"
+        url: "https://github.com/polarsquad/krops"
         ref: "refs/heads/main"
         path: "workload/eu-north-01"
         pullSecret: "flux-github-pat"
@@ -112,7 +112,7 @@ data:
         domain: "cluster.local"
       sync:
         kind: GitRepository
-        url: "https://github.com/polarsquad/knr-ops"
+        url: "https://github.com/polarsquad/krops"
         ref: "refs/heads/main"
         path: "workload/eu-west-01"
         pullSecret: "flux-github-pat"

--- a/mgmt/aws/infrastructure/ack-pod-identity/iam-role.yaml
+++ b/mgmt/aws/infrastructure/ack-pod-identity/iam-role.yaml
@@ -6,10 +6,10 @@
 # Same static pods.eks.amazonaws.com trust policy as the S3 and RDS roles,
 # fully declarable in Git ahead of cluster creation.
 #
-# Permissions are scoped to management of knr-ops-* roles only. Known
+# Permissions are scoped to management of krops-* roles only. Known
 # trade-off: name-scoped iam:CreateRole + iam:PutRolePolicy is still a
 # privilege-escalation surface — the controller can grant ANY permission to a
-# role, as long as the role is named knr-ops-*. Consistent with the pragmatic
+# role, as long as the role is named krops-*. Consistent with the pragmatic
 # name-based scoping used by the other ACK controller roles in this file's
 # directory.
 # ══════════════════════════════════════════════════════════════════════════════
@@ -19,8 +19,8 @@ metadata:
   name: ack-iam-controller
   namespace: ack-system
 spec:
-  name: knr-ops-ack-iam-controller
-  description: "ACK IAM controller on knr-ops workload clusters (EKS Pod Identity)"
+  name: krops-ack-iam-controller
+  description: "ACK IAM controller on krops workload clusters (EKS Pod Identity)"
   assumeRolePolicyDocument: |
     {
       "Version": "2012-10-17",
@@ -38,7 +38,7 @@ spec:
         "Version": "2012-10-17",
         "Statement": [
           {
-            "Sid": "ManageKnrOpsRoles",
+            "Sid": "ManageKropsRoles",
             "Effect": "Allow",
             "Action": [
               "iam:CreateRole",
@@ -57,7 +57,7 @@ spec:
               "iam:UntagRole",
               "iam:ListRoleTags"
             ],
-            "Resource": "arn:aws:iam::*:role/knr-ops-*"
+            "Resource": "arn:aws:iam::*:role/krops-*"
           }
         ]
       }

--- a/mgmt/aws/infrastructure/ack-pod-identity/pod-identity-associations.yaml
+++ b/mgmt/aws/infrastructure/ack-pod-identity/pod-identity-associations.yaml
@@ -1,7 +1,7 @@
 ---
 # ══════════════════════════════════════════════════════════════════════════════
 # EKS Pod Identity associations: bind each ACK controller ServiceAccount on
-# each workload cluster to its knr-ops-ack-* IAM role (S3, RDS, and IAM).
+# each workload cluster to its krops-ack-* IAM role (S3, RDS, and IAM).
 #
 # Reconciled by the ACK EKS controller on this (management) cluster. The
 # association can only be created once the EKS cluster exists — ACK retries

--- a/mgmt/aws/infrastructure/ack-pod-identity/rds-role.yaml
+++ b/mgmt/aws/infrastructure/ack-pod-identity/rds-role.yaml
@@ -6,7 +6,7 @@
 # Same static pods.eks.amazonaws.com trust policy as the S3 role (role.yaml),
 # fully declarable in Git ahead of cluster creation.
 #
-# Permissions are scoped to management of knr-ops-* RDS resources, with three
+# Permissions are scoped to management of krops-* RDS resources, with three
 # additions required by the DBInstance spec we deploy:
 #   - secretsmanager on secret:rds!* — manageMasterUserPassword makes RDS
 #     create and rotate the master password secret on the caller's behalf
@@ -25,8 +25,8 @@ metadata:
   name: ack-rds-controller
   namespace: ack-system
 spec:
-  name: knr-ops-ack-rds-controller
-  description: "ACK RDS controller on knr-ops workload clusters (EKS Pod Identity)"
+  name: krops-ack-rds-controller
+  description: "ACK RDS controller on krops workload clusters (EKS Pod Identity)"
   assumeRolePolicyDocument: |
     {
       "Version": "2012-10-17",
@@ -50,7 +50,7 @@ spec:
             "Resource": "*"
           },
           {
-            "Sid": "ManageKnrOpsInstances",
+            "Sid": "ManageKropsInstances",
             "Effect": "Allow",
             "Action": [
               "rds:CreateDBInstance",
@@ -62,7 +62,7 @@ spec:
               "rds:AddTagsToResource",
               "rds:RemoveTagsFromResource"
             ],
-            "Resource": "arn:aws:rds:*:*:*:knr-ops-*"
+            "Resource": "arn:aws:rds:*:*:*:krops-*"
           },
           {
             "Sid": "ManagedMasterPasswordSecrets",

--- a/mgmt/aws/infrastructure/ack-pod-identity/role.yaml
+++ b/mgmt/aws/infrastructure/ack-pod-identity/role.yaml
@@ -7,7 +7,7 @@
 # IRSA it does not embed a per-cluster OIDC provider ID, which is what makes
 # this approach fully declarable in Git ahead of cluster creation.
 #
-# Permissions are scoped to bucket-level management of knr-ops-* buckets only.
+# Permissions are scoped to bucket-level management of krops-* buckets only.
 # ══════════════════════════════════════════════════════════════════════════════
 apiVersion: iam.services.k8s.aws/v1alpha1
 kind: Role
@@ -15,8 +15,8 @@ metadata:
   name: ack-s3-controller
   namespace: ack-system
 spec:
-  name: knr-ops-ack-s3-controller
-  description: "ACK S3 controller on knr-ops workload clusters (EKS Pod Identity)"
+  name: krops-ack-s3-controller
+  description: "ACK S3 controller on krops workload clusters (EKS Pod Identity)"
   assumeRolePolicyDocument: |
     {
       "Version": "2012-10-17",
@@ -66,7 +66,7 @@ spec:
               "s3:PutIntelligentTieringConfiguration",
               "s3:ListBucket"
             ],
-            "Resource": "arn:aws:s3:::knr-ops-*"
+            "Resource": "arn:aws:s3:::krops-*"
           }
         ]
       }

--- a/mgmt/aws/infrastructure/aws-global-iam/reader-user.yaml
+++ b/mgmt/aws/infrastructure/aws-global-iam/reader-user.yaml
@@ -1,11 +1,11 @@
 ---
 # ══════════════════════════════════════════════════════════════════════════════
 # IAM user for humans: log into the AWS console and assume the per-cluster
-# read-only reader roles (knr-ops-<cluster>-reader, see
+# read-only reader roles (krops-<cluster>-reader, see
 # workload/base/iam-roles/role.yaml) to view the resources this repo creates.
 # Reconciled by the ACK IAM controller on this (management) cluster.
 #
-# The only permission is sts:AssumeRole on knr-ops-*-reader roles — the user
+# The only permission is sts:AssumeRole on krops-*-reader roles — the user
 # can see nothing directly; everything goes through a reader role. The account
 # ID is wildcarded because ${AWS_ACCOUNT_ID} substitution is not available on
 # the management cluster (no cluster-vars ConfigMap here), same as the role
@@ -15,7 +15,7 @@
 # LoginProfile resource in the ACK IAM controller). After the user is
 # reconciled, set the console password ONCE imperatively:
 #
-#   aws iam create-login-profile --user-name knr-ops-reader \
+#   aws iam create-login-profile --user-name krops-reader \
 #     --password '<initial-password>' --password-reset-required
 #
 # See the "Console access" section in docs/aws-iam.md.
@@ -26,17 +26,17 @@ metadata:
   name: reader-user
   namespace: ack-system
 spec:
-  name: knr-ops-reader
+  name: krops-reader
   inlinePolicies:
-    assume-knr-ops-reader-roles: |
+    assume-krops-reader-roles: |
       {
         "Version": "2012-10-17",
         "Statement": [
           {
-            "Sid": "AssumeKnrOpsReaderRoles",
+            "Sid": "AssumeKropsReaderRoles",
             "Effect": "Allow",
             "Action": "sts:AssumeRole",
-            "Resource": "arn:aws:iam::*:role/knr-ops-*-reader"
+            "Resource": "arn:aws:iam::*:role/krops-*-reader"
           }
         ]
       }

--- a/mgmt/aws/infrastructure/konflate/helm.yaml
+++ b/mgmt/aws/infrastructure/konflate/helm.yaml
@@ -4,7 +4,7 @@
 #
 # Reviews this repo's open PRs as RENDERED Flux diffs (blast radius, image
 # changes, render failures, danger lint) instead of raw file diffs. A single
-# instance on the MANAGEMENT cluster tracks github://polarsquad/knr-ops and
+# instance on the MANAGEMENT cluster tracks github://polarsquad/krops and
 # renders from the repo root, which is where every Flux Kustomization path in
 # this repo (./mgmt/aws/..., ./workload/...) resolves against.
 #
@@ -55,7 +55,7 @@ spec:
   values:
     config:
       # Forge URI of the repository to review.
-      repo: github://polarsquad/knr-ops
+      repo: github://polarsquad/krops
       # Empty cluster path = render from the repo root, matching this repo's
       # root-relative Flux Kustomization paths.
       clusterPath: ""

--- a/mgmt/local-host/addons/cni/kindnet.yaml
+++ b/mgmt/local-host/addons/cni/kindnet.yaml
@@ -123,7 +123,7 @@ metadata:
 spec:
   clusterSelector:
     matchLabels:
-      knr-ops.polarsquad.com/environment: local-host
+      krops.polarsquad.com/environment: local-host
   strategy: ApplyOnce
   resources:
     - kind: ConfigMap

--- a/mgmt/local-host/addons/flux-apps/flux-instance.yaml
+++ b/mgmt/local-host/addons/flux-apps/flux-instance.yaml
@@ -36,7 +36,7 @@ data:
         domain: cluster.local
       sync:
         kind: OCIRepository
-        url: oci://knr-registry:5000/knr-ops
+        url: oci://krops-registry:5000/krops
         ref: latest
         path: workload/local-host
       kustomize:
@@ -57,7 +57,7 @@ spec:
   clusterSelector:
     matchLabels:
       fluxcd: enabled
-      knr-ops.polarsquad.com/environment: local-host
+      krops.polarsquad.com/environment: local-host
   strategy: ApplyOnce
   resources:
     - kind: ConfigMap

--- a/mgmt/local-host/addons/flux-apps/flux-operator.yaml
+++ b/mgmt/local-host/addons/flux-apps/flux-operator.yaml
@@ -7,7 +7,7 @@ spec:
   clusterSelector:
     matchLabels:
       fluxcd: enabled
-      knr-ops.polarsquad.com/environment: local-host
+      krops.polarsquad.com/environment: local-host
   repoURL: oci://ghcr.io/controlplaneio-fluxcd/charts
   chartName: flux-operator
   version: "0.58.0"

--- a/mgmt/local-host/clusters/docker/cluster-class.yaml
+++ b/mgmt/local-host/clusters/docker/cluster-class.yaml
@@ -81,7 +81,7 @@ spec:
     spec:
       backend:
         docker:
-          customImage: kindest/node:v1.37.0
+          customImage: kindest/node:v1.37.0@sha256:a1ed56cfb0e7b93589bdf97c8cd566405a265939e3620fc4f5de89adff580ae5
           extraMounts:
             - hostPath: /var/run/docker.sock
               containerPath: /var/run/docker.sock
@@ -96,7 +96,7 @@ spec:
     spec:
       backend:
         docker:
-          customImage: kindest/node:v1.37.0
+          customImage: kindest/node:v1.37.0@sha256:a1ed56cfb0e7b93589bdf97c8cd566405a265939e3620fc4f5de89adff580ae5
           extraMounts:
             - hostPath: /var/run/docker.sock
               containerPath: /var/run/docker.sock

--- a/mgmt/local-host/clusters/docker/cluster.yaml
+++ b/mgmt/local-host/clusters/docker/cluster.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: default
   labels:
     fluxcd: enabled
-    knr-ops.polarsquad.com/environment: local-host
+    krops.polarsquad.com/environment: local-host
 spec:
   clusterNetwork:
     pods:

--- a/mgmt/local-host/clusters/management/cluster-class.yaml
+++ b/mgmt/local-host/clusters/management/cluster-class.yaml
@@ -86,7 +86,7 @@ spec:
     spec:
       backend:
         docker:
-          customImage: kindest/node:v1.37.0
+          customImage: kindest/node:v1.37.0@sha256:a1ed56cfb0e7b93589bdf97c8cd566405a265939e3620fc4f5de89adff580ae5
           extraMounts:
             - hostPath: /var/run/docker.sock
               containerPath: /var/run/docker.sock
@@ -101,7 +101,7 @@ spec:
     spec:
       backend:
         docker:
-          customImage: kindest/node:v1.37.0
+          customImage: kindest/node:v1.37.0@sha256:a1ed56cfb0e7b93589bdf97c8cd566405a265939e3620fc4f5de89adff580ae5
           extraMounts:
             - hostPath: /var/run/docker.sock
               containerPath: /var/run/docker.sock

--- a/mgmt/local-host/clusters/management/cluster-class.yaml
+++ b/mgmt/local-host/clusters/management/cluster-class.yaml
@@ -34,7 +34,7 @@ spec:
             name: docker-management-worker
 ---
 # NOTE: CAPD places every node/lb container on the docker network "kind" by
-# default (no API field for it). That is load-bearing here: knr-registry is
+# default (no API field for it). That is load-bearing here: krops-registry is
 # attached to the same network, so nodes can pull the OCI artifact that Flux
 # syncs mgmt/local-host from, and the network survives `kind delete cluster`
 # because the registry stays attached.

--- a/mgmt/local-host/clusters/management/cluster.yaml
+++ b/mgmt/local-host/clusters/management/cluster.yaml
@@ -8,7 +8,7 @@ metadata:
     # CNI (CAPD clusters ship none). Deliberately NOT `fluxcd: enabled`: that
     # label would make the local-workload-flux-instance ClusterResourceSet
     # deploy a workload FluxInstance into the management cluster.
-    knr-ops.polarsquad.com/environment: local-host
+    krops.polarsquad.com/environment: local-host
 spec:
   clusterNetwork:
     pods:

--- a/mgmt/local-talos/clusters/flux-ks.yaml
+++ b/mgmt/local-talos/clusters/flux-ks.yaml
@@ -1,5 +1,5 @@
 # The Talos management cluster: created by CAPT in the kind bootstrap
-# cluster, moved into itself by `clusterctl move` (knr-bootstrap pivot), and
+# cluster, moved into itself by `clusterctl move` (krops-bootstrap pivot), and
 # from then on reconciled from GitHub by the Flux instance running inside it.
 # Health check gates on the Cluster's Available condition (v1beta2 serves
 # Available, not Ready).

--- a/mgmt/local-talos/clusters/management/cluster.yaml
+++ b/mgmt/local-talos/clusters/management/cluster.yaml
@@ -23,7 +23,7 @@ metadata:
   name: local-talos-management
   namespace: default
   labels:
-    knr-ops.polarsquad.com/environment: local-talos
+    krops.polarsquad.com/environment: local-talos
 spec:
   clusterNetwork:
     pods:

--- a/mgmt/local-talos/kustomization.yaml
+++ b/mgmt/local-talos/kustomization.yaml
@@ -3,13 +3,13 @@ kind: Kustomization
 # Root of the local-talos GitHub-synced tree: each entry registers Flux
 # Kustomizations reconciling the corresponding component from the
 # GitRepository source (like mgmt/aws, NOT the laptop OCI registry:
-# a physical machine cannot reach the laptop-hosted knr-registry).
+# a physical machine cannot reach the laptop-hosted krops-registry).
 #
 # Deliberately absent vs local-host:
 # - addons/cni: CNI on Talos is built in (flannel default).
 # - addons/flux-apps + caaph-system: no HelmChartProxy consumers — this
 #   environment is management-only (#105 scope fence); the management
-#   cluster's own Flux instance is seeded by knr-bootstrap, not by Git.
+#   cluster's own Flux instance is seeded by krops-bootstrap, not by Git.
 #   A future Talos workload cluster issue adds both back.
 resources:
   - infrastructure/flux-ks.yaml

--- a/mise.aws.toml
+++ b/mise.aws.toml
@@ -1,5 +1,5 @@
 [env]
-KNR_OPS_PROFILE = "aws"
+KROPS_PROFILE = "aws"
 
 [tools]
 aws-cli = "2.36.32"
@@ -10,9 +10,9 @@ description = "Provision the clusterawsadm IAM CloudFormation stack for CAPA"
 run = "clusterawsadm bootstrap iam create-cloudformation-stack --region ${AWS_REGION:-eu-north-1}"
 
 [tasks.kubeconfigs]
-description = "Export workload-cluster kubeconfigs to ~/.kube/knr-ops-workloads.yaml (use: export KUBECONFIG=~/.kube/knr-ops-workloads.yaml)"
+description = "Export workload-cluster kubeconfigs to ~/.kube/krops-workloads.yaml (use: export KUBECONFIG=~/.kube/krops-workloads.yaml)"
 run = '''
-KUBECONFIG_FILE="${KUBECONFIG_FILE:-$HOME/.kube/knr-ops-workloads.yaml}"
+KUBECONFIG_FILE="${KUBECONFIG_FILE:-$HOME/.kube/krops-workloads.yaml}"
 fail=0
 # Regions are discovered from the cluster definitions in Git.
 for region in $(find mgmt/aws/clusters -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | sort); do

--- a/mise.local-host.toml
+++ b/mise.local-host.toml
@@ -1,5 +1,5 @@
 [env]
-KNR_OPS_PROFILE = "local-host"
+KROPS_PROFILE = "local-host"
 
 [tasks.oci-push]
 description = "Package the local Git checkout as an OCI artifact and push it to the local registry"
@@ -10,9 +10,9 @@ cd "$REPO_ROOT"
 
 REGISTRY_PORT="${REGISTRY_PORT:-5001}"
 # Toolbox runs reach the registry by kind-network name (the CLI exports
-# REGISTRY_HOST=knr-registry there); host runs default to localhost.
+# REGISTRY_HOST=krops-registry there); host runs default to localhost.
 REGISTRY_HOST="${REGISTRY_HOST:-localhost}"
-OCI_REPOSITORY="${OCI_REPOSITORY:-knr-ops}"
+OCI_REPOSITORY="${OCI_REPOSITORY:-krops}"
 OCI_TAG="${OCI_TAG:-latest}"
 OCI_URL="oci://${REGISTRY_HOST}:${REGISTRY_PORT}/${OCI_REPOSITORY}:${OCI_TAG}"
 OCI_MGMT_SOURCE_PATH="mgmt/local-host"
@@ -37,7 +37,7 @@ GIT_REF="${GIT_REF:-detached}"
 SOURCE_URL=$(git config --get remote.origin.url || true)
 SOURCE_URL="${SOURCE_URL:-file://${REPO_ROOT}}"
 
-ARTIFACT_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/knr-ops-oci.XXXXXX")
+ARTIFACT_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/krops-oci.XXXXXX")
 cleanup_artifact_root() {
   rm -rf "$ARTIFACT_ROOT"
 }

--- a/mise.local-talos.toml
+++ b/mise.local-talos.toml
@@ -7,7 +7,7 @@
 # committed in mgmt/local-talos/clusters/management/cluster.yaml.
 
 [env]
-KNR_OPS_PROFILE = "local-talos"
+KROPS_PROFILE = "local-talos"
 
 [tools]
 talosctl = "1.14.0"
@@ -16,12 +16,12 @@ talosctl = "1.14.0"
 description = "Export the Talos management-cluster kubeconfig (no rewrite: the machine is remote)"
 run = '''
 MGMT_CLUSTER="${MGMT_CLUSTER:-local-talos-management}"
-MGMT_KUBECONFIG="${MGMT_KUBECONFIG:-$HOME/.kube/knr-ops-mgmt.yaml}"
+MGMT_KUBECONFIG="${MGMT_KUBECONFIG:-$HOME/.kube/krops-mgmt.yaml}"
 clusterctl get kubeconfig "$MGMT_CLUSTER" -n default > "$MGMT_KUBECONFIG"
 chmod 600 "$MGMT_KUBECONFIG"
 kubectl --kubeconfig "$MGMT_KUBECONFIG" config rename-context \
   "$(kubectl --kubeconfig "$MGMT_KUBECONFIG" config current-context)" \
-  knr-ops-mgmt >/dev/null
+  krops-mgmt >/dev/null
 echo "Wrote ${MGMT_KUBECONFIG}"
 echo "Use with: KUBECONFIG=${MGMT_KUBECONFIG} kubectl get nodes"
 '''

--- a/mise.toml
+++ b/mise.toml
@@ -93,13 +93,13 @@ description = "Pivot the management cluster from local kind to the CAPI-managed 
 run = "scripts/toolbox-run.sh pivot"
 
 [tasks.mgmt-kubeconfig]
-description = "Export the management-cluster kubeconfig to ~/.kube/knr-ops-mgmt.yaml"
+description = "Export the management-cluster kubeconfig to ~/.kube/krops-mgmt.yaml"
 run = '''
-MGMT_CLUSTER="${MGMT_CLUSTER:-$(case "${KNR_OPS_PROFILE:-aws}" in local-host) echo local-management;; local-talos) echo local-talos-management;; *) echo eu-north-1-management;; esac)}"
-MGMT_KUBECONFIG="${MGMT_KUBECONFIG:-$HOME/.kube/knr-ops-mgmt.yaml}"
+MGMT_CLUSTER="${MGMT_CLUSTER:-$(case "${KROPS_PROFILE:-aws}" in local-host) echo local-management;; local-talos) echo local-talos-management;; *) echo eu-north-1-management;; esac)}"
+MGMT_KUBECONFIG="${MGMT_KUBECONFIG:-$HOME/.kube/krops-mgmt.yaml}"
 clusterctl get kubeconfig "$MGMT_CLUSTER" -n default > "$MGMT_KUBECONFIG"
 chmod 600 "$MGMT_KUBECONFIG"
-if [ "${KNR_OPS_PROFILE:-aws}" = local-host ]; then
+if [ "${KROPS_PROFILE:-aws}" = local-host ]; then
   # CAPD records the load balancer's container-network IP, which is not
   # routable from macOS. Point at the port published on localhost instead.
   engine="${CONTAINER_ENGINE:-docker}"
@@ -117,7 +117,7 @@ if [ "${KNR_OPS_PROFILE:-aws}" = local-host ]; then
 fi
 kubectl --kubeconfig "$MGMT_KUBECONFIG" config rename-context \
   "$(kubectl --kubeconfig "$MGMT_KUBECONFIG" config current-context)" \
-  knr-ops-mgmt >/dev/null
+  krops-mgmt >/dev/null
 echo "Wrote ${MGMT_KUBECONFIG}"
 echo "Use with: KUBECONFIG=${MGMT_KUBECONFIG} kubectl get clusters"
 '''

--- a/pivot.sh
+++ b/pivot.sh
@@ -15,7 +15,7 @@
 #   6. deletes the kind bootstrap cluster.
 #
 # Run from a checkout of the revision you want self-managed (normally main):
-#   mise run pivot                  # aws environment (KNR_OPS_PROFILE=aws)
+#   mise run pivot                  # aws environment (KROPS_PROFILE=aws)
 #   mise -E local-host run pivot    # local-host environment
 #
 # bootstrap.sh execs this script by default (BOOTSTRAP_PIVOT=0 opts out).
@@ -32,12 +32,12 @@ cd "$(dirname "$0")"
 
 source ./bootstrap-common.sh
 
-PROFILE="${KNR_OPS_PROFILE:-${1:-aws}}"
+PROFILE="${KROPS_PROFILE:-${1:-aws}}"
 GIT_BRANCH="${GIT_BRANCH:-main}"
-REGISTRY_NAME="${REGISTRY_NAME:-knr-registry}"
+REGISTRY_NAME="${REGISTRY_NAME:-krops-registry}"
 REGISTRY_PORT="${REGISTRY_PORT:-5001}"
 MGMT_NS="default"
-MGMT_KUBECONFIG="${MGMT_KUBECONFIG:-$HOME/.kube/knr-ops-mgmt.yaml}"
+MGMT_KUBECONFIG="${MGMT_KUBECONFIG:-$HOME/.kube/krops-mgmt.yaml}"
 PIVOT_SKIP_DELETE="${PIVOT_SKIP_DELETE:-0}"
 
 # Chart versions installed imperatively in the target before Flux exists.
@@ -156,7 +156,7 @@ export_mgmt_kubeconfig() {
 
   kubectl --kubeconfig "$MGMT_KUBECONFIG" config rename-context \
     "$(kubectl --kubeconfig "$MGMT_KUBECONFIG" config current-context)" \
-    knr-ops-mgmt >/dev/null
+    krops-mgmt >/dev/null
 
   echo ">>> Waiting for management-cluster nodes to be ready..."
   kubectl --kubeconfig "$MGMT_KUBECONFIG" wait --for=condition=Ready node --all --timeout=15m
@@ -347,8 +347,8 @@ delete_bootstrap_cluster() {
   echo ">>> Pivot complete: the management cluster is self-managed."
   echo ">>> Management kubeconfig: ${MGMT_KUBECONFIG}"
   echo ">>> Use with: KUBECONFIG=${MGMT_KUBECONFIG} kubectl get clusters"
-  if kubectl config use-context knr-ops-mgmt >/dev/null 2>&1; then
-    echo ">>> kubectl context switched to knr-ops-mgmt"
+  if kubectl config use-context krops-mgmt >/dev/null 2>&1; then
+    echo ">>> kubectl context switched to krops-mgmt"
   else
     echo ">>> To use it by default: export KUBECONFIG=${MGMT_KUBECONFIG}"
   fi

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,5 +1,5 @@
 {
-  // Renovate config for knr-ops (issue #74).
+  // Renovate config for krops (issue #74).
   // Runs via the hosted Renovate GitHub App (issue #90).
   // Version sources covered:
   //   - Flux / Helm / Kubernetes manifests under mgmt/ and workload/
@@ -357,7 +357,7 @@
     },
     // EKS addon versions (*-eksbuild.*) intentionally not managed: they have
     // no public registry datasource. Tracked in issue #74 as manual updates.
-    // The locally built localhost:5001/knr-ops-airgap:latest artifact is
+    // The locally built localhost:5001/krops-airgap:latest artifact is
     // extracted but intentionally disabled by the scoped packageRule below.
     // ── end customManagers ────────────────────────────────────────────────
   ],
@@ -375,7 +375,7 @@
     {
       "description": "Do not resolve the air-gap config artifact built locally per run",
       "matchDatasources": ["docker"],
-      "matchPackageNames": ["localhost:5001/knr-ops-airgap"],
+      "matchPackageNames": ["localhost:5001/krops-airgap"],
       "matchFileNames": [
         "airgap/images.txt",
         "airgap/zarf.yaml",

--- a/scripts/toolbox-run.sh
+++ b/scripts/toolbox-run.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# toolbox-run.sh – thin wrapper that runs the knr-ops toolbox container
+# toolbox-run.sh – thin wrapper that runs the krops toolbox container
 # (issue #104). The raw `docker run`/`podman run` invocation in
 # docs/operations.md is the primary interface; `mise run bootstrap|pivot|
 # teardown` call this wrapper for hosts that already have mise.
@@ -17,17 +17,17 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_ROOT"
 
-TOOLBOX_IMAGE="${TOOLBOX_IMAGE:-ghcr.io/polarsquad/knr-ops-toolbox:latest}"
+TOOLBOX_IMAGE="${TOOLBOX_IMAGE:-ghcr.io/polarsquad/krops-toolbox:latest}"
 
 usage() {
   cat >&2 <<EOF
-Usage: scripts/toolbox-run.sh <bootstrap|pivot|teardown> [extra knr-bootstrap args]
+Usage: scripts/toolbox-run.sh <bootstrap|pivot|teardown> [extra krops-bootstrap args]
 
 Env:
   TOOLBOX_IMAGE   image reference (default: ${TOOLBOX_IMAGE};
                   build locally with: docker build -f bootstrap-rs/Dockerfile \\
-                    -t knr-ops-toolbox:dev . && TOOLBOX_IMAGE=knr-ops-toolbox:dev)
-  KNR_OPS_PROFILE aws | local-host | local-talos
+                    -t krops-toolbox:dev . && TOOLBOX_IMAGE=krops-toolbox:dev)
+  KROPS_PROFILE aws | local-host | local-talos
                   (default: the mise environment in use)
 EOF
   exit 2
@@ -109,7 +109,7 @@ fi
 PASS_ENV=(
   -e CONTAINER_ENGINE
   -e ENGINE_SOCK
-  -e KNR_OPS_PROFILE
+  -e KROPS_PROFILE
   -e REGISTRY_PORT
   -e OCI_REPOSITORY
   -e OCI_TAG

--- a/teardown.sh
+++ b/teardown.sh
@@ -16,15 +16,15 @@
 # AWS cleanup (step 4) targets resources that CAPA does not manage or may leave
 # behind. VPC deletion is scoped exclusively to resources tagged by CAPA
 # (sigs.k8s.io/cluster-api-provider-aws/cluster/{clusterName}=owned) so only
-# knr-ops infrastructure is touched.
+# krops infrastructure is touched.
 #
 # Usage:
 #   ./teardown.sh              # Full teardown (k8s + AWS)
-#   KNR_OPS_PROFILE=local-host ./teardown.sh  # Delete CAPD workload + management cluster
+#   KROPS_PROFILE=local-host ./teardown.sh  # Delete CAPD workload + management cluster
 #   AWS_ONLY=1 ./teardown.sh   # AWS orphan cleanup only (skip k8s steps)
 set -euo pipefail
 
-PROFILE="${KNR_OPS_PROFILE:-${1:-aws}}"
+PROFILE="${KROPS_PROFILE:-${1:-aws}}"
 
 preflight_checks() {
   case "$PROFILE" in
@@ -127,10 +127,10 @@ if [ "$PROFILE" = local-host ]; then
   fi
 
   # Clean up the local container registry used by local-host profile
-  if [ -n "${CONTAINER_ENGINE:-}" ] && $CONTAINER_ENGINE ps -a --filter "name=^knr-registry$" | grep -q "knr-registry"; then
-    echo ">>> Removing local registry container 'knr-registry'..."
-    $CONTAINER_ENGINE rm -f knr-registry
-    echo "✓   registry container 'knr-registry' removed"
+  if [ -n "${CONTAINER_ENGINE:-}" ] && $CONTAINER_ENGINE ps -a --filter "name=^krops-registry$" | grep -q "krops-registry"; then
+    echo ">>> Removing local registry container 'krops-registry'..."
+    $CONTAINER_ENGINE rm -f krops-registry
+    echo "✓   registry container 'krops-registry' removed"
   fi
 
   exit 0
@@ -144,14 +144,14 @@ REGIONS="eu-north-1 eu-west-1"
 
 # Global IAM roles (region-independent): the ACK controller pod-identity roles
 # and the per-cluster reader roles created by the workload ACK IAM controllers
-# (knr-ops-${CLUSTER_NAME}-reader, see workload/base/iam-roles/role.yaml)
-GLOBAL_IAM_ROLES="knr-ops-ack-s3-controller knr-ops-ack-rds-controller knr-ops-ack-iam-controller knr-ops-eu-north-1-workload-reader knr-ops-eu-west-1-workload-reader"
+# (krops-${CLUSTER_NAME}-reader, see workload/base/iam-roles/role.yaml)
+GLOBAL_IAM_ROLES="krops-ack-s3-controller krops-ack-rds-controller krops-ack-iam-controller krops-eu-north-1-workload-reader krops-eu-west-1-workload-reader"
 
 # Global IAM users: the console reader user created by the management
 # cluster's ACK IAM controller (mgmt/aws/infrastructure/aws-global-iam/
 # reader-user.yaml). Users need different cleanup than roles: login profile
 # (console password) + inline policies + the user itself.
-GLOBAL_IAM_USERS="knr-ops-reader"
+GLOBAL_IAM_USERS="krops-reader"
 
 # CloudFormation stack created by clusterawsadm bootstrap iam
 CFN_STACK_NAME="cluster-api-provider-aws-sigs-k8s-io"
@@ -235,18 +235,18 @@ _get_cluster_name() {
 # CAPA tags the VPC resources and EIPs it creates with
 # sigs.k8s.io/cluster-api-provider-aws/cluster/<Cluster name>=owned
 # (verified against the live account). VPC/EIP cleanup is gated on this tag so
-# only knr-ops infrastructure is ever touched.
+# only krops infrastructure is ever touched.
 _get_capa_tag_key() {
   echo "sigs.k8s.io/cluster-api-provider-aws/cluster/$(_get_cluster_name "$1")"
 }
 
 # RDS instance identifier created by the ACK RDS controller on each workload
-# cluster: knr-ops-${CLUSTER_NAME}-db (see workload/base/rds-instances/dbinstance.yaml
+# cluster: krops-${CLUSTER_NAME}-db (see workload/base/rds-instances/dbinstance.yaml
 # and the cluster-vars ConfigMap in mgmt/aws/addons/flux-apps/flux-instance.yaml).
 _get_rds_instance() {
   case "$1" in
-    eu-north-1) echo "knr-ops-eu-north-1-workload-db" ;;
-    eu-west-1)  echo "knr-ops-eu-west-1-workload-db" ;;
+    eu-north-1) echo "krops-eu-north-1-workload-db" ;;
+    eu-west-1)  echo "krops-eu-west-1-workload-db" ;;
     *)          return 1 ;;
   esac
 }
@@ -414,7 +414,7 @@ _cleanup_s3_bucket() {
     2>/dev/null || warn "  Failed to delete S3 bucket $_bucket"
 }
 
-# ── VPC resources (knr-ops only – gated on CAPA ownership tag) ─────────────────
+# ── VPC resources (krops only – gated on CAPA ownership tag) ─────────────────
 _cleanup_vpc_resources() {
   _region="$1"; _cluster="$2"
   _cluster_tag_key=$(_get_capa_tag_key "$_region")
@@ -494,7 +494,7 @@ _delete_subnets() {
   _subnet_region="$1"; _subnet_vpc="$2"
 
   # No "non-default" filter needed: the enclosing VPC is CAPA-tagged, so it is
-  # never the account's default VPC and every subnet in it belongs to knr-ops.
+  # never the account's default VPC and every subnet in it belongs to krops.
   # ("default" is not a valid subnet filter name – using it makes the describe
   # call fail silently and skip subnet deletion entirely.)
   for _subnet_id in $(aws ec2 describe-subnets \
@@ -804,8 +804,8 @@ fi
 #   4f. S3 buckets                 – ACK-created versioned data buckets
 #   4g. IAM roles + users          – CAPA per-cluster roles (prefix sweep)
 #                                   + ACK controller roles
-#                                   + ACK-created knr-ops-*-reader roles
-#                                   + the knr-ops-reader console user
+#                                   + ACK-created krops-*-reader roles
+#                                   + the krops-reader console user
 #   4h. CloudFormation stack       – clusterawsadm bootstrap stack
 
 step_aws_cleanup() {
@@ -838,16 +838,16 @@ step_aws_cleanup() {
     _cleanup_rds_instance "$_region" "$(_get_rds_instance "$_region")"
   done
 
-  # ── 4e: VPC resources (CAPA-tagged only – knr-ops scope) ───────────────────
+  # ── 4e: VPC resources (CAPA-tagged only – krops scope) ───────────────────
   for _region in $REGIONS; do
     _cleanup_vpc_resources "$_region" "$(_get_cluster_name "$_region")"
   done
 
-  # ── 4f: S3 buckets (knr-ops-${ACCOUNT_ID}-${CLUSTER_NAME}-data) ────────────
+  # ── 4f: S3 buckets (krops-${ACCOUNT_ID}-${CLUSTER_NAME}-data) ────────────
   _account_id=$(aws sts get-caller-identity --query Account --output text 2>/dev/null || true)
   if [ -n "$_account_id" ]; then
     for _region in $REGIONS; do
-      _cleanup_s3_bucket "knr-ops-${_account_id}-$(_get_cluster_name "$_region")-data" "$_region"
+      _cleanup_s3_bucket "krops-${_account_id}-$(_get_cluster_name "$_region")-data" "$_region"
     done
   else
     warn "  Could not determine AWS account ID – skipping S3 bucket cleanup"

--- a/tests/test-bootstrap-config.py
+++ b/tests/test-bootstrap-config.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Cross-check bootstrap.toml against the Git manifests (issue #98).
 
-The chart versions knr-bootstrap installs imperatively must equal the
+The chart versions krops-bootstrap installs imperatively must equal the
 versions Flux reconciles from Git, or Flux cannot adopt the imperative
 installs without drift. Fails when they disagree, when a declared
 provider-manifest or sync path is missing, when an environment's kind
@@ -122,13 +122,13 @@ def main() -> int:
                     f"environments.{name} teardown cluster-name {cluster_name!r} "
                     f"does not start with its region {region!r}"
                 )
-            # The RDS instance id is knr-ops-<cluster>-db (workload/base/
+            # The RDS instance id is krops-<cluster>-db (workload/base/
             # rds-instances/dbinstance.yaml substitutes CLUSTER_NAME).
             rds = workload.get("rds-instance", "")
-            if cluster_name and rds != f"knr-ops-{cluster_name}-db":
+            if cluster_name and rds != f"krops-{cluster_name}-db":
                 failures.append(
                     f"environments.{name} teardown rds-instance {rds!r} != "
-                    f"knr-ops-{cluster_name}-db"
+                    f"krops-{cluster_name}-db"
                 )
             # The EKS name is '<namespace>_<kcp-name>' — only the namespace
             # separator becomes an underscore (teardown.sh documents this
@@ -145,9 +145,9 @@ def main() -> int:
     teardown = config.get("teardown", {})
     if teardown:
         expected_roles = [
-            "knr-ops-ack-s3-controller",
-            "knr-ops-ack-rds-controller",
-            "knr-ops-ack-iam-controller",
+            "krops-ack-s3-controller",
+            "krops-ack-rds-controller",
+            "krops-ack-iam-controller",
         ]
         roles = teardown.get("global-iam-roles", [])
         for role in expected_roles:
@@ -155,8 +155,8 @@ def main() -> int:
                 failures.append(f"teardown.global-iam-roles missing {role}")
         reader_user = REPO_ROOT / "mgmt/aws/infrastructure/aws-global-iam/reader-user.yaml"
         users = teardown.get("global-iam-users", [])
-        if reader_user.is_file() and "knr-ops-reader" not in users:
-            failures.append("teardown.global-iam-users missing knr-ops-reader")
+        if reader_user.is_file() and "krops-reader" not in users:
+            failures.append("teardown.global-iam-users missing krops-reader")
         pattern = teardown.get("s3-bucket-pattern", "")
         if pattern and "{account_id}" not in pattern or "{cluster_name}" not in pattern:
             failures.append(

--- a/workload/base/iam-roles/role.yaml
+++ b/workload/base/iam-roles/role.yaml
@@ -8,7 +8,7 @@
 # allowed to call sts:AssumeRole on this role can assume it.
 #
 # Permissions are read-only, scoped to the resources this repo creates on BOTH
-# clusters (knr-ops-* S3 buckets and RDS instances): only RDS Describe actions
+# clusters (krops-* S3 buckets and RDS instances): only RDS Describe actions
 # that support resource-level scoping are used — no blanket rds:Describe* on *.
 # ══════════════════════════════════════════════════════════════════════════════
 apiVersion: iam.services.k8s.aws/v1alpha1
@@ -17,8 +17,8 @@ metadata:
   name: reader
   namespace: default
 spec:
-  name: knr-ops-${CLUSTER_NAME}-reader
-  description: "Read-only access to knr-ops S3 buckets and RDS instances"
+  name: krops-${CLUSTER_NAME}-reader
+  description: "Read-only access to krops S3 buckets and RDS instances"
   assumeRolePolicyDocument: |
     {
       "Version": "2012-10-17",
@@ -31,12 +31,12 @@ spec:
       ]
     }
   inlinePolicies:
-    knr-ops-read-only: |
+    krops-read-only: |
       {
         "Version": "2012-10-17",
         "Statement": [
           {
-            "Sid": "ReadKnrOpsBuckets",
+            "Sid": "ReadKropsBuckets",
             "Effect": "Allow",
             "Action": [
               "s3:ListBucket",
@@ -47,18 +47,18 @@ spec:
               "s3:GetLifecycleConfiguration"
             ],
             "Resource": [
-              "arn:aws:s3:::knr-ops-*",
-              "arn:aws:s3:::knr-ops-*/*"
+              "arn:aws:s3:::krops-*",
+              "arn:aws:s3:::krops-*/*"
             ]
           },
           {
-            "Sid": "ReadKnrOpsInstances",
+            "Sid": "ReadKropsInstances",
             "Effect": "Allow",
             "Action": [
               "rds:DescribeDBInstances",
               "rds:ListTagsForResource"
             ],
-            "Resource": "arn:aws:rds:*:${AWS_ACCOUNT_ID}:db:knr-ops-*"
+            "Resource": "arn:aws:rds:*:${AWS_ACCOUNT_ID}:db:krops-*"
           }
         ]
       }

--- a/workload/base/rds-instances/dbinstance.yaml
+++ b/workload/base/rds-instances/dbinstance.yaml
@@ -19,7 +19,7 @@ metadata:
   name: db
   namespace: default
 spec:
-  dbInstanceIdentifier: knr-ops-${CLUSTER_NAME}-db
+  dbInstanceIdentifier: krops-${CLUSTER_NAME}-db
   engine: postgres
   engineVersion: "17"
   # Smallest current-generation instance class (2 vCPU Graviton, 1 GiB RAM)

--- a/workload/base/s3-buckets/bucket.yaml
+++ b/workload/base/s3-buckets/bucket.yaml
@@ -19,7 +19,7 @@ metadata:
   name: data
   namespace: default
 spec:
-  name: knr-ops-${AWS_ACCOUNT_ID}-${CLUSTER_NAME}-data
+  name: krops-${AWS_ACCOUNT_ID}-${CLUSTER_NAME}-data
   createBucketConfiguration:
     locationConstraint: ${AWS_REGION}
   publicAccessBlock:
@@ -47,8 +47,8 @@ spec:
           "Principal": "*",
           "Action": "s3:*",
           "Resource": [
-            "arn:aws:s3:::knr-ops-${AWS_ACCOUNT_ID}-${CLUSTER_NAME}-data",
-            "arn:aws:s3:::knr-ops-${AWS_ACCOUNT_ID}-${CLUSTER_NAME}-data/*"
+            "arn:aws:s3:::krops-${AWS_ACCOUNT_ID}-${CLUSTER_NAME}-data",
+            "arn:aws:s3:::krops-${AWS_ACCOUNT_ID}-${CLUSTER_NAME}-data/*"
           ],
           "Condition": {
             "Bool": { "aws:SecureTransport": "false" }


### PR DESCRIPTION
## What

Renames the project from `knr-ops` to `krops` across the whole repo, ahead of the GitHub repository rename.

Two commits:

1. **`refactor: rename project from knr-ops to krops`** — pure token rename, 467 insertions / 467 deletions:
   - `knr-ops` / `knr_ops` / `KNR_OPS` → `krops` / `krops` / `KROPS` (project name, URLs, `knr-ops-*` resource names, `knr-ops.polarsquad.com` labels, `KNR_OPS_PROFILE`)
   - `knr-bootstrap` → `krops-bootstrap` (Rust CLI, crate and binary)
   - `knr-registry` → `krops-registry` (local OCI registry)
   - `knr_toolbox` / `KNR_TOOLBOX` → `krops_toolbox` / `KROPS_TOOLBOX`
   - `KnrOps*` → `Krops*` (IAM policy names: `KnrOpsRoles`, `KnrOpsBuckets`, `KnrOpsInstances`, `KnrOpsReaderRoles`, `ManageKnrOps*`, `ReadKnrOps*`, `AssumeKnrOpsReaderRoles`)
   - `docs/knr-ops-logo.svg` → `docs/krops-logo.svg`
   - No `knr` strings existed in `*.sops.yaml` files, so no re-encryption was needed.

2. **`fix: pin air-gap image references with sha256 digests`** — the rename touches `airgap/images.txt`, `airgap/zarf.yaml`, and the airgap scripts, which brings them under the PR-scoped digest gate. All previously tag-only references (36 unique images, 90+ occurrences) are pinned. The `kindest/node` `customImage` refs in the local-host cluster classes are pinned too, because the `build-config-artifact.sh` anchor string matches against them at render time.

## Operational impact on reconcile

- The `KnrOps*` → `Krops*` IAM managed policy names and the `knr-ops-*` bucket/role names are live AWS resource names. On the next reconcile after merge, ACK and the IAM manifests create the new policies/resources and the old ones are deleted per the deletion policies. Note: the konflate "Rendered Flux diff" check skips this PR (its guard requires a same-repo head branch, and this PR's head is the shrinedogg/knr-ops fork), so no rendered diff will be posted here; review the raw diff or render locally before merging.
- GitHub redirects `polarsquad/knr-ops` URLs after the repo rename, so the Flux GitRepository URLs keep working either way; this PR already points them at `polarsquad/krops`.

## Verification

- `mise run validate`: OK (all kustomize overlays build, bash syntax, bootstrap.toml cross-check, air-gap digest gate OK with 6 changed files checked)
- `bootstrap-rs`: `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test` (50 passed)
- `tests/test-bootstrap-config.py`: OK
- `tests/test-renovate-coverage.py`: OK
- Renovate dry-run (`renovate@44.50.1`, `--platform=local --dry-run=full`, node 24): extraction identical to `main` (97 files, 281 deps), zero failed lookups

## Follow-up

- Filed separately: the `kindest/node` Renovate rule replaces only the tag and would strand the new `@sha256` pins on the next bump.

