### PR TITLE
docs: recolor architecture diagrams to match krops theme

### DIFF
--- a/docs/air-gap-infra.svg
+++ b/docs/air-gap-infra.svg
@@ -1,183 +1,183 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1600" height="1150" viewBox="0 0 1600 1150">
   <defs>
     <marker id="arrow-teal" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
-      <path d="M0,0 L10,5 L0,10 z" fill="#85c7bb"/>
+      <path d="M0,0 L10,5 L0,10 z" fill="#5CE0B4"/>
     </marker>
     <marker id="arrow-gray" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
-      <path d="M0,0 L10,5 L0,10 z" fill="#8f8f8f"/>
+      <path d="M0,0 L10,5 L0,10 z" fill="#859D91"/>
     </marker>
     <marker id="arrow-purple" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
-      <path d="M0,0 L10,5 L0,10 z" fill="#ab9fd6"/>
+      <path d="M0,0 L10,5 L0,10 z" fill="#B0F6C0"/>
     </marker>
     <marker id="arrow-tan" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
-      <path d="M0,0 L10,5 L0,10 z" fill="#cfa07e"/>
+      <path d="M0,0 L10,5 L0,10 z" fill="#E8A868"/>
     </marker>
   </defs>
 
   <!-- ===== background ===== -->
-  <rect width="1600" height="1150" fill="#0f0f0f"/>
+  <rect width="1600" height="1150" fill="#0C120F"/>
 
   <!-- ===== title block ===== -->
-  <text x="800" y="60" text-anchor="middle" font-family="DejaVu Sans" font-size="40" font-weight="bold" fill="#ff78c9">krops &#183; Zarf Air-Gap Bundle &#183; Radio Off, Chain Intact</text>
-  <text x="800" y="96" text-anchor="middle" font-family="DejaVu Sans" font-size="19" fill="#8f8f8f">Zarf packages the local-host environment &#183; build connected, deploy with no internet &#183; two registries, one package</text>
+  <text x="800" y="60" text-anchor="middle" font-family="DejaVu Sans" font-size="40" font-weight="bold" fill="#5CE0B4">krops &#183; Zarf Air-Gap Bundle &#183; Radio Off, Chain Intact</text>
+  <text x="800" y="96" text-anchor="middle" font-family="DejaVu Sans" font-size="19" fill="#859D91">Zarf packages the local-host environment &#183; build connected, deploy with no internet &#183; two registries, one package</text>
 
   <!-- ===== section headers ===== -->
-  <text x="64" y="138" font-family="DejaVu Sans" font-size="20" font-weight="bold" fill="#fafafa">CONNECTED SIDE (build)</text>
-  <text x="64" y="470" font-family="DejaVu Sans" font-size="20" font-weight="bold" fill="#fafafa">AIR-GAPPED SIDE (deploy)</text>
-  <text x="1090" y="138" font-family="DejaVu Sans" font-size="20" font-weight="bold" fill="#fafafa">FLOW (offline reconciliation)</text>
+  <text x="64" y="138" font-family="DejaVu Sans" font-size="20" font-weight="bold" fill="#FFFFFF">CONNECTED SIDE (build)</text>
+  <text x="64" y="470" font-family="DejaVu Sans" font-size="20" font-weight="bold" fill="#FFFFFF">AIR-GAPPED SIDE (deploy)</text>
+  <text x="1090" y="138" font-family="DejaVu Sans" font-size="20" font-weight="bold" fill="#FFFFFF">FLOW (offline reconciliation)</text>
 
   <!-- ===== connected side: build box ===== -->
-  <rect x="64" y="150" width="440" height="256" rx="14" fill="#131320" stroke="#3d3d55" stroke-width="1.5"/>
-  <rect x="80" y="158" width="408" height="5" rx="2.5" fill="#85c7bb"/>
-  <text x="284" y="198" text-anchor="middle" font-family="DejaVu Sans" font-size="25" font-weight="bold" fill="#85c7bb">Build Machine</text>
-  <text x="284" y="222" text-anchor="middle" font-family="DejaVu Sans Mono" font-size="15" fill="#8f8f8f">airgap/scripts/build-package.sh</text>
-  <text x="100" y="262" font-family="DejaVu Sans" font-size="16" fill="#d6d6d6">&#8226; validate + render the GitOps tree</text>
-  <text x="100" y="292" font-family="DejaVu Sans" font-size="16" fill="#d6d6d6">&#8226; trim tree &#8594; OCI config artifact</text>
-  <text x="100" y="322" font-family="DejaVu Sans" font-size="16" fill="#d6d6d6">&#8226; pull node + workload images, charts</text>
-  <text x="100" y="352" font-family="DejaVu Sans Mono" font-size="16" fill="#85c7bb">&#8226; zarf package create</text>
-  <text x="284" y="388" text-anchor="middle" font-family="DejaVu Sans" font-size="14.5" fill="#8f8f8f">git tree is never modified; airgap variant generated at build</text>
+  <rect x="64" y="150" width="440" height="256" rx="14" fill="#131E18" stroke="#284637" stroke-width="1.5"/>
+  <rect x="80" y="158" width="408" height="5" rx="2.5" fill="#5CE0B4"/>
+  <text x="284" y="198" text-anchor="middle" font-family="DejaVu Sans" font-size="25" font-weight="bold" fill="#5CE0B4">Build Machine</text>
+  <text x="284" y="222" text-anchor="middle" font-family="DejaVu Sans Mono" font-size="15" fill="#859D91">airgap/scripts/build-package.sh</text>
+  <text x="100" y="262" font-family="DejaVu Sans" font-size="16" fill="#D4E2DA">&#8226; validate + render the GitOps tree</text>
+  <text x="100" y="292" font-family="DejaVu Sans" font-size="16" fill="#D4E2DA">&#8226; trim tree &#8594; OCI config artifact</text>
+  <text x="100" y="322" font-family="DejaVu Sans" font-size="16" fill="#D4E2DA">&#8226; pull node + workload images, charts</text>
+  <text x="100" y="352" font-family="DejaVu Sans Mono" font-size="16" fill="#5CE0B4">&#8226; zarf package create</text>
+  <text x="284" y="388" text-anchor="middle" font-family="DejaVu Sans" font-size="14.5" fill="#859D91">git tree is never modified; airgap variant generated at build</text>
 
   <!-- ===== the bundle ===== -->
-  <rect x="620" y="150" width="400" height="256" rx="14" fill="#131320" stroke="#3d3d55" stroke-width="1.5"/>
-  <rect x="636" y="158" width="368" height="5" rx="2.5" fill="#ab9fd6"/>
-  <text x="820" y="198" text-anchor="middle" font-family="DejaVu Sans" font-size="25" font-weight="bold" fill="#ab9fd6">The Bundle</text>
-  <text x="820" y="222" text-anchor="middle" font-family="DejaVu Sans" font-size="16" fill="#8f8f8f">(what crosses the gap)</text>
-  <text x="656" y="258" font-family="DejaVu Sans Mono" font-size="15" fill="#d6d6d6">zarf-package-krops-airgap-*.tar.zst</text>
-  <text x="656" y="286" font-family="DejaVu Sans Mono" font-size="15" fill="#d6d6d6">zarf-init tarball + zarf CLI</text>
-  <text x="656" y="314" font-family="DejaVu Sans Mono" font-size="15" fill="#d6d6d6">archives/*.tar <tspan font-family="DejaVu Sans" fill="#8f8f8f">(kind nodes, images)</tspan></text>
-  <text x="656" y="342" font-family="DejaVu Sans Mono" font-size="15" fill="#d6d6d6">charts/*.tgz <tspan font-family="DejaVu Sans" fill="#8f8f8f">(flux-operator, podinfo)</tspan></text>
-  <text x="656" y="370" font-family="DejaVu Sans Mono" font-size="15" fill="#d6d6d6">config-artifact/ <tspan font-family="DejaVu Sans" fill="#8f8f8f">&#8594; krops:latest</tspan></text>
+  <rect x="620" y="150" width="400" height="256" rx="14" fill="#131E18" stroke="#284637" stroke-width="1.5"/>
+  <rect x="636" y="158" width="368" height="5" rx="2.5" fill="#B0F6C0"/>
+  <text x="820" y="198" text-anchor="middle" font-family="DejaVu Sans" font-size="25" font-weight="bold" fill="#B0F6C0">The Bundle</text>
+  <text x="820" y="222" text-anchor="middle" font-family="DejaVu Sans" font-size="16" fill="#859D91">(what crosses the gap)</text>
+  <text x="656" y="258" font-family="DejaVu Sans Mono" font-size="15" fill="#D4E2DA">zarf-package-krops-airgap-*.tar.zst</text>
+  <text x="656" y="286" font-family="DejaVu Sans Mono" font-size="15" fill="#D4E2DA">zarf-init tarball + zarf CLI</text>
+  <text x="656" y="314" font-family="DejaVu Sans Mono" font-size="15" fill="#D4E2DA">archives/*.tar <tspan font-family="DejaVu Sans" fill="#859D91">(kind nodes, images)</tspan></text>
+  <text x="656" y="342" font-family="DejaVu Sans Mono" font-size="15" fill="#D4E2DA">charts/*.tgz <tspan font-family="DejaVu Sans" fill="#859D91">(flux-operator, podinfo)</tspan></text>
+  <text x="656" y="370" font-family="DejaVu Sans Mono" font-size="15" fill="#D4E2DA">config-artifact/ <tspan font-family="DejaVu Sans" fill="#859D91">&#8594; krops:latest</tspan></text>
 
   <!-- build -> bundle arrow -->
-  <line x1="508" y1="278" x2="612" y2="278" stroke="#85c7bb" stroke-width="2.5" marker-end="url(#arrow-teal)"/>
-  <text x="561" y="258" text-anchor="middle" font-family="DejaVu Sans" font-size="16" font-weight="bold" fill="#fafafa">1. build</text>
+  <line x1="508" y1="278" x2="612" y2="278" stroke="#5CE0B4" stroke-width="2.5" marker-end="url(#arrow-teal)"/>
+  <text x="561" y="258" text-anchor="middle" font-family="DejaVu Sans" font-size="16" font-weight="bold" fill="#FFFFFF">1. build</text>
 
   <!-- ===== the gap ===== -->
-  <line x1="64" y1="432" x2="1030" y2="432" stroke="#f2c464" stroke-width="2" stroke-dasharray="12,10"/>
-  <text x="547" y="424" text-anchor="middle" font-family="DejaVu Sans" font-size="16" font-weight="bold" fill="#f2c464">THE GAP &#183; no internet below this line (validated radio-off)</text>
-  <path d="M820,406 V446" fill="none" stroke="#ab9fd6" stroke-width="2.5" marker-end="url(#arrow-purple)"/>
-  <text x="852" y="440" font-family="DejaVu Sans" font-size="15" fill="#8f8f8f">2. carry across</text>
+  <line x1="64" y1="432" x2="1030" y2="432" stroke="#E5B85C" stroke-width="2" stroke-dasharray="12,10"/>
+  <text x="547" y="424" text-anchor="middle" font-family="DejaVu Sans" font-size="16" font-weight="bold" fill="#E5B85C">THE GAP &#183; no internet below this line (validated radio-off)</text>
+  <path d="M820,406 V446" fill="none" stroke="#B0F6C0" stroke-width="2.5" marker-end="url(#arrow-purple)"/>
+  <text x="852" y="440" font-family="DejaVu Sans" font-size="15" fill="#859D91">2. carry across</text>
 
   <!-- ===== management cluster (offline) ===== -->
-  <rect x="64" y="486" width="500" height="444" rx="14" fill="#131320" stroke="#3d3d55" stroke-width="1.5"/>
-  <rect x="80" y="494" width="468" height="5" rx="2.5" fill="#85c7bb"/>
-  <text x="314" y="532" text-anchor="middle" font-family="DejaVu Sans" font-size="25" font-weight="bold" fill="#85c7bb">Management Cluster</text>
-  <text x="314" y="556" text-anchor="middle" font-family="DejaVu Sans" font-size="16" fill="#8f8f8f">(kind &#183; nodes loaded from archives)</text>
+  <rect x="64" y="486" width="500" height="444" rx="14" fill="#131E18" stroke="#284637" stroke-width="1.5"/>
+  <rect x="80" y="494" width="468" height="5" rx="2.5" fill="#5CE0B4"/>
+  <text x="314" y="532" text-anchor="middle" font-family="DejaVu Sans" font-size="25" font-weight="bold" fill="#5CE0B4">Management Cluster</text>
+  <text x="314" y="556" text-anchor="middle" font-family="DejaVu Sans" font-size="16" fill="#859D91">(kind &#183; nodes loaded from archives)</text>
   <!-- zarf substrate chip -->
-  <rect x="88" y="576" width="452" height="128" rx="10" fill="#cfa07e" fill-opacity="0.10" stroke="#cfa07e" stroke-opacity="0.55" stroke-width="1.2"/>
-  <text x="314" y="604" text-anchor="middle" font-family="DejaVu Sans" font-size="16.5" font-weight="bold" fill="#cfa07e">Zarf owns the substrate</text>
-  <text x="106" y="632" font-family="DejaVu Sans" font-size="15" fill="#d6d6d6">&#8226; registry 127.0.0.1:31999 + rewrite agent</text>
-  <text x="106" y="658" font-family="DejaVu Sans" font-size="15" fill="#d6d6d6">&#8226; cert-manager &#183; Flux &#183; CAPI/CAPD/CAAPH</text>
-  <text x="106" y="684" font-family="DejaVu Sans" font-size="15" fill="#d6d6d6">&#8226; publishes config artifact into the internal registry</text>
+  <rect x="88" y="576" width="452" height="128" rx="10" fill="#E8A868" fill-opacity="0.10" stroke="#E8A868" stroke-opacity="0.55" stroke-width="1.2"/>
+  <text x="314" y="604" text-anchor="middle" font-family="DejaVu Sans" font-size="16.5" font-weight="bold" fill="#E8A868">Zarf owns the substrate</text>
+  <text x="106" y="632" font-family="DejaVu Sans" font-size="15" fill="#D4E2DA">&#8226; registry 127.0.0.1:31999 + rewrite agent</text>
+  <text x="106" y="658" font-family="DejaVu Sans" font-size="15" fill="#D4E2DA">&#8226; cert-manager &#183; Flux &#183; CAPI/CAPD/CAAPH</text>
+  <text x="106" y="684" font-family="DejaVu Sans" font-size="15" fill="#D4E2DA">&#8226; publishes config artifact into the internal registry</text>
   <!-- flux glyph -->
   <g transform="translate(130,760)">
-    <path d="M0,-18 L15,0 L0,18 L-15,0 Z" fill="#85c7bb"/>
-    <line x1="0" y1="-18" x2="0" y2="18" stroke="#131320" stroke-width="2.5"/>
-    <path d="M-10,24 L0,30 L10,24" fill="none" stroke="#85c7bb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M-10,33 L0,39 L10,33" fill="none" stroke="#85c7bb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M0,-18 L15,0 L0,18 L-15,0 Z" fill="#5CE0B4"/>
+    <line x1="0" y1="-18" x2="0" y2="18" stroke="#131E18" stroke-width="2.5"/>
+    <path d="M-10,24 L0,30 L10,24" fill="none" stroke="#5CE0B4" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M-10,33 L0,39 L10,33" fill="none" stroke="#5CE0B4" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   </g>
-  <text x="130" y="826" text-anchor="middle" font-family="DejaVu Sans" font-size="16" font-weight="bold" fill="#fafafa">Flux</text>
-  <rect x="188" y="726" width="352" height="70" rx="8" fill="#1d1d30" stroke="#85c7bb" stroke-opacity="0.6" stroke-width="1.2"/>
-  <text x="364" y="753" text-anchor="middle" font-family="DejaVu Sans" font-size="13" fill="#d6d6d6">FluxInstance syncs from Zarf internal registry</text>
-  <text x="364" y="778" text-anchor="middle" font-family="DejaVu Sans Mono" font-size="13.5" fill="#85c7bb">zarf-docker-registry.zarf.svc:5000</text>
+  <text x="130" y="826" text-anchor="middle" font-family="DejaVu Sans" font-size="16" font-weight="bold" fill="#FFFFFF">Flux</text>
+  <rect x="188" y="726" width="352" height="70" rx="8" fill="#1B2C23" stroke="#5CE0B4" stroke-opacity="0.6" stroke-width="1.2"/>
+  <text x="364" y="753" text-anchor="middle" font-family="DejaVu Sans" font-size="13" fill="#D4E2DA">FluxInstance syncs from Zarf internal registry</text>
+  <text x="364" y="778" text-anchor="middle" font-family="DejaVu Sans Mono" font-size="13.5" fill="#5CE0B4">zarf-docker-registry.zarf.svc:5000</text>
   <!-- flux ownership strip -->
-  <rect x="88" y="848" width="452" height="60" rx="10" fill="#85c7bb" fill-opacity="0.12" stroke="#85c7bb" stroke-opacity="0.5" stroke-width="1.2"/>
-  <text x="314" y="874" text-anchor="middle" font-family="DejaVu Sans" font-size="16" font-weight="bold" fill="#85c7bb">Flux owns the workload definitions</text>
-  <text x="314" y="896" text-anchor="middle" font-family="DejaVu Sans" font-size="14" fill="#d6d6d6">CAPD cluster &#183; kindnet CNI addon &#183; per-cluster Flux addon</text>
+  <rect x="88" y="848" width="452" height="60" rx="10" fill="#5CE0B4" fill-opacity="0.12" stroke="#5CE0B4" stroke-opacity="0.5" stroke-width="1.2"/>
+  <text x="314" y="874" text-anchor="middle" font-family="DejaVu Sans" font-size="16" font-weight="bold" fill="#5CE0B4">Flux owns the workload definitions</text>
+  <text x="314" y="896" text-anchor="middle" font-family="DejaVu Sans" font-size="14" fill="#D4E2DA">CAPD cluster &#183; kindnet CNI addon &#183; per-cluster Flux addon</text>
 
   <!-- provisions arrow -->
-  <line x1="564" y1="708" x2="668" y2="708" stroke="#85c7bb" stroke-width="2.5" stroke-dasharray="7,6" marker-end="url(#arrow-teal)"/>
-  <text x="616" y="686" text-anchor="middle" font-family="DejaVu Sans" font-size="15" font-weight="bold" fill="#fafafa">4. provisions</text>
+  <line x1="564" y1="708" x2="668" y2="708" stroke="#5CE0B4" stroke-width="2.5" stroke-dasharray="7,6" marker-end="url(#arrow-teal)"/>
+  <text x="616" y="686" text-anchor="middle" font-family="DejaVu Sans" font-size="15" font-weight="bold" fill="#FFFFFF">4. provisions</text>
 
   <!-- ===== workload cluster (offline) ===== -->
-  <rect x="676" y="486" width="354" height="444" rx="14" fill="#131320" stroke="#3d3d55" stroke-width="1.5"/>
-  <rect x="692" y="494" width="322" height="5" rx="2.5" fill="#d693b1"/>
-  <text x="853" y="532" text-anchor="middle" font-family="DejaVu Sans" font-size="25" font-weight="bold" fill="#d693b1">Workload Cluster</text>
-  <text x="853" y="556" text-anchor="middle" font-family="DejaVu Sans" font-size="16" fill="#d6d6d6">CAPD &#183; k8s images pre-baked in node</text>
+  <rect x="676" y="486" width="354" height="444" rx="14" fill="#131E18" stroke="#284637" stroke-width="1.5"/>
+  <rect x="692" y="494" width="322" height="5" rx="2.5" fill="#68C5EB"/>
+  <text x="853" y="532" text-anchor="middle" font-family="DejaVu Sans" font-size="25" font-weight="bold" fill="#68C5EB">Workload Cluster</text>
+  <text x="853" y="556" text-anchor="middle" font-family="DejaVu Sans" font-size="16" fill="#D4E2DA">CAPD &#183; k8s images pre-baked in node</text>
   <g transform="translate(740,616) scale(0.85)">
-    <path d="M0,-18 L15,0 L0,18 L-15,0 Z" fill="#d693b1"/>
-    <line x1="0" y1="-18" x2="0" y2="18" stroke="#131320" stroke-width="2.5"/>
-    <path d="M-10,24 L0,30 L10,24" fill="none" stroke="#d693b1" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M-10,33 L0,39 L10,33" fill="none" stroke="#d693b1" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M0,-18 L15,0 L0,18 L-15,0 Z" fill="#68C5EB"/>
+    <line x1="0" y1="-18" x2="0" y2="18" stroke="#131E18" stroke-width="2.5"/>
+    <path d="M-10,24 L0,30 L10,24" fill="none" stroke="#68C5EB" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M-10,33 L0,39 L10,33" fill="none" stroke="#68C5EB" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   </g>
-  <text x="776" y="616" font-family="DejaVu Sans" font-size="16" font-weight="bold" fill="#fafafa">Flux</text>
-  <text x="776" y="635" font-family="DejaVu Sans" font-size="13" fill="#8f8f8f">(local)</text>
-  <rect x="700" y="672" width="306" height="66" rx="8" fill="#1d1d30" stroke="#d693b1" stroke-opacity="0.6" stroke-width="1.2"/>
-  <text x="853" y="697" text-anchor="middle" font-family="DejaVu Sans" font-size="12.5" fill="#d6d6d6">syncs config + charts from</text>
-  <text x="853" y="721" text-anchor="middle" font-family="DejaVu Sans Mono" font-size="15" fill="#d693b1">krops-registry:5000</text>
+  <text x="776" y="616" font-family="DejaVu Sans" font-size="16" font-weight="bold" fill="#FFFFFF">Flux</text>
+  <text x="776" y="635" font-family="DejaVu Sans" font-size="13" fill="#859D91">(local)</text>
+  <rect x="700" y="672" width="306" height="66" rx="8" fill="#1B2C23" stroke="#68C5EB" stroke-opacity="0.6" stroke-width="1.2"/>
+  <text x="853" y="697" text-anchor="middle" font-family="DejaVu Sans" font-size="12.5" fill="#D4E2DA">syncs config + charts from</text>
+  <text x="853" y="721" text-anchor="middle" font-family="DejaVu Sans Mono" font-size="15" fill="#68C5EB">krops-registry:5000</text>
   <!-- podinfo chip -->
-  <rect x="700" y="762" width="306" height="70" rx="10" fill="#1d1d30" stroke="#3d3d55" stroke-width="1.2"/>
-  <g stroke="#cfa07e" stroke-width="1.8" fill="none">
+  <rect x="700" y="762" width="306" height="70" rx="10" fill="#1B2C23" stroke="#284637" stroke-width="1.2"/>
+  <g stroke="#E8A868" stroke-width="1.8" fill="none">
     <circle cx="736" cy="790" r="7"/>
     <path d="M723,818 a13,13 0 0 1 26,0"/>
   </g>
-  <text x="766" y="792" font-family="DejaVu Sans Mono" font-size="17" font-weight="bold" fill="#fafafa">podinfo</text>
-  <text x="766" y="816" font-family="DejaVu Sans" font-size="14" fill="#d6d6d6">via preLoadImages, zero pulls</text>
+  <text x="766" y="792" font-family="DejaVu Sans Mono" font-size="17" font-weight="bold" fill="#FFFFFF">podinfo</text>
+  <text x="766" y="816" font-family="DejaVu Sans" font-size="14" fill="#D4E2DA">via preLoadImages, zero pulls</text>
   <!-- lifecycle strip -->
-  <rect x="700" y="856" width="306" height="42" rx="8" fill="#d693b1" fill-opacity="0.14"/>
-  <text x="853" y="883" text-anchor="middle" font-family="DejaVu Sans" font-size="15.5" font-weight="bold" fill="#d693b1">Manages application lifecycle</text>
+  <rect x="700" y="856" width="306" height="42" rx="8" fill="#68C5EB" fill-opacity="0.14"/>
+  <text x="853" y="883" text-anchor="middle" font-family="DejaVu Sans" font-size="15.5" font-weight="bold" fill="#68C5EB">Manages application lifecycle</text>
 
   <!-- ===== legend strip ===== -->
-  <rect x="64" y="962" width="966" height="96" rx="12" fill="#131320" stroke="#3d3d55" stroke-width="1.5"/>
-  <text x="88" y="998" font-family="DejaVu Sans" font-size="17" font-weight="bold" fill="#cfa07e">Zarf</text>
-  <text x="140" y="998" font-family="DejaVu Sans" font-size="16" fill="#d6d6d6">= substrate: registry, agent, cert-manager, flux-operator, CAPI/CAPD/CAAPH, config artifact</text>
-  <text x="88" y="1034" font-family="DejaVu Sans" font-size="17" font-weight="bold" fill="#85c7bb">Flux</text>
-  <text x="140" y="1034" font-family="DejaVu Sans" font-size="16" fill="#d6d6d6">= workload definitions: CAPD cluster, CNI addon, per-cluster Flux addon, apps</text>
+  <rect x="64" y="962" width="966" height="96" rx="12" fill="#131E18" stroke="#284637" stroke-width="1.5"/>
+  <text x="88" y="998" font-family="DejaVu Sans" font-size="17" font-weight="bold" fill="#E8A868">Zarf</text>
+  <text x="140" y="998" font-family="DejaVu Sans" font-size="16" fill="#D4E2DA">= substrate: registry, agent, cert-manager, flux-operator, CAPI/CAPD/CAAPH, config artifact</text>
+  <text x="88" y="1034" font-family="DejaVu Sans" font-size="17" font-weight="bold" fill="#5CE0B4">Flux</text>
+  <text x="140" y="1034" font-family="DejaVu Sans" font-size="16" fill="#D4E2DA">= workload definitions: CAPD cluster, CNI addon, per-cluster Flux addon, apps</text>
 
   <!-- ===== flow panel ===== -->
-  <rect x="1090" y="150" width="446" height="904" rx="14" fill="#131320" stroke="#3d3d55" stroke-width="1.5"/>
+  <rect x="1090" y="150" width="446" height="904" rx="14" fill="#131E18" stroke="#284637" stroke-width="1.5"/>
 
   <!-- step 1 -->
-  <circle cx="1140" cy="208" r="15" fill="#85c7bb"/>
-  <text x="1140" y="214" text-anchor="middle" font-family="DejaVu Sans" font-size="15" font-weight="bold" fill="#0f0f0f">1</text>
-  <text x="1168" y="204" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">Connected: <tspan font-family="DejaVu Sans Mono" font-size="16" fill="#85c7bb">build-package.sh</tspan></text>
-  <text x="1168" y="230" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">renders the tree, pulls every image</text>
-  <text x="1168" y="256" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">and chart, creates the Zarf package.</text>
-  <line x1="1122" y1="290" x2="1504" y2="290" stroke="#34344a" stroke-width="1.2"/>
+  <circle cx="1140" cy="208" r="15" fill="#5CE0B4"/>
+  <text x="1140" y="214" text-anchor="middle" font-family="DejaVu Sans" font-size="15" font-weight="bold" fill="#0C120F">1</text>
+  <text x="1168" y="204" font-family="DejaVu Sans" font-size="17" fill="#D4E2DA">Connected: <tspan font-family="DejaVu Sans Mono" font-size="16" fill="#5CE0B4">build-package.sh</tspan></text>
+  <text x="1168" y="230" font-family="DejaVu Sans" font-size="17" fill="#D4E2DA">renders the tree, pulls every image</text>
+  <text x="1168" y="256" font-family="DejaVu Sans" font-size="17" fill="#D4E2DA">and chart, creates the Zarf package.</text>
+  <line x1="1122" y1="290" x2="1504" y2="290" stroke="#1F362A" stroke-width="1.2"/>
 
   <!-- step 2 -->
-  <circle cx="1140" cy="338" r="15" fill="#ab9fd6"/>
-  <text x="1140" y="344" text-anchor="middle" font-family="DejaVu Sans" font-size="15" font-weight="bold" fill="#0f0f0f">2</text>
-  <text x="1168" y="334" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">The bundle crosses the gap. Offline:</text>
-  <text x="1168" y="360" font-family="DejaVu Sans Mono" font-size="15.5" fill="#ab9fd6">docker load archives; create kind</text>
-  <text x="1168" y="386" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">mgmt cluster, seed krops-registry.</text>
-  <line x1="1122" y1="420" x2="1504" y2="420" stroke="#34344a" stroke-width="1.2"/>
+  <circle cx="1140" cy="338" r="15" fill="#B0F6C0"/>
+  <text x="1140" y="344" text-anchor="middle" font-family="DejaVu Sans" font-size="15" font-weight="bold" fill="#0C120F">2</text>
+  <text x="1168" y="334" font-family="DejaVu Sans" font-size="17" fill="#D4E2DA">The bundle crosses the gap. Offline:</text>
+  <text x="1168" y="360" font-family="DejaVu Sans Mono" font-size="15.5" fill="#B0F6C0">docker load archives; create kind</text>
+  <text x="1168" y="386" font-family="DejaVu Sans" font-size="17" fill="#D4E2DA">mgmt cluster, seed krops-registry.</text>
+  <line x1="1122" y1="420" x2="1504" y2="420" stroke="#1F362A" stroke-width="1.2"/>
 
   <!-- step 3 -->
-  <circle cx="1140" cy="468" r="15" fill="#cfa07e"/>
-  <text x="1140" y="474" text-anchor="middle" font-family="DejaVu Sans" font-size="15" font-weight="bold" fill="#0f0f0f">3</text>
-  <text x="1168" y="464" font-family="DejaVu Sans Mono" font-size="16" fill="#cfa07e">zarf init + zarf package deploy:</text>
-  <text x="1168" y="490" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">internal registry + agent, substrate</text>
-  <text x="1168" y="516" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">components; agent rewrites every</text>
-  <text x="1168" y="542" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">image ref to the internal registry.</text>
-  <line x1="1122" y1="576" x2="1504" y2="576" stroke="#34344a" stroke-width="1.2"/>
+  <circle cx="1140" cy="468" r="15" fill="#E8A868"/>
+  <text x="1140" y="474" text-anchor="middle" font-family="DejaVu Sans" font-size="15" font-weight="bold" fill="#0C120F">3</text>
+  <text x="1168" y="464" font-family="DejaVu Sans Mono" font-size="16" fill="#E8A868">zarf init + zarf package deploy:</text>
+  <text x="1168" y="490" font-family="DejaVu Sans" font-size="17" fill="#D4E2DA">internal registry + agent, substrate</text>
+  <text x="1168" y="516" font-family="DejaVu Sans" font-size="17" fill="#D4E2DA">components; agent rewrites every</text>
+  <text x="1168" y="542" font-family="DejaVu Sans" font-size="17" fill="#D4E2DA">image ref to the internal registry.</text>
+  <line x1="1122" y1="576" x2="1504" y2="576" stroke="#1F362A" stroke-width="1.2"/>
 
   <!-- step 4 -->
-  <circle cx="1140" cy="624" r="15" fill="#85c7bb"/>
-  <text x="1140" y="630" text-anchor="middle" font-family="DejaVu Sans" font-size="15" font-weight="bold" fill="#0f0f0f">4</text>
-  <text x="1168" y="620" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">FluxInstance syncs the config</text>
-  <text x="1168" y="646" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">artifact from Zarf's registry; Flux</text>
-  <text x="1168" y="672" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">reconciles the CAPD cluster and</text>
-  <text x="1168" y="698" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">installs workload Flux.</text>
-  <line x1="1122" y1="732" x2="1504" y2="732" stroke="#34344a" stroke-width="1.2"/>
+  <circle cx="1140" cy="624" r="15" fill="#5CE0B4"/>
+  <text x="1140" y="630" text-anchor="middle" font-family="DejaVu Sans" font-size="15" font-weight="bold" fill="#0C120F">4</text>
+  <text x="1168" y="620" font-family="DejaVu Sans" font-size="17" fill="#D4E2DA">FluxInstance syncs the config</text>
+  <text x="1168" y="646" font-family="DejaVu Sans" font-size="17" fill="#D4E2DA">artifact from Zarf's registry; Flux</text>
+  <text x="1168" y="672" font-family="DejaVu Sans" font-size="17" fill="#D4E2DA">reconciles the CAPD cluster and</text>
+  <text x="1168" y="698" font-family="DejaVu Sans" font-size="17" fill="#D4E2DA">installs workload Flux.</text>
+  <line x1="1122" y1="732" x2="1504" y2="732" stroke="#1F362A" stroke-width="1.2"/>
 
   <!-- step 5 -->
-  <circle cx="1140" cy="780" r="15" fill="#d693b1"/>
-  <text x="1140" y="786" text-anchor="middle" font-family="DejaVu Sans" font-size="15" font-weight="bold" fill="#0f0f0f">5</text>
-  <text x="1168" y="776" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">Workload Flux pulls config + charts</text>
-  <text x="1168" y="802" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">from krops-registry; podinfo runs</text>
-  <text x="1168" y="828" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">from pre-loaded images. Zero pulls,</text>
-  <text x="1168" y="854" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">zero public packets.</text>
-  <line x1="1122" y1="888" x2="1504" y2="888" stroke="#34344a" stroke-width="1.2"/>
+  <circle cx="1140" cy="780" r="15" fill="#68C5EB"/>
+  <text x="1140" y="786" text-anchor="middle" font-family="DejaVu Sans" font-size="15" font-weight="bold" fill="#0C120F">5</text>
+  <text x="1168" y="776" font-family="DejaVu Sans" font-size="17" fill="#D4E2DA">Workload Flux pulls config + charts</text>
+  <text x="1168" y="802" font-family="DejaVu Sans" font-size="17" fill="#D4E2DA">from krops-registry; podinfo runs</text>
+  <text x="1168" y="828" font-family="DejaVu Sans" font-size="17" fill="#D4E2DA">from pre-loaded images. Zero pulls,</text>
+  <text x="1168" y="854" font-family="DejaVu Sans" font-size="17" fill="#D4E2DA">zero public packets.</text>
+  <line x1="1122" y1="888" x2="1504" y2="888" stroke="#1F362A" stroke-width="1.2"/>
 
   <!-- update drill -->
-  <text x="1122" y="930" font-family="DejaVu Sans" font-size="22" font-weight="bold" fill="#f2c464">Update drill</text>
-  <text x="1122" y="962" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">Config-only change: rebuild + re-push</text>
-  <text x="1122" y="988" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6"><tspan font-family="DejaVu Sans Mono" font-size="16" fill="#fafafa">krops:latest</tspan>, no package rebuild.</text>
-  <text x="1122" y="1014" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">Substrate change: new package +</text>
-  <text x="1122" y="1040" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">fresh <tspan font-family="DejaVu Sans Mono" font-size="16" fill="#fafafa">zarf package deploy</tspan>.</text>
+  <text x="1122" y="930" font-family="DejaVu Sans" font-size="22" font-weight="bold" fill="#E5B85C">Update drill</text>
+  <text x="1122" y="962" font-family="DejaVu Sans" font-size="17" fill="#D4E2DA">Config-only change: rebuild + re-push</text>
+  <text x="1122" y="988" font-family="DejaVu Sans" font-size="17" fill="#D4E2DA"><tspan font-family="DejaVu Sans Mono" font-size="16" fill="#FFFFFF">krops:latest</tspan>, no package rebuild.</text>
+  <text x="1122" y="1014" font-family="DejaVu Sans" font-size="17" fill="#D4E2DA">Substrate change: new package +</text>
+  <text x="1122" y="1040" font-family="DejaVu Sans" font-size="17" fill="#D4E2DA">fresh <tspan font-family="DejaVu Sans Mono" font-size="16" fill="#FFFFFF">zarf package deploy</tspan>.</text>
 
   <!-- ===== footer ===== -->
-  <text x="800" y="1102" text-anchor="middle" font-family="DejaVu Sans" font-size="17" fill="#8f8f8f">Validated end-to-end with the radio off: CI captures public traffic and fails on any packet.</text>
-  <text x="800" y="1128" text-anchor="middle" font-family="DejaVu Sans" font-size="17" fill="#8f8f8f">Same GitOps chain as local-host: only the delivery vehicle changes.</text>
+  <text x="800" y="1102" text-anchor="middle" font-family="DejaVu Sans" font-size="17" fill="#859D91">Validated end-to-end with the radio off: CI captures public traffic and fails on any packet.</text>
+  <text x="800" y="1128" text-anchor="middle" font-family="DejaVu Sans" font-size="17" fill="#859D91">Same GitOps chain as local-host: only the delivery vehicle changes.</text>
 </svg>

--- a/docs/aws-infra.svg
+++ b/docs/aws-infra.svg
@@ -1,49 +1,49 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1600" height="1150" viewBox="0 0 1600 1150">
   <defs>
     <marker id="arrow-teal" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
-      <path d="M0,0 L10,5 L0,10 z" fill="#85c7bb"/>
+      <path d="M0,0 L10,5 L0,10 z" fill="#5CE0B4"/>
     </marker>
     <marker id="arrow-gray" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
-      <path d="M0,0 L10,5 L0,10 z" fill="#8f8f8f"/>
+      <path d="M0,0 L10,5 L0,10 z" fill="#859D91"/>
     </marker>
   </defs>
 
   <!-- ===== background ===== -->
-  <rect width="1600" height="1150" fill="#0f0f0f"/>
+  <rect width="1600" height="1150" fill="#0C120F"/>
 
   <!-- ===== title block ===== -->
-  <text x="800" y="60" text-anchor="middle" font-family="DejaVu Sans" font-size="40" font-weight="bold" fill="#ff78c9">krops &#183; GitOps Architecture &#183; 1 Repo &#215; 2 Lifecycles</text>
-  <text x="800" y="96" text-anchor="middle" font-family="DejaVu Sans" font-size="19" fill="#8f8f8f">Flux + CAPI/CAPA + ACK &#183; the management plane provisions clusters &#183; workload planes reconcile apps</text>
+  <text x="800" y="60" text-anchor="middle" font-family="DejaVu Sans" font-size="40" font-weight="bold" fill="#5CE0B4">krops &#183; GitOps Architecture &#183; 1 Repo &#215; 2 Lifecycles</text>
+  <text x="800" y="96" text-anchor="middle" font-family="DejaVu Sans" font-size="19" fill="#859D91">Flux + CAPI/CAPA + ACK &#183; the management plane provisions clusters &#183; workload planes reconcile apps</text>
 
   <!-- ===== section headers ===== -->
-  <text x="64" y="138" font-family="DejaVu Sans" font-size="20" font-weight="bold" fill="#fafafa">TOPOLOGY (clusters and sync flows)</text>
-  <text x="1090" y="138" font-family="DejaVu Sans" font-size="20" font-weight="bold" fill="#fafafa">FLOW (reconciliation order)</text>
+  <text x="64" y="138" font-family="DejaVu Sans" font-size="20" font-weight="bold" fill="#FFFFFF">TOPOLOGY (clusters and sync flows)</text>
+  <text x="1090" y="138" font-family="DejaVu Sans" font-size="20" font-weight="bold" fill="#FFFFFF">FLOW (reconciliation order)</text>
 
   <!-- ===== connections (drawn first, behind boxes) ===== -->
-  <line x1="508" y1="256" x2="612" y2="256" stroke="#85c7bb" stroke-width="2.5" marker-end="url(#arrow-teal)"/>
-  <text x="561" y="222" text-anchor="middle" font-family="DejaVu Sans" font-size="17" font-weight="bold" fill="#fafafa">1. syncs</text>
-  <text x="561" y="244" text-anchor="middle" font-family="DejaVu Sans Mono" font-size="16" fill="#85c7bb">mgmt/</text>
-  <path d="M284,484 V594" fill="none" stroke="#85c7bb" stroke-width="2.5" stroke-dasharray="7,6" marker-end="url(#arrow-teal)"/>
-  <path d="M284,556 H815 V594" fill="none" stroke="#85c7bb" stroke-width="2.5" stroke-dasharray="7,6" marker-end="url(#arrow-teal)"/>
-  <text x="560" y="530" text-anchor="middle" font-family="DejaVu Sans" font-size="16" fill="#d6d6d6">provisions EKS clusters &#183; installs Flux via <tspan font-family="DejaVu Sans Mono" fill="#85c7bb">flux-apps</tspan></text>
+  <line x1="508" y1="256" x2="612" y2="256" stroke="#5CE0B4" stroke-width="2.5" marker-end="url(#arrow-teal)"/>
+  <text x="561" y="222" text-anchor="middle" font-family="DejaVu Sans" font-size="17" font-weight="bold" fill="#FFFFFF">1. syncs</text>
+  <text x="561" y="244" text-anchor="middle" font-family="DejaVu Sans Mono" font-size="16" fill="#5CE0B4">mgmt/</text>
+  <path d="M284,484 V594" fill="none" stroke="#5CE0B4" stroke-width="2.5" stroke-dasharray="7,6" marker-end="url(#arrow-teal)"/>
+  <path d="M284,556 H815 V594" fill="none" stroke="#5CE0B4" stroke-width="2.5" stroke-dasharray="7,6" marker-end="url(#arrow-teal)"/>
+  <text x="560" y="530" text-anchor="middle" font-family="DejaVu Sans" font-size="16" fill="#D4E2DA">provisions EKS clusters &#183; installs Flux via <tspan font-family="DejaVu Sans Mono" fill="#5CE0B4">flux-apps</tspan></text>
 
   <!-- ===== management cluster ===== -->
-  <rect x="64" y="150" width="440" height="330" rx="14" fill="#131320" stroke="#3d3d55" stroke-width="1.5"/>
-  <rect x="80" y="158" width="408" height="5" rx="2.5" fill="#85c7bb"/>
-  <text x="284" y="198" text-anchor="middle" font-family="DejaVu Sans" font-size="25" font-weight="bold" fill="#85c7bb">Management Cluster</text>
-  <text x="284" y="222" text-anchor="middle" font-family="DejaVu Sans" font-size="16" fill="#8f8f8f">(self-managed EKS &#183; post-pivot)</text>
+  <rect x="64" y="150" width="440" height="330" rx="14" fill="#131E18" stroke="#284637" stroke-width="1.5"/>
+  <rect x="80" y="158" width="408" height="5" rx="2.5" fill="#5CE0B4"/>
+  <text x="284" y="198" text-anchor="middle" font-family="DejaVu Sans" font-size="25" font-weight="bold" fill="#5CE0B4">Management Cluster</text>
+  <text x="284" y="222" text-anchor="middle" font-family="DejaVu Sans" font-size="16" fill="#859D91">(self-managed EKS &#183; post-pivot)</text>
   <!-- flux glyph -->
   <g transform="translate(122,262)">
-    <path d="M0,-18 L15,0 L0,18 L-15,0 Z" fill="#85c7bb"/>
-    <line x1="0" y1="-18" x2="0" y2="18" stroke="#131320" stroke-width="2.5"/>
-    <path d="M-10,24 L0,30 L10,24" fill="none" stroke="#85c7bb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M-10,33 L0,39 L10,33" fill="none" stroke="#85c7bb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M0,-18 L15,0 L0,18 L-15,0 Z" fill="#5CE0B4"/>
+    <line x1="0" y1="-18" x2="0" y2="18" stroke="#131E18" stroke-width="2.5"/>
+    <path d="M-10,24 L0,30 L10,24" fill="none" stroke="#5CE0B4" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M-10,33 L0,39 L10,33" fill="none" stroke="#5CE0B4" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   </g>
-  <text x="122" y="328" text-anchor="middle" font-family="DejaVu Sans" font-size="16" font-weight="bold" fill="#fafafa">Flux</text>
-  <line x1="162" y1="266" x2="230" y2="266" stroke="#8f8f8f" stroke-width="2" marker-end="url(#arrow-gray)"/>
+  <text x="122" y="328" text-anchor="middle" font-family="DejaVu Sans" font-size="16" font-weight="bold" fill="#FFFFFF">Flux</text>
+  <line x1="162" y1="266" x2="230" y2="266" stroke="#859D91" stroke-width="2" marker-end="url(#arrow-gray)"/>
   <!-- capi/capa chip -->
-  <rect x="238" y="230" width="250" height="72" rx="10" fill="#1d1d30" stroke="#3d3d55" stroke-width="1.2"/>
-  <g stroke="#85c7bb" stroke-width="1.6" fill="none">
+  <rect x="238" y="230" width="250" height="72" rx="10" fill="#1B2C23" stroke="#284637" stroke-width="1.2"/>
+  <g stroke="#5CE0B4" stroke-width="1.6" fill="none">
     <circle cx="272" cy="258" r="9"/>
     <circle cx="272" cy="258" r="3.2"/>
     <g>
@@ -55,202 +55,202 @@
     <circle cx="290" cy="276" r="6.5"/>
     <circle cx="290" cy="276" r="2.2"/>
   </g>
-  <text x="308" y="264" font-family="DejaVu Sans" font-size="17" font-weight="bold" fill="#fafafa">CAPI / CAPA</text>
-  <text x="308" y="287" font-family="DejaVu Sans" font-size="14.5" fill="#d6d6d6">controllers</text>
+  <text x="308" y="264" font-family="DejaVu Sans" font-size="17" font-weight="bold" fill="#FFFFFF">CAPI / CAPA</text>
+  <text x="308" y="287" font-family="DejaVu Sans" font-size="14.5" fill="#D4E2DA">controllers</text>
   <!-- infra lifecycle sub-panel -->
-  <rect x="88" y="340" width="384" height="120" rx="10" fill="#85c7bb" fill-opacity="0.12" stroke="#85c7bb" stroke-opacity="0.5" stroke-width="1.2"/>
-  <text x="280" y="374" text-anchor="middle" font-family="DejaVu Sans" font-size="16.5" font-weight="bold" fill="#85c7bb">Manages infrastructure lifecycle</text>
-  <path d="M116,424 a9,9 0 0 1 2,-17.8 a11,11 0 0 1 21,-1.5 a8.5,8.5 0 0 1 3,17.5 z" fill="none" stroke="#d6d6d6" stroke-width="1.7" stroke-linejoin="round"/>
-  <text x="152" y="420" font-family="DejaVu Sans" font-size="15" fill="#d6d6d6">EKS clusters</text>
-  <g fill="none" stroke="#d6d6d6" stroke-width="1.7" stroke-linejoin="round">
+  <rect x="88" y="340" width="384" height="120" rx="10" fill="#5CE0B4" fill-opacity="0.12" stroke="#5CE0B4" stroke-opacity="0.5" stroke-width="1.2"/>
+  <text x="280" y="374" text-anchor="middle" font-family="DejaVu Sans" font-size="16.5" font-weight="bold" fill="#5CE0B4">Manages infrastructure lifecycle</text>
+  <path d="M116,424 a9,9 0 0 1 2,-17.8 a11,11 0 0 1 21,-1.5 a8.5,8.5 0 0 1 3,17.5 z" fill="none" stroke="#D4E2DA" stroke-width="1.7" stroke-linejoin="round"/>
+  <text x="152" y="420" font-family="DejaVu Sans" font-size="15" fill="#D4E2DA">EKS clusters</text>
+  <g fill="none" stroke="#D4E2DA" stroke-width="1.7" stroke-linejoin="round">
     <path d="M270,406 h9 a5,5 0 1 1 10,0 h9 v9 a5,5 0 1 1 0,10 v9 h-28 z"/>
   </g>
-  <text x="306" y="420" font-family="DejaVu Sans" font-size="15" fill="#d6d6d6">Flux bootstrap addon</text>
+  <text x="306" y="420" font-family="DejaVu Sans" font-size="15" fill="#D4E2DA">Flux bootstrap addon</text>
 
   <!-- ===== git repository ===== -->
-  <rect x="620" y="150" width="400" height="330" rx="14" fill="#131320" stroke="#3d3d55" stroke-width="1.5"/>
-  <rect x="636" y="158" width="368" height="5" rx="2.5" fill="#ab9fd6"/>
-  <text x="820" y="198" text-anchor="middle" font-family="DejaVu Sans" font-size="25" font-weight="bold" fill="#ab9fd6">Git Repository</text>
-  <text x="820" y="222" text-anchor="middle" font-family="DejaVu Sans" font-size="16" fill="#8f8f8f">(polarsquad/krops)</text>
+  <rect x="620" y="150" width="400" height="330" rx="14" fill="#131E18" stroke="#284637" stroke-width="1.5"/>
+  <rect x="636" y="158" width="368" height="5" rx="2.5" fill="#B0F6C0"/>
+  <text x="820" y="198" text-anchor="middle" font-family="DejaVu Sans" font-size="25" font-weight="bold" fill="#B0F6C0">Git Repository</text>
+  <text x="820" y="222" text-anchor="middle" font-family="DejaVu Sans" font-size="16" fill="#859D91">(polarsquad/krops)</text>
   <!-- folder tree -->
   <g fill="none" stroke-width="1.7">
-    <path d="M660,250 h9 l4,5 h15 v16 h-28 z" stroke="#85c7bb"/>
-    <path d="M660,288 h9 l4,5 h15 v16 h-28 z" stroke="#d693b1"/>
-    <path d="M708,326 h8 l4,4.5 h13 v14 h-25 z" stroke="#d693b1" stroke-opacity="0.85"/>
-    <path d="M708,360 h8 l4,4.5 h13 v14 h-25 z" stroke="#d693b1" stroke-opacity="0.85"/>
-    <path d="M708,394 h8 l4,4.5 h13 v14 h-25 z" stroke="#d693b1" stroke-opacity="0.85"/>
+    <path d="M660,250 h9 l4,5 h15 v16 h-28 z" stroke="#5CE0B4"/>
+    <path d="M660,288 h9 l4,5 h15 v16 h-28 z" stroke="#68C5EB"/>
+    <path d="M708,326 h8 l4,4.5 h13 v14 h-25 z" stroke="#68C5EB" stroke-opacity="0.85"/>
+    <path d="M708,360 h8 l4,4.5 h13 v14 h-25 z" stroke="#68C5EB" stroke-opacity="0.85"/>
+    <path d="M708,394 h8 l4,4.5 h13 v14 h-25 z" stroke="#68C5EB" stroke-opacity="0.85"/>
   </g>
-  <g stroke="#3d3d55" stroke-width="1.4" fill="none">
+  <g stroke="#284637" stroke-width="1.4" fill="none">
     <path d="M674,312 V403 M674,335 h28 M674,369 h28 M674,403 h28"/>
   </g>
-  <text x="700" y="268" font-family="DejaVu Sans Mono" font-size="17" font-weight="bold" fill="#85c7bb">mgmt/</text>
-  <text x="700" y="306" font-family="DejaVu Sans Mono" font-size="17" font-weight="bold" fill="#d693b1">workload/</text>
-  <text x="744" y="342" font-family="DejaVu Sans Mono" font-size="16" fill="#d693b1">base/</text>
-  <text x="744" y="376" font-family="DejaVu Sans Mono" font-size="16" fill="#d693b1">eu-north-01/</text>
-  <text x="744" y="410" font-family="DejaVu Sans Mono" font-size="16" fill="#d693b1">eu-west-01/</text>
-  <text x="820" y="442" text-anchor="middle" font-family="DejaVu Sans" font-size="14.5" fill="#8f8f8f">Flux tracks <tspan font-family="DejaVu Sans Mono" fill="#d6d6d6">main</tspan></text>
-  <text x="820" y="464" text-anchor="middle" font-family="DejaVu Sans" font-size="14.5" fill="#8f8f8f">SOPS-encrypted secrets in-repo</text>
+  <text x="700" y="268" font-family="DejaVu Sans Mono" font-size="17" font-weight="bold" fill="#5CE0B4">mgmt/</text>
+  <text x="700" y="306" font-family="DejaVu Sans Mono" font-size="17" font-weight="bold" fill="#68C5EB">workload/</text>
+  <text x="744" y="342" font-family="DejaVu Sans Mono" font-size="16" fill="#68C5EB">base/</text>
+  <text x="744" y="376" font-family="DejaVu Sans Mono" font-size="16" fill="#68C5EB">eu-north-01/</text>
+  <text x="744" y="410" font-family="DejaVu Sans Mono" font-size="16" fill="#68C5EB">eu-west-01/</text>
+  <text x="820" y="442" text-anchor="middle" font-family="DejaVu Sans" font-size="14.5" fill="#859D91">Flux tracks <tspan font-family="DejaVu Sans Mono" fill="#D4E2DA">main</tspan></text>
+  <text x="820" y="464" text-anchor="middle" font-family="DejaVu Sans" font-size="14.5" fill="#859D91">SOPS-encrypted secrets in-repo</text>
 
   <!-- ===== workload cluster 1 ===== -->
   <g>
-    <rect x="64" y="600" width="430" height="330" rx="14" fill="#131320" stroke="#3d3d55" stroke-width="1.5"/>
-    <rect x="80" y="608" width="398" height="5" rx="2.5" fill="#d693b1"/>
-    <text x="279" y="648" text-anchor="middle" font-family="DejaVu Sans" font-size="25" font-weight="bold" fill="#d693b1">Workload Cluster</text>
-    <text x="279" y="672" text-anchor="middle" font-family="DejaVu Sans" font-size="16" fill="#d6d6d6">eu-north-1 (EKS)</text>
+    <rect x="64" y="600" width="430" height="330" rx="14" fill="#131E18" stroke="#284637" stroke-width="1.5"/>
+    <rect x="80" y="608" width="398" height="5" rx="2.5" fill="#68C5EB"/>
+    <text x="279" y="648" text-anchor="middle" font-family="DejaVu Sans" font-size="25" font-weight="bold" fill="#68C5EB">Workload Cluster</text>
+    <text x="279" y="672" text-anchor="middle" font-family="DejaVu Sans" font-size="16" fill="#D4E2DA">eu-north-1 (EKS)</text>
     <g transform="translate(120,712) scale(0.85)">
-      <path d="M0,-18 L15,0 L0,18 L-15,0 Z" fill="#d693b1"/>
-      <line x1="0" y1="-18" x2="0" y2="18" stroke="#131320" stroke-width="2.5"/>
-      <path d="M-10,24 L0,30 L10,24" fill="none" stroke="#d693b1" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-      <path d="M-10,33 L0,39 L10,33" fill="none" stroke="#d693b1" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+      <path d="M0,-18 L15,0 L0,18 L-15,0 Z" fill="#68C5EB"/>
+      <line x1="0" y1="-18" x2="0" y2="18" stroke="#131E18" stroke-width="2.5"/>
+      <path d="M-10,24 L0,30 L10,24" fill="none" stroke="#68C5EB" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+      <path d="M-10,33 L0,39 L10,33" fill="none" stroke="#68C5EB" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
     </g>
-    <text x="156" y="712" font-family="DejaVu Sans" font-size="16" font-weight="bold" fill="#fafafa">Flux</text>
-    <text x="156" y="731" font-family="DejaVu Sans" font-size="13" fill="#8f8f8f">(local)</text>
-    <rect x="218" y="680" width="254" height="62" rx="8" fill="#1d1d30" stroke="#d693b1" stroke-opacity="0.6" stroke-width="1.2"/>
-    <text x="345" y="703" text-anchor="middle" font-family="DejaVu Sans" font-size="12.5" fill="#d6d6d6">syncs</text>
-    <text x="345" y="726" text-anchor="middle" font-family="DejaVu Sans Mono" font-size="16" fill="#d693b1">workload/eu-north-01/</text>
+    <text x="156" y="712" font-family="DejaVu Sans" font-size="16" font-weight="bold" fill="#FFFFFF">Flux</text>
+    <text x="156" y="731" font-family="DejaVu Sans" font-size="13" fill="#859D91">(local)</text>
+    <rect x="218" y="680" width="254" height="62" rx="8" fill="#1B2C23" stroke="#68C5EB" stroke-opacity="0.6" stroke-width="1.2"/>
+    <text x="345" y="703" text-anchor="middle" font-family="DejaVu Sans" font-size="12.5" fill="#D4E2DA">syncs</text>
+    <text x="345" y="726" text-anchor="middle" font-family="DejaVu Sans Mono" font-size="16" fill="#68C5EB">workload/eu-north-01/</text>
   </g>
 
   <!-- ===== workload cluster 2 ===== -->
   <g>
-    <rect x="600" y="600" width="430" height="330" rx="14" fill="#131320" stroke="#3d3d55" stroke-width="1.5"/>
-    <rect x="616" y="608" width="398" height="5" rx="2.5" fill="#d693b1"/>
-    <text x="815" y="648" text-anchor="middle" font-family="DejaVu Sans" font-size="25" font-weight="bold" fill="#d693b1">Workload Cluster</text>
-    <text x="815" y="672" text-anchor="middle" font-family="DejaVu Sans" font-size="16" fill="#d6d6d6">eu-west-1 (EKS)</text>
+    <rect x="600" y="600" width="430" height="330" rx="14" fill="#131E18" stroke="#284637" stroke-width="1.5"/>
+    <rect x="616" y="608" width="398" height="5" rx="2.5" fill="#68C5EB"/>
+    <text x="815" y="648" text-anchor="middle" font-family="DejaVu Sans" font-size="25" font-weight="bold" fill="#68C5EB">Workload Cluster</text>
+    <text x="815" y="672" text-anchor="middle" font-family="DejaVu Sans" font-size="16" fill="#D4E2DA">eu-west-1 (EKS)</text>
     <g transform="translate(656,712) scale(0.85)">
-      <path d="M0,-18 L15,0 L0,18 L-15,0 Z" fill="#d693b1"/>
-      <line x1="0" y1="-18" x2="0" y2="18" stroke="#131320" stroke-width="2.5"/>
-      <path d="M-10,24 L0,30 L10,24" fill="none" stroke="#d693b1" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-      <path d="M-10,33 L0,39 L10,33" fill="none" stroke="#d693b1" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+      <path d="M0,-18 L15,0 L0,18 L-15,0 Z" fill="#68C5EB"/>
+      <line x1="0" y1="-18" x2="0" y2="18" stroke="#131E18" stroke-width="2.5"/>
+      <path d="M-10,24 L0,30 L10,24" fill="none" stroke="#68C5EB" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+      <path d="M-10,33 L0,39 L10,33" fill="none" stroke="#68C5EB" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
     </g>
-    <text x="692" y="712" font-family="DejaVu Sans" font-size="16" font-weight="bold" fill="#fafafa">Flux</text>
-    <text x="692" y="731" font-family="DejaVu Sans" font-size="13" fill="#8f8f8f">(local)</text>
-    <rect x="754" y="680" width="254" height="62" rx="8" fill="#1d1d30" stroke="#d693b1" stroke-opacity="0.6" stroke-width="1.2"/>
-    <text x="881" y="703" text-anchor="middle" font-family="DejaVu Sans" font-size="12.5" fill="#d6d6d6">syncs</text>
-    <text x="881" y="726" text-anchor="middle" font-family="DejaVu Sans Mono" font-size="16" fill="#d693b1">workload/eu-west-01/</text>
+    <text x="692" y="712" font-family="DejaVu Sans" font-size="16" font-weight="bold" fill="#FFFFFF">Flux</text>
+    <text x="692" y="731" font-family="DejaVu Sans" font-size="13" fill="#859D91">(local)</text>
+    <rect x="754" y="680" width="254" height="62" rx="8" fill="#1B2C23" stroke="#68C5EB" stroke-opacity="0.6" stroke-width="1.2"/>
+    <text x="881" y="703" text-anchor="middle" font-family="DejaVu Sans" font-size="12.5" fill="#D4E2DA">syncs</text>
+    <text x="881" y="726" text-anchor="middle" font-family="DejaVu Sans Mono" font-size="16" fill="#68C5EB">workload/eu-west-01/</text>
   </g>
 
   <!-- pipelines (both clusters) -->
   <g id="pipe1">
-    <g stroke="#d6d6d6" stroke-width="1.8" fill="none">
+    <g stroke="#D4E2DA" stroke-width="1.8" fill="none">
       <circle cx="120" cy="794" r="12"/><circle cx="120" cy="794" r="4.2"/>
       <line x1="120" y1="777" x2="120" y2="782"/><line x1="120" y1="806" x2="120" y2="811"/>
       <line x1="103" y1="794" x2="108" y2="794"/><line x1="132" y1="794" x2="137" y2="794"/>
       <line x1="108" y1="782" x2="111.5" y2="785.5"/><line x1="128.5" y1="802.5" x2="132" y2="806"/>
       <line x1="108" y1="806" x2="111.5" y2="802.5"/><line x1="128.5" y1="785.5" x2="132" y2="782"/>
     </g>
-    <line x1="146" y1="794" x2="184" y2="794" stroke="#8f8f8f" stroke-width="1.8" marker-end="url(#arrow-gray)"/>
-    <g stroke="#85c7bb" stroke-width="1.8" fill="none">
+    <line x1="146" y1="794" x2="184" y2="794" stroke="#859D91" stroke-width="1.8" marker-end="url(#arrow-gray)"/>
+    <g stroke="#5CE0B4" stroke-width="1.8" fill="none">
       <ellipse cx="215" cy="782" rx="13" ry="4.5"/>
       <path d="M202,782 L206,806 h18 L228,782"/>
     </g>
-    <line x1="241" y1="794" x2="279" y2="794" stroke="#8f8f8f" stroke-width="1.8" marker-end="url(#arrow-gray)"/>
-    <g stroke="#ab9fd6" stroke-width="1.8" fill="none">
+    <line x1="241" y1="794" x2="279" y2="794" stroke="#859D91" stroke-width="1.8" marker-end="url(#arrow-gray)"/>
+    <g stroke="#B0F6C0" stroke-width="1.8" fill="none">
       <ellipse cx="310" cy="780" rx="13" ry="4.5"/>
       <path d="M297,780 V806 a13,4.5 0 0 0 26,0 V780"/>
       <path d="M297,793 a13,4.5 0 0 0 26,0"/>
     </g>
-    <line x1="336" y1="794" x2="374" y2="794" stroke="#8f8f8f" stroke-width="1.8" marker-end="url(#arrow-gray)"/>
-    <g stroke="#cfa07e" stroke-width="1.8" fill="none">
+    <line x1="336" y1="794" x2="374" y2="794" stroke="#859D91" stroke-width="1.8" marker-end="url(#arrow-gray)"/>
+    <g stroke="#E8A868" stroke-width="1.8" fill="none">
       <circle cx="405" cy="783" r="6.5"/>
       <path d="M393,808 a12,12 0 0 1 24,0"/>
     </g>
-    <text x="130" y="844" text-anchor="middle" font-family="DejaVu Sans Mono" font-size="14" fill="#d6d6d6">aws-operators</text>
-    <text x="215" y="870" text-anchor="middle" font-family="DejaVu Sans Mono" font-size="14" fill="#d6d6d6">s3-buckets</text>
-    <text x="310" y="844" text-anchor="middle" font-family="DejaVu Sans Mono" font-size="14" fill="#d6d6d6">rds-instances</text>
-    <text x="405" y="870" text-anchor="middle" font-family="DejaVu Sans Mono" font-size="14" fill="#d6d6d6">iam-roles</text>
+    <text x="130" y="844" text-anchor="middle" font-family="DejaVu Sans Mono" font-size="14" fill="#D4E2DA">aws-operators</text>
+    <text x="215" y="870" text-anchor="middle" font-family="DejaVu Sans Mono" font-size="14" fill="#D4E2DA">s3-buckets</text>
+    <text x="310" y="844" text-anchor="middle" font-family="DejaVu Sans Mono" font-size="14" fill="#D4E2DA">rds-instances</text>
+    <text x="405" y="870" text-anchor="middle" font-family="DejaVu Sans Mono" font-size="14" fill="#D4E2DA">iam-roles</text>
   </g>
   <use href="#pipe1" x="536" y="0"/>
 
   <!-- lifecycle strips -->
-  <rect x="88" y="884" width="382" height="42" rx="8" fill="#d693b1" fill-opacity="0.14"/>
-  <text x="279" y="911" text-anchor="middle" font-family="DejaVu Sans" font-size="16" font-weight="bold" fill="#d693b1">Manages application lifecycle</text>
-  <rect x="624" y="884" width="382" height="42" rx="8" fill="#d693b1" fill-opacity="0.14"/>
-  <text x="815" y="911" text-anchor="middle" font-family="DejaVu Sans" font-size="16" font-weight="bold" fill="#d693b1">Manages application lifecycle</text>
+  <rect x="88" y="884" width="382" height="42" rx="8" fill="#68C5EB" fill-opacity="0.14"/>
+  <text x="279" y="911" text-anchor="middle" font-family="DejaVu Sans" font-size="16" font-weight="bold" fill="#68C5EB">Manages application lifecycle</text>
+  <rect x="624" y="884" width="382" height="42" rx="8" fill="#68C5EB" fill-opacity="0.14"/>
+  <text x="815" y="911" text-anchor="middle" font-family="DejaVu Sans" font-size="16" font-weight="bold" fill="#68C5EB">Manages application lifecycle</text>
 
   <!-- dots between clusters -->
-  <text x="547" y="780" text-anchor="middle" font-family="DejaVu Sans" font-size="24" fill="#8f8f8f">&#183; &#183; &#183;</text>
+  <text x="547" y="780" text-anchor="middle" font-family="DejaVu Sans" font-size="24" fill="#859D91">&#183; &#183; &#183;</text>
 
   <!-- aws marks -->
   <g id="awsmark">
-    <text x="270" y="964" text-anchor="middle" font-family="DejaVu Sans" font-size="21" font-weight="bold" fill="#cfa07e">aws</text>
-    <path d="M250,971 Q270,982 291,969" fill="none" stroke="#cfa07e" stroke-width="2.2" stroke-linecap="round"/>
-    <path d="M291,969 l-1,5.5 M291,969 l-5.5,-0.5" stroke="#cfa07e" stroke-width="2.2" stroke-linecap="round"/>
+    <text x="270" y="964" text-anchor="middle" font-family="DejaVu Sans" font-size="21" font-weight="bold" fill="#E8A868">aws</text>
+    <path d="M250,971 Q270,982 291,969" fill="none" stroke="#E8A868" stroke-width="2.2" stroke-linecap="round"/>
+    <path d="M291,969 l-1,5.5 M291,969 l-5.5,-0.5" stroke="#E8A868" stroke-width="2.2" stroke-linecap="round"/>
   </g>
   <use href="#awsmark" x="536" y="0"/>
 
   <!-- ===== legend strip ===== -->
-  <rect x="64" y="992" width="966" height="66" rx="12" fill="#131320" stroke="#3d3d55" stroke-width="1.5"/>
-  <g stroke="#cfa07e" stroke-width="1.7" fill="none">
+  <rect x="64" y="992" width="966" height="66" rx="12" fill="#131E18" stroke="#284637" stroke-width="1.5"/>
+  <g stroke="#E8A868" stroke-width="1.7" fill="none">
     <circle cx="106" cy="1021" r="8"/>
     <path d="M102,1029 v4 h8 v-4 M103,1037 h6"/>
     <line x1="106" y1="1006" x2="106" y2="1009"/>
     <line x1="94" y1="1012" x2="96.5" y2="1014"/>
     <line x1="118" y1="1012" x2="115.5" y2="1014"/>
   </g>
-  <text x="134" y="1032" font-family="DejaVu Sans" font-size="17" font-weight="bold" fill="#85c7bb">Management cluster</text>
-  <text x="340" y="1032" font-family="DejaVu Sans" font-size="16" fill="#d6d6d6">= infrastructure lifecycle</text>
-  <line x1="592" y1="1004" x2="592" y2="1046" stroke="#3d3d55" stroke-width="1.4"/>
-  <text x="618" y="1032" font-family="DejaVu Sans" font-size="17" font-weight="bold" fill="#d693b1">Workload clusters</text>
-  <text x="806" y="1032" font-family="DejaVu Sans" font-size="16" fill="#d6d6d6">= application lifecycle</text>
+  <text x="134" y="1032" font-family="DejaVu Sans" font-size="17" font-weight="bold" fill="#5CE0B4">Management cluster</text>
+  <text x="340" y="1032" font-family="DejaVu Sans" font-size="16" fill="#D4E2DA">= infrastructure lifecycle</text>
+  <line x1="592" y1="1004" x2="592" y2="1046" stroke="#284637" stroke-width="1.4"/>
+  <text x="618" y="1032" font-family="DejaVu Sans" font-size="17" font-weight="bold" fill="#68C5EB">Workload clusters</text>
+  <text x="806" y="1032" font-family="DejaVu Sans" font-size="16" fill="#D4E2DA">= application lifecycle</text>
 
   <!-- ===== flow panel ===== -->
-  <rect x="1090" y="150" width="446" height="904" rx="14" fill="#131320" stroke="#3d3d55" stroke-width="1.5"/>
+  <rect x="1090" y="150" width="446" height="904" rx="14" fill="#131E18" stroke="#284637" stroke-width="1.5"/>
 
   <!-- step 1 -->
-  <circle cx="1140" cy="208" r="15" fill="#85c7bb"/>
-  <text x="1140" y="214" text-anchor="middle" font-family="DejaVu Sans" font-size="15" font-weight="bold" fill="#0f0f0f">1</text>
-  <text x="1168" y="204" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">Management cluster Flux syncs</text>
-  <text x="1168" y="230" font-family="DejaVu Sans Mono" font-size="16" fill="#85c7bb">mgmt/<tspan font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">, provisions EKS clusters,</tspan></text>
-  <text x="1168" y="256" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">and installs Flux on each workload</text>
-  <text x="1168" y="282" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">cluster via <tspan font-family="DejaVu Sans Mono" font-size="16" fill="#85c7bb">flux-apps</tspan>.</text>
+  <circle cx="1140" cy="208" r="15" fill="#5CE0B4"/>
+  <text x="1140" y="214" text-anchor="middle" font-family="DejaVu Sans" font-size="15" font-weight="bold" fill="#0C120F">1</text>
+  <text x="1168" y="204" font-family="DejaVu Sans" font-size="17" fill="#D4E2DA">Management cluster Flux syncs</text>
+  <text x="1168" y="230" font-family="DejaVu Sans Mono" font-size="16" fill="#5CE0B4">mgmt/<tspan font-family="DejaVu Sans" font-size="17" fill="#D4E2DA">, provisions EKS clusters,</tspan></text>
+  <text x="1168" y="256" font-family="DejaVu Sans" font-size="17" fill="#D4E2DA">and installs Flux on each workload</text>
+  <text x="1168" y="282" font-family="DejaVu Sans" font-size="17" fill="#D4E2DA">cluster via <tspan font-family="DejaVu Sans Mono" font-size="16" fill="#5CE0B4">flux-apps</tspan>.</text>
   <g transform="translate(1140,334) scale(0.85)">
-    <path d="M0,-18 L15,0 L0,18 L-15,0 Z" fill="#85c7bb"/>
-    <line x1="0" y1="-18" x2="0" y2="18" stroke="#131320" stroke-width="2.5"/>
-    <path d="M-10,24 L0,30 L10,24" fill="none" stroke="#85c7bb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M0,-18 L15,0 L0,18 L-15,0 Z" fill="#5CE0B4"/>
+    <line x1="0" y1="-18" x2="0" y2="18" stroke="#131E18" stroke-width="2.5"/>
+    <path d="M-10,24 L0,30 L10,24" fill="none" stroke="#5CE0B4" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   </g>
-  <line x1="1122" y1="384" x2="1504" y2="384" stroke="#34344a" stroke-width="1.2"/>
+  <line x1="1122" y1="384" x2="1504" y2="384" stroke="#1F362A" stroke-width="1.2"/>
 
   <!-- step 2 -->
-  <circle cx="1140" cy="432" r="15" fill="#d693b1"/>
-  <text x="1140" y="438" text-anchor="middle" font-family="DejaVu Sans" font-size="15" font-weight="bold" fill="#0f0f0f">2</text>
-  <text x="1168" y="428" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">Each workload cluster runs its own</text>
-  <text x="1168" y="454" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">Flux instance, syncing its overlay</text>
-  <text x="1168" y="480" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">under <tspan font-family="DejaVu Sans Mono" font-size="16" fill="#d693b1">workload/&lt;cluster&gt;/</tspan>.</text>
-  <g stroke="#d693b1" stroke-width="1.7" fill="none">
+  <circle cx="1140" cy="432" r="15" fill="#68C5EB"/>
+  <text x="1140" y="438" text-anchor="middle" font-family="DejaVu Sans" font-size="15" font-weight="bold" fill="#0C120F">2</text>
+  <text x="1168" y="428" font-family="DejaVu Sans" font-size="17" fill="#D4E2DA">Each workload cluster runs its own</text>
+  <text x="1168" y="454" font-family="DejaVu Sans" font-size="17" fill="#D4E2DA">Flux instance, syncing its overlay</text>
+  <text x="1168" y="480" font-family="DejaVu Sans" font-size="17" fill="#D4E2DA">under <tspan font-family="DejaVu Sans Mono" font-size="16" fill="#68C5EB">workload/&lt;cluster&gt;/</tspan>.</text>
+  <g stroke="#68C5EB" stroke-width="1.7" fill="none">
     <circle cx="1130" cy="530" r="5.5"/><circle cx="1152" cy="518" r="5.5"/><circle cx="1152" cy="542" r="5.5"/><circle cx="1174" cy="530" r="5.5"/>
     <line x1="1135" y1="527" x2="1147" y2="521"/><line x1="1135" y1="533" x2="1147" y2="539"/>
     <line x1="1157" y1="521" x2="1169" y2="527"/><line x1="1157" y1="539" x2="1169" y2="533"/>
   </g>
-  <line x1="1122" y1="580" x2="1504" y2="580" stroke="#34344a" stroke-width="1.2"/>
+  <line x1="1122" y1="580" x2="1504" y2="580" stroke="#1F362A" stroke-width="1.2"/>
 
   <!-- step 3 -->
-  <circle cx="1140" cy="628" r="15" fill="#d693b1"/>
-  <text x="1140" y="634" text-anchor="middle" font-family="DejaVu Sans" font-size="15" font-weight="bold" fill="#0f0f0f">3</text>
-  <text x="1168" y="624" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">Workload Flux reconciles locally:</text>
-  <text x="1168" y="660" font-family="DejaVu Sans Mono" font-size="18" fill="#d6d6d6">1. <tspan fill="#fafafa">aws-operators</tspan> <tspan font-family="DejaVu Sans" fill="#8f8f8f">(ACK)</tspan></text>
-  <text x="1168" y="692" font-family="DejaVu Sans Mono" font-size="18" fill="#d6d6d6">2. <tspan fill="#fafafa">s3-buckets &#183; rds-instances</tspan></text>
-  <text x="1200" y="724" font-family="DejaVu Sans Mono" font-size="18" fill="#fafafa">&#183; iam-roles <tspan font-family="DejaVu Sans" fill="#d6d6d6">in parallel</tspan></text>
-  <text x="1168" y="754" font-family="DejaVu Sans Mono" font-size="14.5" fill="#8f8f8f">(each dependsOn: aws-operators)</text>
-  <line x1="1122" y1="788" x2="1504" y2="788" stroke="#34344a" stroke-width="1.2"/>
+  <circle cx="1140" cy="628" r="15" fill="#68C5EB"/>
+  <text x="1140" y="634" text-anchor="middle" font-family="DejaVu Sans" font-size="15" font-weight="bold" fill="#0C120F">3</text>
+  <text x="1168" y="624" font-family="DejaVu Sans" font-size="17" fill="#D4E2DA">Workload Flux reconciles locally:</text>
+  <text x="1168" y="660" font-family="DejaVu Sans Mono" font-size="18" fill="#D4E2DA">1. <tspan fill="#FFFFFF">aws-operators</tspan> <tspan font-family="DejaVu Sans" fill="#859D91">(ACK)</tspan></text>
+  <text x="1168" y="692" font-family="DejaVu Sans Mono" font-size="18" fill="#D4E2DA">2. <tspan fill="#FFFFFF">s3-buckets &#183; rds-instances</tspan></text>
+  <text x="1200" y="724" font-family="DejaVu Sans Mono" font-size="18" fill="#FFFFFF">&#183; iam-roles <tspan font-family="DejaVu Sans" fill="#D4E2DA">in parallel</tspan></text>
+  <text x="1168" y="754" font-family="DejaVu Sans Mono" font-size="14.5" fill="#859D91">(each dependsOn: aws-operators)</text>
+  <line x1="1122" y1="788" x2="1504" y2="788" stroke="#1F362A" stroke-width="1.2"/>
 
   <!-- golden rule -->
-  <text x="1122" y="832" font-family="DejaVu Sans" font-size="22" font-weight="bold" fill="#f2c464">Golden rule</text>
-  <text x="1122" y="866" font-family="DejaVu Sans" font-size="18" fill="#d6d6d6">Edit YAML in Git; never mutate</text>
-  <text x="1122" y="894" font-family="DejaVu Sans" font-size="18" fill="#d6d6d6">the clusters. Flux tracks <tspan font-family="DejaVu Sans Mono" font-size="17" fill="#fafafa">main</tspan>:</text>
-  <text x="1122" y="922" font-family="DejaVu Sans" font-size="18" fill="#d6d6d6">nothing reconciles until merged.</text>
-  <line x1="1122" y1="958" x2="1504" y2="958" stroke="#34344a" stroke-width="1.2"/>
+  <text x="1122" y="832" font-family="DejaVu Sans" font-size="22" font-weight="bold" fill="#E5B85C">Golden rule</text>
+  <text x="1122" y="866" font-family="DejaVu Sans" font-size="18" fill="#D4E2DA">Edit YAML in Git; never mutate</text>
+  <text x="1122" y="894" font-family="DejaVu Sans" font-size="18" fill="#D4E2DA">the clusters. Flux tracks <tspan font-family="DejaVu Sans Mono" font-size="17" fill="#FFFFFF">main</tspan>:</text>
+  <text x="1122" y="922" font-family="DejaVu Sans" font-size="18" fill="#D4E2DA">nothing reconciles until merged.</text>
+  <line x1="1122" y1="958" x2="1504" y2="958" stroke="#1F362A" stroke-width="1.2"/>
 
   <!-- color key -->
-  <circle cx="1132" cy="998" r="6" fill="#85c7bb"/>
-  <text x="1146" y="1004" font-family="DejaVu Sans Mono" font-size="14" fill="#d6d6d6">mgmt</text>
-  <circle cx="1210" cy="998" r="6" fill="#ab9fd6"/>
-  <text x="1224" y="1004" font-family="DejaVu Sans Mono" font-size="14" fill="#d6d6d6">git</text>
-  <circle cx="1282" cy="998" r="6" fill="#d693b1"/>
-  <text x="1296" y="1004" font-family="DejaVu Sans Mono" font-size="14" fill="#d6d6d6">workload</text>
-  <circle cx="1398" cy="998" r="6" fill="#cfa07e"/>
-  <text x="1412" y="1004" font-family="DejaVu Sans Mono" font-size="14" fill="#d6d6d6">aws</text>
+  <circle cx="1132" cy="998" r="6" fill="#5CE0B4"/>
+  <text x="1146" y="1004" font-family="DejaVu Sans Mono" font-size="14" fill="#D4E2DA">mgmt</text>
+  <circle cx="1210" cy="998" r="6" fill="#B0F6C0"/>
+  <text x="1224" y="1004" font-family="DejaVu Sans Mono" font-size="14" fill="#D4E2DA">git</text>
+  <circle cx="1282" cy="998" r="6" fill="#68C5EB"/>
+  <text x="1296" y="1004" font-family="DejaVu Sans Mono" font-size="14" fill="#D4E2DA">workload</text>
+  <circle cx="1398" cy="998" r="6" fill="#E8A868"/>
+  <text x="1412" y="1004" font-family="DejaVu Sans Mono" font-size="14" fill="#D4E2DA">aws</text>
 
   <!-- ===== footer ===== -->
-  <text x="800" y="1102" text-anchor="middle" font-family="DejaVu Sans" font-size="17" fill="#8f8f8f">Every persistent change lands in Git; Flux converges the clusters.</text>
-  <text x="800" y="1128" text-anchor="middle" font-family="DejaVu Sans" font-size="17" fill="#8f8f8f">No Terraform, no state files: the Kubernetes API is the only toolchain.</text>
+  <text x="800" y="1102" text-anchor="middle" font-family="DejaVu Sans" font-size="17" fill="#859D91">Every persistent change lands in Git; Flux converges the clusters.</text>
+  <text x="800" y="1128" text-anchor="middle" font-family="DejaVu Sans" font-size="17" fill="#859D91">No Terraform, no state files: the Kubernetes API is the only toolchain.</text>
 </svg>

--- a/docs/local-host-infra.svg
+++ b/docs/local-host-infra.svg
@@ -1,53 +1,53 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1600" height="1150" viewBox="0 0 1600 1150">
   <defs>
     <marker id="arrow-teal" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
-      <path d="M0,0 L10,5 L0,10 z" fill="#85c7bb"/>
+      <path d="M0,0 L10,5 L0,10 z" fill="#5CE0B4"/>
     </marker>
     <marker id="arrow-gray" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
-      <path d="M0,0 L10,5 L0,10 z" fill="#8f8f8f"/>
+      <path d="M0,0 L10,5 L0,10 z" fill="#859D91"/>
     </marker>
     <marker id="arrow-purple" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
-      <path d="M0,0 L10,5 L0,10 z" fill="#ab9fd6"/>
+      <path d="M0,0 L10,5 L0,10 z" fill="#B0F6C0"/>
     </marker>
   </defs>
 
   <!-- ===== background ===== -->
-  <rect width="1600" height="1150" fill="#0f0f0f"/>
+  <rect width="1600" height="1150" fill="#0C120F"/>
 
   <!-- ===== title block ===== -->
-  <text x="800" y="60" text-anchor="middle" font-family="DejaVu Sans" font-size="40" font-weight="bold" fill="#ff78c9">krops &#183; local-host Environment &#183; Same Chain, Zero Cloud</text>
-  <text x="800" y="96" text-anchor="middle" font-family="DejaVu Sans" font-size="19" fill="#8f8f8f">Flux + CAPI/CAPD &#183; local OCI registry replaces GitHub &#183; the full GitOps + CAPI lifecycle on one laptop</text>
+  <text x="800" y="60" text-anchor="middle" font-family="DejaVu Sans" font-size="40" font-weight="bold" fill="#5CE0B4">krops &#183; local-host Environment &#183; Same Chain, Zero Cloud</text>
+  <text x="800" y="96" text-anchor="middle" font-family="DejaVu Sans" font-size="19" fill="#859D91">Flux + CAPI/CAPD &#183; local OCI registry replaces GitHub &#183; the full GitOps + CAPI lifecycle on one laptop</text>
 
   <!-- ===== section headers ===== -->
-  <text x="64" y="138" font-family="DejaVu Sans" font-size="20" font-weight="bold" fill="#fafafa">TOPOLOGY (all containers on your laptop)</text>
-  <text x="1090" y="138" font-family="DejaVu Sans" font-size="20" font-weight="bold" fill="#fafafa">FLOW (reconciliation order)</text>
+  <text x="64" y="138" font-family="DejaVu Sans" font-size="20" font-weight="bold" fill="#FFFFFF">TOPOLOGY (all containers on your laptop)</text>
+  <text x="1090" y="138" font-family="DejaVu Sans" font-size="20" font-weight="bold" fill="#FFFFFF">FLOW (reconciliation order)</text>
 
   <!-- ===== connections (behind boxes) ===== -->
-  <line x1="612" y1="256" x2="508" y2="256" stroke="#ab9fd6" stroke-width="2.5" marker-end="url(#arrow-purple)"/>
-  <text x="561" y="222" text-anchor="middle" font-family="DejaVu Sans" font-size="17" font-weight="bold" fill="#fafafa">2. syncs</text>
-  <text x="561" y="244" text-anchor="middle" font-family="DejaVu Sans Mono" font-size="11" fill="#85c7bb">mgmt/local-host/</text>
-  <path d="M284,484 V594" fill="none" stroke="#85c7bb" stroke-width="2.5" stroke-dasharray="7,6" marker-end="url(#arrow-teal)"/>
-  <text x="470" y="530" text-anchor="middle" font-family="DejaVu Sans" font-size="16" fill="#d6d6d6">3. provisions CAPD cluster &#183; installs Flux via <tspan font-family="DejaVu Sans Mono" fill="#85c7bb">flux-apps</tspan></text>
-  <path d="M820,484 V560 H560 V594" fill="none" stroke="#ab9fd6" stroke-width="2.5" stroke-dasharray="7,6" marker-end="url(#arrow-purple)"/>
-  <text x="820" y="580" text-anchor="middle" font-family="DejaVu Sans" font-size="16" fill="#d6d6d6">4. workload Flux pulls same OCI artifact</text>
+  <line x1="612" y1="256" x2="508" y2="256" stroke="#B0F6C0" stroke-width="2.5" marker-end="url(#arrow-purple)"/>
+  <text x="561" y="222" text-anchor="middle" font-family="DejaVu Sans" font-size="17" font-weight="bold" fill="#FFFFFF">2. syncs</text>
+  <text x="561" y="244" text-anchor="middle" font-family="DejaVu Sans Mono" font-size="11" fill="#5CE0B4">mgmt/local-host/</text>
+  <path d="M284,484 V594" fill="none" stroke="#5CE0B4" stroke-width="2.5" stroke-dasharray="7,6" marker-end="url(#arrow-teal)"/>
+  <text x="470" y="530" text-anchor="middle" font-family="DejaVu Sans" font-size="16" fill="#D4E2DA">3. provisions CAPD cluster &#183; installs Flux via <tspan font-family="DejaVu Sans Mono" fill="#5CE0B4">flux-apps</tspan></text>
+  <path d="M820,484 V560 H560 V594" fill="none" stroke="#B0F6C0" stroke-width="2.5" stroke-dasharray="7,6" marker-end="url(#arrow-purple)"/>
+  <text x="820" y="580" text-anchor="middle" font-family="DejaVu Sans" font-size="16" fill="#D4E2DA">4. workload Flux pulls same OCI artifact</text>
 
   <!-- ===== management cluster ===== -->
-  <rect x="64" y="150" width="440" height="330" rx="14" fill="#131320" stroke="#3d3d55" stroke-width="1.5"/>
-  <rect x="80" y="158" width="408" height="5" rx="2.5" fill="#85c7bb"/>
-  <text x="284" y="198" text-anchor="middle" font-family="DejaVu Sans" font-size="25" font-weight="bold" fill="#85c7bb">Management Cluster</text>
-  <text x="284" y="222" text-anchor="middle" font-family="DejaVu Sans" font-size="16" fill="#8f8f8f">(self-managed CAPD &#183; post-pivot)</text>
+  <rect x="64" y="150" width="440" height="330" rx="14" fill="#131E18" stroke="#284637" stroke-width="1.5"/>
+  <rect x="80" y="158" width="408" height="5" rx="2.5" fill="#5CE0B4"/>
+  <text x="284" y="198" text-anchor="middle" font-family="DejaVu Sans" font-size="25" font-weight="bold" fill="#5CE0B4">Management Cluster</text>
+  <text x="284" y="222" text-anchor="middle" font-family="DejaVu Sans" font-size="16" fill="#859D91">(self-managed CAPD &#183; post-pivot)</text>
   <!-- flux glyph -->
   <g transform="translate(122,262)">
-    <path d="M0,-18 L15,0 L0,18 L-15,0 Z" fill="#85c7bb"/>
-    <line x1="0" y1="-18" x2="0" y2="18" stroke="#131320" stroke-width="2.5"/>
-    <path d="M-10,24 L0,30 L10,24" fill="none" stroke="#85c7bb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M-10,33 L0,39 L10,33" fill="none" stroke="#85c7bb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M0,-18 L15,0 L0,18 L-15,0 Z" fill="#5CE0B4"/>
+    <line x1="0" y1="-18" x2="0" y2="18" stroke="#131E18" stroke-width="2.5"/>
+    <path d="M-10,24 L0,30 L10,24" fill="none" stroke="#5CE0B4" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M-10,33 L0,39 L10,33" fill="none" stroke="#5CE0B4" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   </g>
-  <text x="122" y="328" text-anchor="middle" font-family="DejaVu Sans" font-size="16" font-weight="bold" fill="#fafafa">Flux</text>
-  <line x1="162" y1="266" x2="230" y2="266" stroke="#8f8f8f" stroke-width="2" marker-end="url(#arrow-gray)"/>
+  <text x="122" y="328" text-anchor="middle" font-family="DejaVu Sans" font-size="16" font-weight="bold" fill="#FFFFFF">Flux</text>
+  <line x1="162" y1="266" x2="230" y2="266" stroke="#859D91" stroke-width="2" marker-end="url(#arrow-gray)"/>
   <!-- capi/capd chip -->
-  <rect x="238" y="230" width="250" height="72" rx="10" fill="#1d1d30" stroke="#3d3d55" stroke-width="1.2"/>
-  <g stroke="#85c7bb" stroke-width="1.6" fill="none">
+  <rect x="238" y="230" width="250" height="72" rx="10" fill="#1B2C23" stroke="#284637" stroke-width="1.2"/>
+  <g stroke="#5CE0B4" stroke-width="1.6" fill="none">
     <circle cx="272" cy="258" r="9"/>
     <circle cx="272" cy="258" r="3.2"/>
     <g>
@@ -59,147 +59,147 @@
     <circle cx="290" cy="276" r="6.5"/>
     <circle cx="290" cy="276" r="2.2"/>
   </g>
-  <text x="308" y="264" font-family="DejaVu Sans" font-size="17" font-weight="bold" fill="#fafafa">CAPI / CAPD</text>
-  <text x="308" y="287" font-family="DejaVu Sans" font-size="14.5" fill="#d6d6d6">Docker provider</text>
+  <text x="308" y="264" font-family="DejaVu Sans" font-size="17" font-weight="bold" fill="#FFFFFF">CAPI / CAPD</text>
+  <text x="308" y="287" font-family="DejaVu Sans" font-size="14.5" fill="#D4E2DA">Docker provider</text>
   <!-- infra lifecycle sub-panel -->
-  <rect x="88" y="340" width="384" height="120" rx="10" fill="#85c7bb" fill-opacity="0.12" stroke="#85c7bb" stroke-opacity="0.5" stroke-width="1.2"/>
-  <text x="280" y="374" text-anchor="middle" font-family="DejaVu Sans" font-size="16.5" font-weight="bold" fill="#85c7bb">Manages infrastructure lifecycle</text>
-  <path d="M116,424 a9,9 0 0 1 2,-17.8 a11,11 0 0 1 21,-1.5 a8.5,8.5 0 0 1 3,17.5 z" fill="none" stroke="#d6d6d6" stroke-width="1.7" stroke-linejoin="round"/>
-  <text x="152" y="420" font-family="DejaVu Sans" font-size="15" fill="#d6d6d6">CAPD cluster</text>
-  <g fill="none" stroke="#d6d6d6" stroke-width="1.7" stroke-linejoin="round">
+  <rect x="88" y="340" width="384" height="120" rx="10" fill="#5CE0B4" fill-opacity="0.12" stroke="#5CE0B4" stroke-opacity="0.5" stroke-width="1.2"/>
+  <text x="280" y="374" text-anchor="middle" font-family="DejaVu Sans" font-size="16.5" font-weight="bold" fill="#5CE0B4">Manages infrastructure lifecycle</text>
+  <path d="M116,424 a9,9 0 0 1 2,-17.8 a11,11 0 0 1 21,-1.5 a8.5,8.5 0 0 1 3,17.5 z" fill="none" stroke="#D4E2DA" stroke-width="1.7" stroke-linejoin="round"/>
+  <text x="152" y="420" font-family="DejaVu Sans" font-size="15" fill="#D4E2DA">CAPD cluster</text>
+  <g fill="none" stroke="#D4E2DA" stroke-width="1.7" stroke-linejoin="round">
     <path d="M270,406 h9 a5,5 0 1 1 10,0 h9 v9 a5,5 0 1 1 0,10 v9 h-28 z"/>
   </g>
-  <text x="306" y="420" font-family="DejaVu Sans" font-size="15" fill="#d6d6d6">Flux bootstrap addon</text>
+  <text x="306" y="420" font-family="DejaVu Sans" font-size="15" fill="#D4E2DA">Flux bootstrap addon</text>
 
   <!-- ===== local OCI registry ===== -->
-  <rect x="620" y="150" width="400" height="330" rx="14" fill="#131320" stroke="#3d3d55" stroke-width="1.5"/>
-  <rect x="636" y="158" width="368" height="5" rx="2.5" fill="#ab9fd6"/>
-  <text x="820" y="198" text-anchor="middle" font-family="DejaVu Sans" font-size="25" font-weight="bold" fill="#ab9fd6">Local OCI Registry</text>
-  <text x="820" y="222" text-anchor="middle" font-family="DejaVu Sans Mono" font-size="16" fill="#8f8f8f">krops-registry:5000</text>
+  <rect x="620" y="150" width="400" height="330" rx="14" fill="#131E18" stroke="#284637" stroke-width="1.5"/>
+  <rect x="636" y="158" width="368" height="5" rx="2.5" fill="#B0F6C0"/>
+  <text x="820" y="198" text-anchor="middle" font-family="DejaVu Sans" font-size="25" font-weight="bold" fill="#B0F6C0">Local OCI Registry</text>
+  <text x="820" y="222" text-anchor="middle" font-family="DejaVu Sans Mono" font-size="16" fill="#859D91">krops-registry:5000</text>
   <!-- artifact box -->
-  <rect x="652" y="244" width="336" height="60" rx="10" fill="#1d1d30" stroke="#ab9fd6" stroke-opacity="0.6" stroke-width="1.2"/>
-  <text x="820" y="269" text-anchor="middle" font-family="DejaVu Sans Mono" font-size="17" font-weight="bold" fill="#ab9fd6">oci://krops-registry:5000/krops</text>
-  <text x="820" y="292" text-anchor="middle" font-family="DejaVu Sans Mono" font-size="15" fill="#d6d6d6">krops:latest</text>
+  <rect x="652" y="244" width="336" height="60" rx="10" fill="#1B2C23" stroke="#B0F6C0" stroke-opacity="0.6" stroke-width="1.2"/>
+  <text x="820" y="269" text-anchor="middle" font-family="DejaVu Sans Mono" font-size="17" font-weight="bold" fill="#B0F6C0">oci://krops-registry:5000/krops</text>
+  <text x="820" y="292" text-anchor="middle" font-family="DejaVu Sans Mono" font-size="15" fill="#D4E2DA">krops:latest</text>
   <!-- folder tree -->
   <g fill="none" stroke-width="1.7">
-    <path d="M672,326 h9 l4,5 h15 v16 h-28 z" stroke="#85c7bb"/>
-    <path d="M672,368 h9 l4,5 h15 v16 h-28 z" stroke="#d693b1"/>
+    <path d="M672,326 h9 l4,5 h15 v16 h-28 z" stroke="#5CE0B4"/>
+    <path d="M672,368 h9 l4,5 h15 v16 h-28 z" stroke="#68C5EB"/>
   </g>
-  <text x="712" y="344" font-family="DejaVu Sans Mono" font-size="17" font-weight="bold" fill="#85c7bb">mgmt/local-host/</text>
-  <text x="712" y="386" font-family="DejaVu Sans Mono" font-size="17" font-weight="bold" fill="#d693b1">workload/local-host/</text>
-  <text x="820" y="428" text-anchor="middle" font-family="DejaVu Sans" font-size="14.5" fill="#8f8f8f">published from your working tree by</text>
-  <text x="820" y="452" text-anchor="middle" font-family="DejaVu Sans Mono" font-size="15" fill="#d6d6d6">mise -E local-host run oci-push</text>
+  <text x="712" y="344" font-family="DejaVu Sans Mono" font-size="17" font-weight="bold" fill="#5CE0B4">mgmt/local-host/</text>
+  <text x="712" y="386" font-family="DejaVu Sans Mono" font-size="17" font-weight="bold" fill="#68C5EB">workload/local-host/</text>
+  <text x="820" y="428" text-anchor="middle" font-family="DejaVu Sans" font-size="14.5" fill="#859D91">published from your working tree by</text>
+  <text x="820" y="452" text-anchor="middle" font-family="DejaVu Sans Mono" font-size="15" fill="#D4E2DA">mise -E local-host run oci-push</text>
 
   <!-- push arrow into registry (from laptop) -->
-  <line x1="1058" y1="256" x2="1028" y2="256" stroke="#8f8f8f" stroke-width="2" marker-end="url(#arrow-gray)"/>
-  <text x="1044" y="230" text-anchor="end" font-family="DejaVu Sans" font-size="15" fill="#8f8f8f">1. oci-push</text>
+  <line x1="1058" y1="256" x2="1028" y2="256" stroke="#859D91" stroke-width="2" marker-end="url(#arrow-gray)"/>
+  <text x="1044" y="230" text-anchor="end" font-family="DejaVu Sans" font-size="15" fill="#859D91">1. oci-push</text>
 
   <!-- ===== workload cluster ===== -->
-  <rect x="290" y="600" width="540" height="330" rx="14" fill="#131320" stroke="#3d3d55" stroke-width="1.5"/>
-  <rect x="306" y="608" width="508" height="5" rx="2.5" fill="#d693b1"/>
-  <text x="560" y="648" text-anchor="middle" font-family="DejaVu Sans" font-size="25" font-weight="bold" fill="#d693b1">Workload Cluster</text>
-  <text x="560" y="672" text-anchor="middle" font-family="DejaVu Sans" font-size="16" fill="#d6d6d6">CAPD &#183; 1 control plane + 1 worker (Docker containers)</text>
+  <rect x="290" y="600" width="540" height="330" rx="14" fill="#131E18" stroke="#284637" stroke-width="1.5"/>
+  <rect x="306" y="608" width="508" height="5" rx="2.5" fill="#68C5EB"/>
+  <text x="560" y="648" text-anchor="middle" font-family="DejaVu Sans" font-size="25" font-weight="bold" fill="#68C5EB">Workload Cluster</text>
+  <text x="560" y="672" text-anchor="middle" font-family="DejaVu Sans" font-size="16" fill="#D4E2DA">CAPD &#183; 1 control plane + 1 worker (Docker containers)</text>
   <g transform="translate(370,722) scale(0.85)">
-    <path d="M0,-18 L15,0 L0,18 L-15,0 Z" fill="#d693b1"/>
-    <line x1="0" y1="-18" x2="0" y2="18" stroke="#131320" stroke-width="2.5"/>
-    <path d="M-10,24 L0,30 L10,24" fill="none" stroke="#d693b1" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M-10,33 L0,39 L10,33" fill="none" stroke="#d693b1" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M0,-18 L15,0 L0,18 L-15,0 Z" fill="#68C5EB"/>
+    <line x1="0" y1="-18" x2="0" y2="18" stroke="#131E18" stroke-width="2.5"/>
+    <path d="M-10,24 L0,30 L10,24" fill="none" stroke="#68C5EB" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M-10,33 L0,39 L10,33" fill="none" stroke="#68C5EB" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   </g>
-  <text x="406" y="722" font-family="DejaVu Sans" font-size="16" font-weight="bold" fill="#fafafa">Flux</text>
-  <text x="406" y="741" font-family="DejaVu Sans" font-size="13" fill="#8f8f8f">(local)</text>
-  <rect x="470" y="690" width="300" height="62" rx="8" fill="#1d1d30" stroke="#d693b1" stroke-opacity="0.6" stroke-width="1.2"/>
-  <text x="620" y="713" text-anchor="middle" font-family="DejaVu Sans" font-size="12.5" fill="#d6d6d6">syncs OCI artifact path</text>
-  <text x="620" y="736" text-anchor="middle" font-family="DejaVu Sans Mono" font-size="16" fill="#d693b1">workload/local-host/</text>
+  <text x="406" y="722" font-family="DejaVu Sans" font-size="16" font-weight="bold" fill="#FFFFFF">Flux</text>
+  <text x="406" y="741" font-family="DejaVu Sans" font-size="13" fill="#859D91">(local)</text>
+  <rect x="470" y="690" width="300" height="62" rx="8" fill="#1B2C23" stroke="#68C5EB" stroke-opacity="0.6" stroke-width="1.2"/>
+  <text x="620" y="713" text-anchor="middle" font-family="DejaVu Sans" font-size="12.5" fill="#D4E2DA">syncs OCI artifact path</text>
+  <text x="620" y="736" text-anchor="middle" font-family="DejaVu Sans Mono" font-size="16" fill="#68C5EB">workload/local-host/</text>
   <!-- podinfo app chip -->
-  <rect x="370" y="782" width="380" height="70" rx="10" fill="#1d1d30" stroke="#3d3d55" stroke-width="1.2"/>
-  <g stroke="#cfa07e" stroke-width="1.8" fill="none">
+  <rect x="370" y="782" width="380" height="70" rx="10" fill="#1B2C23" stroke="#284637" stroke-width="1.2"/>
+  <g stroke="#E8A868" stroke-width="1.8" fill="none">
     <circle cx="410" cy="810" r="7"/>
     <path d="M397,838 a13,13 0 0 1 26,0"/>
   </g>
-  <text x="442" y="812" font-family="DejaVu Sans Mono" font-size="17" font-weight="bold" fill="#fafafa">podinfo</text>
-  <text x="442" y="836" font-family="DejaVu Sans" font-size="14.5" fill="#d6d6d6">demo app &#183; reachable from your laptop</text>
+  <text x="442" y="812" font-family="DejaVu Sans Mono" font-size="17" font-weight="bold" fill="#FFFFFF">podinfo</text>
+  <text x="442" y="836" font-family="DejaVu Sans" font-size="14.5" fill="#D4E2DA">demo app &#183; reachable from your laptop</text>
   <!-- lifecycle strip -->
-  <rect x="314" y="872" width="492" height="42" rx="8" fill="#d693b1" fill-opacity="0.14"/>
-  <text x="560" y="899" text-anchor="middle" font-family="DejaVu Sans" font-size="16" font-weight="bold" fill="#d693b1">Manages application lifecycle</text>
+  <rect x="314" y="872" width="492" height="42" rx="8" fill="#68C5EB" fill-opacity="0.14"/>
+  <text x="560" y="899" text-anchor="middle" font-family="DejaVu Sans" font-size="16" font-weight="bold" fill="#68C5EB">Manages application lifecycle</text>
 
   <!-- port-forward arrow -->
-  <path d="M830,817 H1000" fill="none" stroke="#8f8f8f" stroke-width="2" marker-end="url(#arrow-gray)"/>
-  <text x="915" y="795" text-anchor="middle" font-family="DejaVu Sans" font-size="15" fill="#8f8f8f">5. port-forward</text>
-  <text x="915" y="843" text-anchor="middle" font-family="DejaVu Sans Mono" font-size="15" fill="#cfa07e">localhost:9898</text>
+  <path d="M830,817 H1000" fill="none" stroke="#859D91" stroke-width="2" marker-end="url(#arrow-gray)"/>
+  <text x="915" y="795" text-anchor="middle" font-family="DejaVu Sans" font-size="15" fill="#859D91">5. port-forward</text>
+  <text x="915" y="843" text-anchor="middle" font-family="DejaVu Sans Mono" font-size="15" fill="#E8A868">localhost:9898</text>
 
   <!-- ===== legend strip ===== -->
-  <rect x="64" y="992" width="966" height="66" rx="12" fill="#131320" stroke="#3d3d55" stroke-width="1.5"/>
-  <g stroke="#cfa07e" stroke-width="1.7" fill="none">
+  <rect x="64" y="992" width="966" height="66" rx="12" fill="#131E18" stroke="#284637" stroke-width="1.5"/>
+  <g stroke="#E8A868" stroke-width="1.7" fill="none">
     <circle cx="106" cy="1021" r="8"/>
     <path d="M102,1029 v4 h8 v-4 M103,1037 h6"/>
     <line x1="106" y1="1006" x2="106" y2="1009"/>
     <line x1="94" y1="1012" x2="96.5" y2="1014"/>
     <line x1="118" y1="1012" x2="115.5" y2="1014"/>
   </g>
-  <text x="134" y="1032" font-family="DejaVu Sans" font-size="17" font-weight="bold" fill="#85c7bb">Management cluster</text>
-  <text x="340" y="1032" font-family="DejaVu Sans" font-size="16" fill="#d6d6d6">= infrastructure lifecycle</text>
-  <line x1="592" y1="1004" x2="592" y2="1046" stroke="#3d3d55" stroke-width="1.4"/>
-  <text x="618" y="1032" font-family="DejaVu Sans" font-size="17" font-weight="bold" fill="#d693b1">Workload cluster</text>
-  <text x="796" y="1032" font-family="DejaVu Sans" font-size="16" fill="#d6d6d6">= application lifecycle</text>
+  <text x="134" y="1032" font-family="DejaVu Sans" font-size="17" font-weight="bold" fill="#5CE0B4">Management cluster</text>
+  <text x="340" y="1032" font-family="DejaVu Sans" font-size="16" fill="#D4E2DA">= infrastructure lifecycle</text>
+  <line x1="592" y1="1004" x2="592" y2="1046" stroke="#284637" stroke-width="1.4"/>
+  <text x="618" y="1032" font-family="DejaVu Sans" font-size="17" font-weight="bold" fill="#68C5EB">Workload cluster</text>
+  <text x="796" y="1032" font-family="DejaVu Sans" font-size="16" fill="#D4E2DA">= application lifecycle</text>
 
   <!-- ===== flow panel ===== -->
-  <rect x="1090" y="150" width="446" height="904" rx="14" fill="#131320" stroke="#3d3d55" stroke-width="1.5"/>
+  <rect x="1090" y="150" width="446" height="904" rx="14" fill="#131E18" stroke="#284637" stroke-width="1.5"/>
 
   <!-- step 1 -->
-  <circle cx="1140" cy="208" r="15" fill="#ab9fd6"/>
-  <text x="1140" y="214" text-anchor="middle" font-family="DejaVu Sans" font-size="15" font-weight="bold" fill="#0f0f0f">1</text>
-  <text x="1168" y="204" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">Toolbox creates kind + registry;</text>
-  <text x="1168" y="230" font-family="DejaVu Sans Mono" font-size="15.5" fill="#ab9fd6">oci-push publishes mgmt/ and</text>
-  <text x="1168" y="256" font-family="DejaVu Sans Mono" font-size="15.5" fill="#ab9fd6">workload/ as krops:latest.</text>
-  <text x="1168" y="282" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">No GitHub PAT, no AWS account.</text>
-  <line x1="1122" y1="316" x2="1504" y2="316" stroke="#34344a" stroke-width="1.2"/>
+  <circle cx="1140" cy="208" r="15" fill="#B0F6C0"/>
+  <text x="1140" y="214" text-anchor="middle" font-family="DejaVu Sans" font-size="15" font-weight="bold" fill="#0C120F">1</text>
+  <text x="1168" y="204" font-family="DejaVu Sans" font-size="17" fill="#D4E2DA">Toolbox creates kind + registry;</text>
+  <text x="1168" y="230" font-family="DejaVu Sans Mono" font-size="15.5" fill="#B0F6C0">oci-push publishes mgmt/ and</text>
+  <text x="1168" y="256" font-family="DejaVu Sans Mono" font-size="15.5" fill="#B0F6C0">workload/ as krops:latest.</text>
+  <text x="1168" y="282" font-family="DejaVu Sans" font-size="17" fill="#D4E2DA">No GitHub PAT, no AWS account.</text>
+  <line x1="1122" y1="316" x2="1504" y2="316" stroke="#1F362A" stroke-width="1.2"/>
 
   <!-- step 2 -->
-  <circle cx="1140" cy="364" r="15" fill="#85c7bb"/>
-  <text x="1140" y="370" text-anchor="middle" font-family="DejaVu Sans" font-size="15" font-weight="bold" fill="#0f0f0f">2</text>
-  <text x="1168" y="360" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">Management Flux syncs the OCI</text>
-  <text x="1168" y="386" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">artifact (<tspan font-family="DejaVu Sans Mono" font-size="16" fill="#85c7bb">mgmt/local-host/</tspan>) and</text>
-  <text x="1168" y="412" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">installs CAPI with the Docker</text>
-  <text x="1168" y="438" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">provider (CAPD).</text>
-  <line x1="1122" y1="472" x2="1504" y2="472" stroke="#34344a" stroke-width="1.2"/>
+  <circle cx="1140" cy="364" r="15" fill="#5CE0B4"/>
+  <text x="1140" y="370" text-anchor="middle" font-family="DejaVu Sans" font-size="15" font-weight="bold" fill="#0C120F">2</text>
+  <text x="1168" y="360" font-family="DejaVu Sans" font-size="17" fill="#D4E2DA">Management Flux syncs the OCI</text>
+  <text x="1168" y="386" font-family="DejaVu Sans" font-size="17" fill="#D4E2DA">artifact (<tspan font-family="DejaVu Sans Mono" font-size="16" fill="#5CE0B4">mgmt/local-host/</tspan>) and</text>
+  <text x="1168" y="412" font-family="DejaVu Sans" font-size="17" fill="#D4E2DA">installs CAPI with the Docker</text>
+  <text x="1168" y="438" font-family="DejaVu Sans" font-size="17" fill="#D4E2DA">provider (CAPD).</text>
+  <line x1="1122" y1="472" x2="1504" y2="472" stroke="#1F362A" stroke-width="1.2"/>
 
   <!-- step 3 -->
-  <circle cx="1140" cy="520" r="15" fill="#85c7bb"/>
-  <text x="1140" y="526" text-anchor="middle" font-family="DejaVu Sans" font-size="15" font-weight="bold" fill="#0f0f0f">3</text>
-  <text x="1168" y="516" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">CAPD provisions a workload cluster</text>
-  <text x="1168" y="542" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">as Docker containers (1 CP + 1</text>
-  <text x="1168" y="568" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">worker); <tspan font-family="DejaVu Sans Mono" font-size="16" fill="#85c7bb">flux-apps</tspan> installs a</text>
-  <text x="1168" y="594" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">second Flux instance there.</text>
-  <line x1="1122" y1="628" x2="1504" y2="628" stroke="#34344a" stroke-width="1.2"/>
+  <circle cx="1140" cy="520" r="15" fill="#5CE0B4"/>
+  <text x="1140" y="526" text-anchor="middle" font-family="DejaVu Sans" font-size="15" font-weight="bold" fill="#0C120F">3</text>
+  <text x="1168" y="516" font-family="DejaVu Sans" font-size="17" fill="#D4E2DA">CAPD provisions a workload cluster</text>
+  <text x="1168" y="542" font-family="DejaVu Sans" font-size="17" fill="#D4E2DA">as Docker containers (1 CP + 1</text>
+  <text x="1168" y="568" font-family="DejaVu Sans" font-size="17" fill="#D4E2DA">worker); <tspan font-family="DejaVu Sans Mono" font-size="16" fill="#5CE0B4">flux-apps</tspan> installs a</text>
+  <text x="1168" y="594" font-family="DejaVu Sans" font-size="17" fill="#D4E2DA">second Flux instance there.</text>
+  <line x1="1122" y1="628" x2="1504" y2="628" stroke="#1F362A" stroke-width="1.2"/>
 
   <!-- step 4 -->
-  <circle cx="1140" cy="676" r="15" fill="#d693b1"/>
-  <text x="1140" y="682" text-anchor="middle" font-family="DejaVu Sans" font-size="15" font-weight="bold" fill="#0f0f0f">4</text>
-  <text x="1168" y="672" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">Workload Flux syncs the same OCI</text>
-  <text x="1168" y="698" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">artifact under <tspan font-family="DejaVu Sans Mono" font-size="16" fill="#d693b1">workload/local-host/</tspan></text>
-  <text x="1168" y="724" font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">and reconciles <tspan font-family="DejaVu Sans Mono" font-size="16" fill="#fafafa">podinfo</tspan>; verify at</text>
-  <text x="1168" y="750" font-family="DejaVu Sans Mono" font-size="16" fill="#cfa07e">http://localhost:9898<tspan font-family="DejaVu Sans" font-size="17" fill="#d6d6d6">.</tspan></text>
-  <line x1="1122" y1="788" x2="1504" y2="788" stroke="#34344a" stroke-width="1.2"/>
+  <circle cx="1140" cy="676" r="15" fill="#68C5EB"/>
+  <text x="1140" y="682" text-anchor="middle" font-family="DejaVu Sans" font-size="15" font-weight="bold" fill="#0C120F">4</text>
+  <text x="1168" y="672" font-family="DejaVu Sans" font-size="17" fill="#D4E2DA">Workload Flux syncs the same OCI</text>
+  <text x="1168" y="698" font-family="DejaVu Sans" font-size="17" fill="#D4E2DA">artifact under <tspan font-family="DejaVu Sans Mono" font-size="16" fill="#68C5EB">workload/local-host/</tspan></text>
+  <text x="1168" y="724" font-family="DejaVu Sans" font-size="17" fill="#D4E2DA">and reconciles <tspan font-family="DejaVu Sans Mono" font-size="16" fill="#FFFFFF">podinfo</tspan>; verify at</text>
+  <text x="1168" y="750" font-family="DejaVu Sans Mono" font-size="16" fill="#E8A868">http://localhost:9898<tspan font-family="DejaVu Sans" font-size="17" fill="#D4E2DA">.</tspan></text>
+  <line x1="1122" y1="788" x2="1504" y2="788" stroke="#1F362A" stroke-width="1.2"/>
 
   <!-- golden rule -->
-  <text x="1122" y="832" font-family="DejaVu Sans" font-size="22" font-weight="bold" fill="#f2c464">Golden rule</text>
-  <text x="1122" y="866" font-family="DejaVu Sans" font-size="18" fill="#d6d6d6">Edit YAML in the tree; never mutate</text>
-  <text x="1122" y="894" font-family="DejaVu Sans" font-size="18" fill="#d6d6d6">the clusters. Flux tracks the OCI</text>
-  <text x="1122" y="922" font-family="DejaVu Sans" font-size="18" fill="#d6d6d6">artifact: nothing reconciles until</text>
-  <text x="1122" y="950" font-family="DejaVu Sans" font-size="18" fill="#d6d6d6">you <tspan font-family="DejaVu Sans Mono" font-size="17" fill="#fafafa">oci-push</tspan> again.</text>
-  <line x1="1122" y1="978" x2="1504" y2="978" stroke="#34344a" stroke-width="1.2"/>
+  <text x="1122" y="832" font-family="DejaVu Sans" font-size="22" font-weight="bold" fill="#E5B85C">Golden rule</text>
+  <text x="1122" y="866" font-family="DejaVu Sans" font-size="18" fill="#D4E2DA">Edit YAML in the tree; never mutate</text>
+  <text x="1122" y="894" font-family="DejaVu Sans" font-size="18" fill="#D4E2DA">the clusters. Flux tracks the OCI</text>
+  <text x="1122" y="922" font-family="DejaVu Sans" font-size="18" fill="#D4E2DA">artifact: nothing reconciles until</text>
+  <text x="1122" y="950" font-family="DejaVu Sans" font-size="18" fill="#D4E2DA">you <tspan font-family="DejaVu Sans Mono" font-size="17" fill="#FFFFFF">oci-push</tspan> again.</text>
+  <line x1="1122" y1="978" x2="1504" y2="978" stroke="#1F362A" stroke-width="1.2"/>
 
   <!-- color key -->
-  <circle cx="1132" cy="1014" r="6" fill="#85c7bb"/>
-  <text x="1146" y="1020" font-family="DejaVu Sans Mono" font-size="14" fill="#d6d6d6">mgmt</text>
-  <circle cx="1210" cy="1014" r="6" fill="#ab9fd6"/>
-  <text x="1224" y="1020" font-family="DejaVu Sans Mono" font-size="14" fill="#d6d6d6">oci</text>
-  <circle cx="1282" cy="1014" r="6" fill="#d693b1"/>
-  <text x="1296" y="1020" font-family="DejaVu Sans Mono" font-size="14" fill="#d6d6d6">workload</text>
-  <circle cx="1398" cy="1014" r="6" fill="#cfa07e"/>
-  <text x="1412" y="1020" font-family="DejaVu Sans Mono" font-size="14" fill="#d6d6d6">app</text>
+  <circle cx="1132" cy="1014" r="6" fill="#5CE0B4"/>
+  <text x="1146" y="1020" font-family="DejaVu Sans Mono" font-size="14" fill="#D4E2DA">mgmt</text>
+  <circle cx="1210" cy="1014" r="6" fill="#B0F6C0"/>
+  <text x="1224" y="1020" font-family="DejaVu Sans Mono" font-size="14" fill="#D4E2DA">oci</text>
+  <circle cx="1282" cy="1014" r="6" fill="#68C5EB"/>
+  <text x="1296" y="1020" font-family="DejaVu Sans Mono" font-size="14" fill="#D4E2DA">workload</text>
+  <circle cx="1398" cy="1014" r="6" fill="#E8A868"/>
+  <text x="1412" y="1020" font-family="DejaVu Sans Mono" font-size="14" fill="#D4E2DA">app</text>
 
   <!-- ===== footer ===== -->
-  <text x="800" y="1102" text-anchor="middle" font-family="DejaVu Sans" font-size="17" fill="#8f8f8f">After workload readiness, pivot moves CAPI into local-management and deletes kind.</text>
-  <text x="800" y="1128" text-anchor="middle" font-family="DejaVu Sans" font-size="17" fill="#8f8f8f">Same chain as aws: CAPD and a local registry replace CAPA and GitHub.</text>
+  <text x="800" y="1102" text-anchor="middle" font-family="DejaVu Sans" font-size="17" fill="#859D91">After workload readiness, pivot moves CAPI into local-management and deletes kind.</text>
+  <text x="800" y="1128" text-anchor="middle" font-family="DejaVu Sans" font-size="17" fill="#859D91">Same chain as aws: CAPD and a local registry replace CAPA and GitHub.</text>
 </svg>


### PR DESCRIPTION
## What

Recolors the three architecture diagrams in `docs/` to match the new krops theme:
- `docs/aws-infra.svg`
- `docs/local-host-infra.svg`
- `docs/air-gap-infra.svg`

Updates the palette from the legacy knr-ops scheme (hot pink, purple, and dark indigo containers) to the krops brand palette:
- Canvas background updated to Dark Obsidian (`#0C120F`), matching `docs/krops-logo.svg`
- Container cards and subpanels updated to dark forest slate (`#131E18` / `#1B2C23`)
- Card strokes updated to deep sage (`#284637`)
- Titles, management plane, and CAPI controllers updated to Seafoam Mint (`#5CE0B4`)
- Git repository, OCI registry, and airgap bundle updated to Pale Sprout Pistachio (`#B0F6C0`)
- Workload clusters and planes updated to Sky Blue (`#68C5EB`)
- AWS, app, and substrate highlights updated to Warm Amber (`#E8A868`)
- Golden rule and airgap boundary updated to Golden Wheat (`#E5B85C`)
- Typography updated to Pure White (`#FFFFFF`) and sage neutral (`#D4E2DA`)

Leaves `docs/krops-logo.svg` untouched.

## Verification

- `mise run validate`: OK
- SVG rendering verified via `resvg` across all three figures
