### PR TITLE
docs: align README and docs with krops rename and style standards

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # krops
-## kubernetes-native resource operations
+## kubernetes resource operations
 
 ![krops logo](docs/krops-logo.svg)
 
@@ -144,7 +144,7 @@ Dependency versions are managed by Renovate
 in their native consumer files and update PRs open weekly. See
 [Dependencies](docs/dependencies.md).
 
-### Environments (formerly profiles)
+### Environments
 
 The shared toolchain is defined in `mise.toml`. AWS-specific tools are layered
 through `mise.aws.toml`; use the `aws` environment when those tools are
@@ -260,10 +260,18 @@ teardown controls, toolbox release, and current parity status.
 │                                  (ARM + GPU MachinePools); eu-north-1 also
 │                                  carries the self-managed management cluster
 ├── mgmt/local-host/              OCI-synced CAPI/CAPD local workload cluster
-│                                  and its management cluster definition
+│   │                              and its management cluster definition
+│   ├── infrastructure/           capi-operator, cert-manager
+│   ├── capi-providers/           caaph-system, capd-system, capi-system
+│   ├── addons/                   kindnet CNI, flux-apps
+│   └── clusters/                 docker (workload), management (self-managed)
 ├── mgmt/local-talos/             Single-node Talos management cluster on
-│                                  bare metal via Tinkerbell (CAPT);
-│                                  GitHub-synced like mgmt/aws
+│   │                              bare metal via Tinkerbell (CAPT);
+│   │                              GitHub-synced like mgmt/aws
+│   ├── infrastructure/           capi-operator, cert-manager
+│   ├── capi-providers/           cabpt-system, cacppt-system, capi-system,
+│   │                              capt-system (Tinkerbell)
+│   └── clusters/                 management (self-managed)
 └── workload/                     Synced by each WORKLOAD cluster's Flux
     ├── base/                     ACK S3/RDS/IAM controllers, Bucket CRs,
     │                              DBInstance CRs, reader Role CRs

--- a/docs/airgap.md
+++ b/docs/airgap.md
@@ -151,7 +151,7 @@ verifies that the declared air-gap inventory remains available and complete.
 Fork and default-branch guards prevent fork or non-default-branch manual
 dispatches from consuming the ARM64 runners.
 
-Gap (deploy) — from `airgap/`:
+Gap (deploy): from `airgap/`:
 
 ```sh
 # CI keyless-signed package (default trusted workflow identity)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,7 +5,7 @@ platform. A disposable local [kind](https://kind.sigs.k8s.io/) cluster
 bootstraps [Flux](https://fluxcd.io/), provisions the self-managed management
 cluster through CAPI, and is deleted after a `clusterctl move` pivot: the
 management cluster then reconciles itself and everything else from this
-repository — AWS EKS workload clusters provisioned via
+repository: AWS EKS workload clusters provisioned via
 [CAPA](https://cluster-api-aws.sigs.k8s.io/), per-cluster Flux instances
 delivered through CAPI addons, and application workloads (the
 [ACK](https://aws-controllers-k8s.github.io/docs/) S3, RDS, and IAM operators
@@ -158,7 +158,7 @@ The management cluster also runs a single
 (`mgmt/aws/infrastructure/konflate/`), pointed at this repo
 (`github://polarsquad/krops`, rendering from the repo root). It renders each
 open PR at its merge-base and head and shows the diff of the *rendered* Flux
-output — blast radius, image changes, render failures, and danger lint —
+output (blast radius, image changes, render failures, and danger lint)
 instead of the raw file diff. Results reach the PR two ways: a GitHub Actions
 workflow (`.github/workflows/konflate.yml`) runs a one-shot konflate service
 container on each PR push and gates the `konflate / Rendered Flux diff` check
@@ -183,7 +183,7 @@ aws-operators (ACK S3 + RDS + IAM controllers) ▶ s3-buckets (Bucket CRs)
 2. `flux-apps` matches those labels: a **HelmChartProxy** installs the Flux
    Operator on every workload cluster, and per-region **ClusterResourceSets**
    apply a `FluxInstance` (syncing `workload/<region>-01/`), a `cluster-vars`
-   ConfigMap (`AWS_REGION`, `CLUSTER_NAME`, `AWS_ACCOUNT_ID` — used by Flux
+   ConfigMap (`AWS_REGION`, `CLUSTER_NAME`, `AWS_ACCOUNT_ID`, used by Flux
    `postBuild` substitution), and the Git pull secret.
 3. The workload cluster's Flux reconciles `workload/`: first `aws-operators`
    (ACK S3 + RDS + IAM controllers, `wait: true`), then `s3-buckets`,
@@ -192,3 +192,11 @@ aws-operators (ACK S3 + RDS + IAM controllers) ▶ s3-buckets (Bucket CRs)
 See [AWS authentication & IAM](./aws-iam.md) for how the ACK controllers
 authenticate, and [Workload resources](./workload-resources.md) for what they
 create.
+
+## Other deployment environments
+
+While the diagram above details the `aws` reference environment, the repository includes two other deployment targets walking the same GitOps and CAPI lifecycle:
+
+- **`local-host`**: replaces AWS with local Docker containers (CAPD) and GitHub with a local OCI registry (`krops-registry:5000`). It provisions a one-control-plane/one-worker workload cluster and reconciles Podinfo end to end on a single host. See the architecture diagram in [docs/local-host-infra.svg](local-host-infra.svg).
+- **`local-talos`**: pivots onto bare metal via Tinkerbell (CAPT) and Talos Linux (CABPT and CACPPT), syncing directly from GitHub.
+- **Air-gap bundle**: packages `local-host` with Zarf for completely disconnected deployment with verified SBOMs and signed artifacts. See the air-gap architecture diagram in [docs/air-gap-infra.svg](air-gap-infra.svg) and [Air-gapped krops](./airgap.md).

--- a/docs/aws-iam.md
+++ b/docs/aws-iam.md
@@ -11,18 +11,18 @@ The ACK S3, RDS, and IAM controllers on the workload clusters carry
   (`mgmt/aws/infrastructure/ack-controllers/`, authenticated with the same
   SOPS-encrypted credential pattern as CAPA) which declaratively create:
   - an IAM `Role` per controller, trusted by `pods.eks.amazonaws.com`:
-    - `krops-ack-s3-controller` — scoped to `krops-*` buckets only
-    - `krops-ack-rds-controller` — RDS management scoped to `krops-*`
+    - `krops-ack-s3-controller`: scoped to `krops-*` buckets only
+    - `krops-ack-rds-controller`: RDS management scoped to `krops-*`
       RDS resources (plus read-only `rds:Describe*`), the
       `secretsmanager:CreateSecret`/`TagResource`/`RotateSecret` actions on
       `rds!*` secrets required by `manageMasterUserPassword`,
       `kms:DescribeKey` and grant management (`CreateGrant`/`ListGrants`/
       `RevokeGrant`, restricted with `kms:GrantIsForAWSResource`) so RDS can
-      use the default `aws/rds` and `aws/secretsmanager` KMS keys — without
-      these `CreateDBInstance` fails with `KMSKeyNotAccessibleFault` — and
+      use the default `aws/rds` and `aws/secretsmanager` KMS keys (without
+      these `CreateDBInstance` fails with `KMSKeyNotAccessibleFault`) and
       `iam:CreateServiceLinkedRole` for `AWSServiceRoleForRDS` (needed the
       first time an RDS instance is created in the account)
-    - `krops-ack-iam-controller` — IAM role management scoped to
+    - `krops-ack-iam-controller`: IAM role management scoped to
       `krops-*` roles only. Known trade-off: name-scoped `iam:CreateRole`
       + `iam:PutRolePolicy` is still a privilege-escalation surface (any
       permission can be granted to a role, as long as it is named
@@ -32,7 +32,7 @@ The ACK S3, RDS, and IAM controllers on the workload clusters carry
     `ack-s3-controller` / `ack-rds-controller` / `ack-iam-controller`
     ServiceAccounts to their roles.
 
-Pod Identity is used instead of IRSA because its trust policy is static — it
+Pod Identity is used instead of IRSA because its trust policy is static: it
 does not embed a per-cluster OIDC provider ID, so the whole chain can live in
 Git before the clusters exist. ACK retries the associations until CAPA has
 finished provisioning the EKS clusters.
@@ -40,16 +40,16 @@ finished provisioning the EKS clusters.
 ## Per-cluster read-only IAM roles
 
 `workload/base/iam-roles/role.yaml` has each cluster's ACK IAM controller create
-one read-only IAM role (`krops-<cluster>-reader`) — IAM is global, so the
+one read-only IAM role (`krops-<cluster>-reader`). IAM is global, so the
 cluster name is part of the role name to keep the two clusters from fighting
 over one role:
 
 - trust policy: the AWS account root (`arn:aws:iam::<account>:root`,
-  `sts:AssumeRole`) — any principal in the account that is itself allowed to
+  `sts:AssumeRole`): any principal in the account that is itself allowed to
   assume the role can use it
 - read-only permissions covering the resources this repo creates on **both**
   clusters: `krops-*` S3 buckets (bucket + object reads) and `krops-*`
-  RDS instances (`rds:DescribeDBInstances`, `rds:ListTagsForResource` —
+  RDS instances (`rds:DescribeDBInstances`, `rds:ListTagsForResource`:
   only Describe actions that support resource-level scoping)
 
 ## Console access: the `krops-reader` IAM user
@@ -57,7 +57,7 @@ over one role:
 `mgmt/aws/infrastructure/aws-global-iam/reader-user.yaml` has the
 **management** cluster's ACK IAM controller create one IAM `User`
 (`krops-reader`) whose only permission is `sts:AssumeRole` on
-`arn:aws:iam::*:role/krops-*-reader` — it can see nothing directly and is
+`arn:aws:iam::*:role/krops-*-reader`: it can see nothing directly and is
 just a doorway into the per-cluster reader roles above.
 
 The ACK IAM controller has no `LoginProfile` resource, so the console
@@ -76,7 +76,7 @@ Then, to browse the repo-created resources in the AWS console:
    login).
 2. Use **Switch Role** (account menu, top right) with the account ID and role
    name `krops-eu-north-1-workload-reader` or
-   `krops-eu-west-1-workload-reader` — or use the direct link:
+   `krops-eu-west-1-workload-reader`, or use the direct link:
 
    ```
    https://signin.aws.amazon.com/switchrole?roleName=krops-eu-north-1-workload-reader&account=<account-id>

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -4,7 +4,7 @@
 
 1. Create `mgmt/aws/clusters/<region>/<env>/` with a `cluster.yaml`,
    `kustomization.yaml` (set `namePrefix`), and `capi-nameref.yaml` (so CAPI
-   cross-references get the prefix applied — see the existing regions).
+   cross-references get the prefix applied; see the existing regions).
 2. Label the `Cluster` with `fluxcd: enabled` **and** `region: <region>`, and
    include the `eks-pod-identity-agent` addon in the `AWSManagedControlPlane`.
 3. Register it in `mgmt/aws/clusters/<region>/kustomization.yaml` and add a
@@ -29,16 +29,18 @@ Follow the `aws-operators` / `s3-buckets` pattern in `workload/base/`:
    use `postBuild.substituteFrom: cluster-vars` for per-cluster values like
    `${AWS_REGION}` and `${CLUSTER_NAME}`).
 2. Register the `flux-ks.yaml` in `workload/base/kustomization.yaml`.
-3. Run `mise run validate`, commit, and push — every workload cluster picks it
+3. Run `mise run validate`, commit, and push. Every workload cluster picks it
    up on its next sync.
 
 ## Using other providers
 
 The management cluster is not AWS-only. Providers are declared as CAPI
 operator CRs (`operator.cluster.x-k8s.io/v1alpha2`) under
-`mgmt/aws/capi-providers/`, one directory per provider namespace, and
-registered in `mgmt/aws/capi-providers/flux-ks.yaml`. The operator resolves
-the well-known provider names (`aws`, `azure`, `talos`,
+`mgmt/<environment>/capi-providers/` (for example `mgmt/aws/capi-providers/` for
+AWS EKS, `mgmt/local-host/capi-providers/` for local Docker, and
+`mgmt/local-talos/capi-providers/` for Talos and Tinkerbell), one directory per
+provider namespace, and registered in that environment's `capi-providers/flux-ks.yaml`.
+The operator resolves the well-known provider names (`aws`, `azure`, `talos`,
 `k0sproject-k0smotron`) from the same built-in registry `clusterctl` uses, so
 a provider is just a typed CR with a pinned version:
 

--- a/docs/konflate.md
+++ b/docs/konflate.md
@@ -5,13 +5,13 @@ open PRs as **rendered** Flux diffs instead of raw file diffs. For each PR it
 renders the full Flux output at the merge-base and at the head, then diffs the
 two, so a review shows:
 
-- **Blast radius** — which clusters/Kustomizations a change actually touches
+- **Blast radius**: which clusters/Kustomizations a change actually touches
   (a one-line kustomize edit can fan out to many rendered resources).
-- **Image changes** — container image bumps extracted from the rendered
+- **Image changes**: container image bumps extracted from the rendered
   output.
-- **Render failures** — a PR that breaks the Flux render is caught before
+- **Render failures**: a PR that breaks the Flux render is caught before
   merge, not at reconcile time.
-- **Danger lint** — cautions on risky changes.
+- **Danger lint**: cautions on risky changes.
 
 Reporting happens two ways:
 
@@ -28,7 +28,7 @@ Reporting happens two ways:
 
 A single instance runs on the **management cluster**, deployed from
 `mgmt/aws/infrastructure/konflate/` by the `konflate` Flux Kustomization
-(`mgmt/aws/infrastructure/flux-ks.yaml` — SOPS decryption enabled, no
+(`mgmt/aws/infrastructure/flux-ks.yaml`: SOPS decryption enabled, no
 `dependsOn`, so it comes up independently of the CAPI/ACK chains).
 
 | Piece | Detail |
@@ -36,9 +36,9 @@ A single instance runs on the **management cluster**, deployed from
 | Chart | OCI artifact `oci://ghcr.io/home-operations/charts/konflate`, pinned tag (see `helm.yaml`) |
 | Namespace | `konflate` |
 | `config.repo` | `github://polarsquad/krops` |
-| `config.clusterPath` | `""` — render from the repo root, matching this repo's root-relative Flux Kustomization paths (`./mgmt/aws/...`, `./workload/...`) |
-| `config.prComments` | `true` — post the rendered summary as a PR comment |
-| `config.statusChecks` | `true` — post the `Konflate` commit status with the render verdict |
+| `config.clusterPath` | `""` (render from the repo root, matching this repo's root-relative Flux Kustomization paths: `./mgmt/aws/...`, `./workload/...`) |
+| `config.prComments` | `true` (post the rendered summary as a PR comment) |
+| `config.statusChecks` | `true` (post the `Konflate` commit status with the render verdict) |
 | Secret | `konflate-token` (SOPS-encrypted, `konflate-token.sops.yaml`) |
 | Persistence | Enabled (kind's default local-path StorageClass) so source caches and rendered diffs survive pod restarts |
 
@@ -75,11 +75,11 @@ verdict a dependable gate.
 ## Authentication
 
 The `konflate-token` secret carries two values (rotation:
-[Secret management](./secrets.md#setting--rotating-the-konflate-tokens)):
+[Secret management](./secrets.md#setting-and-rotating-the-konflate-tokens)):
 
-- **`KONFLATE_TOKEN`** — a read-only GitHub PAT. The repo is private, so
+- **`KONFLATE_TOKEN`**: a read-only GitHub PAT. The repo is private, so
   konflate needs it to list PRs and clone.
-- **`KONFLATE_WRITE_TOKEN`** — the write-back credential, kept separate from
+- **`KONFLATE_WRITE_TOKEN`**: the write-back credential, kept separate from
   the read token so that one carries no write scope. A fine-grained PAT with
   **Pull requests** and **Commit statuses** (R/W) on this repo, or a classic
   PAT with `repo` scope.
@@ -88,12 +88,12 @@ The `konflate-token` secret carries two values (rotation:
 
 On every render konflate:
 
-1. **Posts / edits the PR comment** — the rendered summary (blast radius,
+1. **Posts / edits the PR comment**: the rendered summary (blast radius,
    image changes, cautions, render failures) as a single comment, found by a
-   hidden marker and edited in place on each subsequent render — it never
+   hidden marker and edited in place on each subsequent render; it never
    piles up duplicates.
-2. **Posts the `Konflate` commit status** on the PR head — `success` when the
-   diff rendered, `failure` when it didn't. To gate merges on the render, mark
+2. **Posts the `Konflate` commit status** on the PR head (success when the
+   diff rendered, failure when it didn't). To gate merges on the render, mark
    `Konflate` as a required status check in branch protection.
 
 Notes:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -175,7 +175,7 @@ You also need:
   `secretsmanager:CreateSecret`/`TagResource`/`RotateSecret` permissions
   (managed master passwords) used by the workload clusters' ACK RDS
   controllers are granted through the Git-declared
-  `krops-ack-rds-controller` pod-identity role — no extra static
+  `krops-ack-rds-controller` pod-identity role; no extra static
   credentials are required for them.
 - The `clusterawsadm` IAM CloudFormation stack provisioned before bootstrap and
   removed by a full AWS teardown:
@@ -266,8 +266,8 @@ This initial imperative phase performs these steps:
 5. Pivots: moves the CAPI inventory into the self-managed management cluster
    and deletes the kind cluster (see [Pivot recovery](#pivot-recovery)).
 
-Everything downstream — providers, EKS clusters, workload Flux instances, the
-ACK operator, IAM role, pod identity bindings, and S3 buckets — reconciles
+Everything downstream (providers, EKS clusters, workload Flux instances, the
+ACK operator, IAM role, pod identity bindings, and S3 buckets) reconciles
 from Git with no further manual steps.
 
 The local-host environment performs the cluster, Flux Operator, and FluxInstance

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -64,13 +64,13 @@ docker run --rm --user "$(id -u):$(id -g)" \
 ## Setting / rotating AWS credentials
 
 ```sh
-# CAPA — generate the base64 profile (requires AWS creds in your shell env):
+# CAPA: generate the base64 profile (requires AWS creds in your shell env):
 clusterawsadm bootstrap credentials encode-as-profile
 # Put the value into stringData.AWS_B64ENCODED_CREDENTIALS, then encrypt:
 $EDITOR mgmt/aws/capi-providers/capa-system/aws-credentials.sops.yaml
 mise run sops-encrypt mgmt/aws/capi-providers/capa-system/aws-credentials.sops.yaml
 
-# ACK — standard AWS shared-credentials-file format under stringData.credentials:
+# ACK: standard AWS shared-credentials-file format under stringData.credentials:
 $EDITOR mgmt/aws/infrastructure/ack-controllers/aws-credentials.sops.yaml
 mise run sops-encrypt mgmt/aws/infrastructure/ack-controllers/aws-credentials.sops.yaml
 ```
@@ -84,7 +84,7 @@ mise run sops-decrypt <file>.sops.yaml
 ## Setting / rotating the GitHub PAT
 
 The management cluster's own `flux-github-pat` secret is created imperatively
-at bootstrap (from `GITHUB_TOKEN` in `.env`) and is **not** in Git — Flux
+at bootstrap (from `GITHUB_TOKEN` in `.env`) and is **not** in Git; Flux
 needs it to clone the repo before it could ever decrypt anything (a
 chicken-and-egg constraint). The workload clusters' copy *is* in Git
 (`flux-pull-secret.sops.yaml`) because the management cluster's Flux decrypts
@@ -104,7 +104,7 @@ mise run sops-encrypt mgmt/aws/addons/flux-apps/flux-pull-secret.sops.yaml
 Remember to also update `GITHUB_TOKEN` in `.env` so the next bootstrap uses
 the new token.
 
-## Setting / rotating the konflate tokens
+## Setting and rotating the konflate tokens
 
 What each token does is covered in [PR review: konflate](./konflate.md).
 

--- a/docs/workload-resources.md
+++ b/docs/workload-resources.md
@@ -18,13 +18,13 @@ see [AWS authentication & IAM](./aws-iam.md).
 ## RDS instances
 
 `workload/base/rds-instances/dbinstance.yaml` creates one PostgreSQL 17 instance
-per cluster (`krops-<cluster>-db`) in that cluster's own region — the ACK
+per cluster (`krops-<cluster>-db`) in that cluster's own region; the ACK
 RDS controller runs with `aws.region: ${AWS_REGION}`:
 
 - `db.t4g.micro`, 20 GiB gp3, single-AZ (smallest footprint)
 - not publicly accessible, storage encrypted
 - master password managed by RDS (`manageMasterUserPassword: true`) and stored
-  in Secrets Manager — workload clusters have no SOPS key, so an in-Git
+  in Secrets Manager; workload clusters have no SOPS key, so an in-Git
   password secret is not an option
 
 > **Known limitation**: the `DBInstance` sets no `dbSubnetGroupName`, so the


### PR DESCRIPTION
## Summary

- Align `README.md` subtitle with the rename: change `kubernetes-native resource operations` to `kubernetes resource operations`
- Expand `README.md` repository layout tree to include subtrees for `mgmt/local-host/` and `mgmt/local-talos/`
- Remove stale `(formerly profiles)` qualifier from the `### Environments` heading in `README.md`
- Document `local-host`, `local-talos`, and air-gap deployment targets in `docs/architecture.md`
- Clarify provider directory structure for non-AWS environments in `docs/extending.md`
- Fix broken cross-reference anchor between `docs/konflate.md` and `docs/secrets.md`
- Replace em-dashes across `docs/` with plain punctuation

## Validation

- `mise run validate` (bash -n, airgap image digest pins, bootstrap.toml cross-check, kustomize overlays)
- Custom link verification script (`python3 /tmp/check_links.py`) confirms no broken anchors
- `git diff --check`
