### PR TITLE
fix(airgap): resolve zarf init package by glob instead of pinned version

### DIFF
--- a/airgap/scripts/build-package.sh
+++ b/airgap/scripts/build-package.sh
@@ -63,9 +63,19 @@ fi
 echo "==> 3/5 offline host assets, workload-node images, and OCI charts"
 mkdir -p airgap/archives
 
+INIT_STAGING=$(mktemp -d "${TMPDIR:-/tmp}/krops-zarf-init.XXXXXX")
 mise x -- zarf tools download-init \
   --architecture arm64 \
-  --output-directory airgap/archives
+  --output-directory "$INIT_STAGING"
+shopt -s nullglob
+init_outputs=("$INIT_STAGING"/*)
+shopt -u nullglob
+if [ "${#init_outputs[@]}" -ne 1 ]; then
+  echo "ERROR: expected exactly one init package from zarf tools download-init, found ${#init_outputs[@]}" >&2
+  exit 1
+fi
+mv "${init_outputs[0]}" airgap/archives/zarf-init-arm64.tar.zst
+rm -rf "$INIT_STAGING"
 
 HOST_IMAGES=(
   kindest/node:v1.37.0@sha256:a1ed56cfb0e7b93589bdf97c8cd566405a265939e3620fc4f5de89adff580ae5

--- a/airgap/scripts/offline-run.sh
+++ b/airgap/scripts/offline-run.sh
@@ -122,7 +122,18 @@ else
 fi
 
 step "3. zarf init"
-if ( cd "$AIRGAP_DIR" && "$ZARF" init "$ARCHIVES/zarf-init-arm64-v0.83.0.tar.zst" \
+# The init package filename embeds the zarf CLI version (it is produced by
+# `zarf tools download-init` in build-package.sh), so it tracks the mise pin
+# in mise.toml. Resolve by glob instead of hardcoding a version that
+# Renovate bumps out from under this script.
+shopt -s nullglob
+init_packages=("$ARCHIVES"/zarf-init-arm64-v*.tar.zst)
+shopt -u nullglob
+if [ "${#init_packages[@]}" -ne 1 ]; then
+  fail "expected exactly one zarf init package matching $ARCHIVES/zarf-init-arm64-v*.tar.zst, found ${#init_packages[@]}"
+  exit 1
+fi
+if ( cd "$AIRGAP_DIR" && "$ZARF" init "${init_packages[0]}" \
        --registry-mode=nodeport --components="" --confirm ); then
   pass "zarf init"
 else

--- a/airgap/scripts/offline-run.sh
+++ b/airgap/scripts/offline-run.sh
@@ -122,18 +122,7 @@ else
 fi
 
 step "3. zarf init"
-# The init package filename embeds the zarf CLI version (it is produced by
-# `zarf tools download-init` in build-package.sh), so it tracks the mise pin
-# in mise.toml. Resolve by glob instead of hardcoding a version that
-# Renovate bumps out from under this script.
-shopt -s nullglob
-init_packages=("$ARCHIVES"/zarf-init-arm64-v*.tar.zst)
-shopt -u nullglob
-if [ "${#init_packages[@]}" -ne 1 ]; then
-  fail "expected exactly one zarf init package matching $ARCHIVES/zarf-init-arm64-v*.tar.zst, found ${#init_packages[@]}"
-  exit 1
-fi
-if ( cd "$AIRGAP_DIR" && "$ZARF" init "${init_packages[0]}" \
+if ( cd "$AIRGAP_DIR" && "$ZARF" init "$ARCHIVES/zarf-init-arm64.tar.zst" \
        --registry-mode=nodeport --components="" --confirm ); then
   pass "zarf init"
 else

--- a/airgap/scripts/stage-and-create-cluster.sh
+++ b/airgap/scripts/stage-and-create-cluster.sh
@@ -114,7 +114,5 @@ helm push "$ARCHIVES/charts/flux-operator-0.58.0.tgz" "oci://localhost:${REGISTR
 helm push "$ARCHIVES/charts/podinfo-6.14.0.tgz" "oci://localhost:${REGISTRY_PORT}/stefanprodan/charts" --plain-http
 
 echo ">>> Staged. Next:"
-# The init package filename embeds the zarf CLI version (see the mise pin in
-# mise.toml); the shell expands the glob when this command is run manually.
-echo "      zarf init archives/zarf-init-arm64-v*.tar.zst --registry-mode=nodeport --components=\"\" --confirm"
+echo "      zarf init archives/zarf-init-arm64.tar.zst --registry-mode=nodeport --components=\"\" --confirm"
 echo "      zarf package deploy zarf-package-krops-airgap-arm64-0.1.0.tar.zst --confirm"

--- a/airgap/scripts/stage-and-create-cluster.sh
+++ b/airgap/scripts/stage-and-create-cluster.sh
@@ -114,5 +114,7 @@ helm push "$ARCHIVES/charts/flux-operator-0.58.0.tgz" "oci://localhost:${REGISTR
 helm push "$ARCHIVES/charts/podinfo-6.14.0.tgz" "oci://localhost:${REGISTRY_PORT}/stefanprodan/charts" --plain-http
 
 echo ">>> Staged. Next:"
-echo "      zarf init archives/zarf-init-arm64-v0.83.0.tar.zst --registry-mode=nodeport --components=\"\" --confirm"
+# The init package filename embeds the zarf CLI version (see the mise pin in
+# mise.toml); the shell expands the glob when this command is run manually.
+echo "      zarf init archives/zarf-init-arm64-v*.tar.zst --registry-mode=nodeport --components=\"\" --confirm"
 echo "      zarf package deploy zarf-package-krops-airgap-arm64-0.1.0.tar.zst --confirm"

--- a/docs/airgap.md
+++ b/docs/airgap.md
@@ -97,7 +97,7 @@ The verification linchpin is the agent's **image rewrite** plus a Ready
 | Item | Purpose |
 |---|---|
 | `zarf` CLI binary | runs the deploy |
-| `archives/zarf-init-arm64-v0.83.0.tar.zst` | `zarf init` (registry + agent) |
+| `archives/zarf-init-arm64-v<version>.tar.zst` | `zarf init` (registry + agent); `<version>` matches the zarf CLI pin in `mise.toml` (`zarf tools download-init` names the file after the CLI) |
 | `zarf-package-krops-airgap-arm64-0.1.0.tar.zst` | signed package, including per-component Syft JSON/HTML SBOMs and the Sigstore signature bundle |
 | `archives/kindest_node_v1.37.0_mgmt.tar` | mgmt kind node (host daemon) |
 | `archives/kindest_node_v1.37.0.tar` | CAPD workload and management nodes (host daemon) |

--- a/docs/airgap.md
+++ b/docs/airgap.md
@@ -97,7 +97,7 @@ The verification linchpin is the agent's **image rewrite** plus a Ready
 | Item | Purpose |
 |---|---|
 | `zarf` CLI binary | runs the deploy |
-| `archives/zarf-init-arm64-v<version>.tar.zst` | `zarf init` (registry + agent); `<version>` matches the zarf CLI pin in `mise.toml` (`zarf tools download-init` names the file after the CLI) |
+| `archives/zarf-init-arm64.tar.zst` | `zarf init` (registry + agent); built by `zarf tools download-init` from the zarf CLI pinned in `mise.toml` and renamed at build time, so `mise.toml` stays the sole version declaration |
 | `zarf-package-krops-airgap-arm64-0.1.0.tar.zst` | signed package, including per-component Syft JSON/HTML SBOMs and the Sigstore signature bundle |
 | `archives/kindest_node_v1.37.0_mgmt.tar` | mgmt kind node (host daemon) |
 | `archives/kindest_node_v1.37.0.tar` | CAPD workload and management nodes (host daemon) |


### PR DESCRIPTION
## Problem

Every nightly `air-gapped` run has failed at the `zarf init` step since 2026-09-01 ([latest run](https://github.com/polarsquad/krops/actions/runs/34303671677)):

```
ERR unable to load package: opening ".../airgap/archives/zarf-init-arm64-v0.83.0.tar.zst": no such file or directory
FAIL: zarf init
```

`airgap/scripts/offline-run.sh` hardcoded the init package filename, but that file is produced by `zarf tools download-init` in `build-package.sh`, which names it after the zarf CLI version pinned in `mise.toml`. Renovate bumped the pin (v0.83.0 -> v0.84.0 in aa41a96, then v0.85.0 in #209) and no Renovate manager covers the hardcoded filename, so the bundle stopped containing the file the deploy script looks for. Last green nightly: 2026-08-31 (ran before aa41a96 merged); 8 consecutive failures since.

## Fix

Establish the init package's provenance at build time instead of pinning a version at deploy time:

- `build-package.sh`: `zarf tools download-init` now runs into a clean staging directory, the build fails unless exactly one output was generated, and that output is renamed to the stable `archives/zarf-init-arm64.tar.zst`. `mise.toml` stays the sole version declaration; the bundle provably contains the archive built by that pinned zarf CLI, regardless of stale archives left in `archives/` from earlier runs.
- `offline-run.sh` / `stage-and-create-cluster.sh`: reference the stable filename, no version arithmetic.
- `docs/airgap.md`: the bundle table documents the stable filename and its build-time provenance.

## Verification

- `bash -n` on all three scripts.
- Staging block simulated with a stubbed `download-init`: 1 output renames to `zarf-init-arm64.tar.zst`; 0 and 2 outputs fail with `ERROR: expected exactly one init package`.
- `python3 airgap/tests/test-airgap-image-digests.py --all` passes.

Note: the `air-gapped` workflow runs on upstream main only, so full end-to-end validation happens on the next nightly after merge (or a manual dispatch).
