### PR TITLE
feat: add the azure environment (CAPZ + ASO management side)

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,5 +1,5 @@
 # SOPS configuration. Encrypts only the `data`/`stringData` fields of any
-# manifest named `*.sops.yaml` under mgmt/aws/, leaving keys/metadata readable.
+# manifest named `*.sops.yaml` under mgmt/aws/ or mgmt/azure/, leaving keys/metadata readable.
 #
 # The `age` recipient below is a PUBLIC key — safe to commit. The matching
 # PRIVATE key lives in `age.agekey` (gitignored) and is loaded into the cluster
@@ -7,6 +7,6 @@
 #
 # To rotate or add recipients, edit this file and run:  mise run sops-updatekeys
 creation_rules:
-  - path_regex: mgmt/aws/.*\.sops\.yaml$
+  - path_regex: mgmt/(aws|azure)/.*\.sops\.yaml$
     encrypted_regex: "^(data|stringData)$"
     age: age1amqtgevmdxutg07rkr3wggua43620zgncgfq53vkww0283wrgspqv9q0jw

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,19 @@ resources. There is no app source code here, only declarative infrastructure.
   management-only; no `addons/` (Talos ships its own CNI, no
   HelmChartProxy consumers). The wiring landed in #169 and the docs in
   #171; the remaining #105 item is the hardware acceptance run.
+- `mgmt/azure/`: the Azure management variant (issue #71). Same component
+  layout as `mgmt/aws/` (`infrastructure/`, `capi-providers/`, `addons/`,
+  `clusters/`), synced from GitHub. CAPZ v1.27.0 (`capi-providers/capz-system/`)
+  bundles Azure Service Operator (ASO) into `capz-system`; clusters are
+  `AzureASOManaged*` (AKS) with the ASO resources inline. The bundled ASO also
+  reconciles the identity plumbing in `infrastructure/aso-workload-identity/`
+  (user-assigned identity, per-cluster data resource group, role assignment,
+  federated credential), which replaces ACK pod identity. Credentials: one
+  service principal in `infrastructure/azure-identity/aso-credentials.sops.yaml`,
+  read by CAPZ (`AzureClusterIdentity`) and by ASO (`credential-from`
+  annotation). Non-secret IDs live in `azure-vars` (flux-system) and in the
+  workload `cluster-vars`. Upgrade CAPZ one minor at a time (ASO CRD
+  migrations). Teardown is manual until the live acceptance run.
 - `workload/`: synced by each WORKLOAD cluster's Flux.
   - `base/`: ACK controllers and S3/RDS/IAM custom resources.
   - `<region>-01/`: per-cluster overlays pointing at `../base`.
@@ -63,7 +76,9 @@ resources. There is no app source code here, only declarative infrastructure.
   rerun-safe-by-default semantics. Chart versions it installs imperatively
   are Renovate-annotated constants in `src/main.rs`. CI (bootstrap-rs
   workflow) runs fmt/clippy/build/test; the toolchain is pinned in
-  `rust-toolchain.toml`.
+  `rust-toolchain.toml`. Two config-driven knobs added for azure:
+  `pivot-sops-secrets` (SOPS manifests applied in the pivot target before
+  the move) and `teardown.manual` (refuse with operator text).
 - `bootstrap.sh` / `pivot.sh` / `teardown.sh`: the shell equivalents of the
   CLI's phases. Kept until the binary completes full parity runs per
   environment, then retired (issues #92/#95/#100). The lifecycle mise tasks
@@ -195,6 +210,7 @@ Load these only when the task touches their domain:
 
 - `docs/architecture.md`: reconciliation order, how workload apps are delivered.
 - `docs/bootstrap-cli.md`: the `krops-bootstrap` Rust CLI: interface, env knobs, pivot, parity status.
+- `docs/azure.md`: the Azure environment: subscription prep, credentials, AKS clusters, ASO on workload clusters, upgrade rules.
 - `docs/extending.md`: adding a workload cluster, adding apps, adding other providers (Azure, Talos, k0smotron).
 - `docs/secrets.md`: SOPS + age setup, credential rotation.
 - `docs/konflate.md`: rendered PR review, CI gate, tokens, write-back.

--- a/bootstrap-rs/src/config.rs
+++ b/bootstrap-rs/src/config.rs
@@ -72,6 +72,12 @@ pub struct Environment {
     pub provider_manifests: Vec<String>,
     #[serde(default)]
     pub move_fallbacks: Vec<MoveFallback>,
+    /// SOPS-encrypted manifests the pivot decrypts (operator age key) and
+    /// applies to the target before `clusterctl move` (issue #71): secrets
+    /// referenced by moved objects without an owner reference into the
+    /// Cluster hierarchy. Relative to the repository root.
+    #[serde(default)]
+    pub pivot_sops_secrets: Vec<String>,
     /// Teardown constants for this environment (issue #100).
     #[serde(default)]
     pub teardown: TeardownEnv,
@@ -154,6 +160,11 @@ pub struct TeardownEnv {
     /// or PXE-boot fresh.
     #[serde(default)]
     pub hardware_release: bool,
+    /// Teardown is not automated for this environment: refuse to run and
+    /// print this operator text instead (issue #71, azure until the live
+    /// acceptance run establishes the sweep).
+    #[serde(default)]
+    pub manual: Option<String>,
 }
 
 impl BootstrapConfig {
@@ -355,6 +366,26 @@ manifest = "mgmt/aws/infrastructure/aws-identity/identity.yaml"
         let empty = format!("{bad}[environments]\n");
         let config: BootstrapConfig = toml::from_str(&empty).unwrap();
         assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn parses_pivot_sops_secrets_and_manual_teardown() {
+        let text = format!(
+            "{MINIMAL}\n[environments.azure]\nkind = \"azure\"\nsync = \"github\"\n\
+             sync-path = \"mgmt/azure\"\nmgmt-cluster = \"swedencentral-management\"\n\
+             mgmt-ready-timeout = \"40m\"\ninfra-provider-namespace = \"capz-system\"\n\
+             infra-provider-name = \"azure\"\nprovider-manifests = []\n\
+             pivot-sops-secrets = [\"mgmt/azure/x.sops.yaml\"]\n\
+             [environments.azure.teardown]\nmanual = \"do it by hand\"\n"
+        );
+        let config = parse(&text).unwrap();
+        let azure = config.environment("azure").unwrap();
+        assert_eq!(azure.pivot_sops_secrets, vec!["mgmt/azure/x.sops.yaml"]);
+        assert_eq!(azure.teardown.manual.as_deref(), Some("do it by hand"));
+        // Existing environments default to no secrets and automated teardown.
+        let aws = config.environment("aws").unwrap();
+        assert!(aws.pivot_sops_secrets.is_empty());
+        assert!(aws.teardown.manual.is_none());
     }
 
     #[test]

--- a/bootstrap-rs/src/main.rs
+++ b/bootstrap-rs/src/main.rs
@@ -418,6 +418,10 @@ fn required_tools(env: &Environment) -> Vec<&'static str> {
     if env.sync == SyncSource::Oci {
         tools.extend(["flux", "curl"]);
     }
+    if !env.pivot_sops_secrets.is_empty() {
+        // The pivot decrypts these with the operator's age key (Phase 3).
+        tools.push("sops");
+    }
     tools
 }
 
@@ -1862,6 +1866,37 @@ async fn pivot_install_capi_in_target(
         .await?;
     }
 
+    // Config-driven pivot secrets (issue #71): decrypt each declared
+    // *.sops.yaml with the operator's age key and apply it to the target
+    // over stdin. On the bootstrap cluster Flux decrypts these; the target
+    // has no Flux yet and the moved objects reference them by name.
+    if !cfg.environment.pivot_sops_secrets.is_empty() {
+        println!(">>> Applying pivot SOPS secrets in the target...");
+        if std::env::var_os("SOPS_AGE_KEY_FILE").is_none() {
+            std::env::set_var("SOPS_AGE_KEY_FILE", cfg.age_key_file.as_os_str());
+        }
+        for manifest in &cfg.environment.pivot_sops_secrets {
+            let plaintext = capture(
+                "sops",
+                &[
+                    "--decrypt",
+                    "--input-type",
+                    "yaml",
+                    "--output-type",
+                    "yaml",
+                    manifest,
+                ],
+            )
+            .await?;
+            run_with_stdin(
+                "kubectl",
+                &kubectl_cmd(Some(kc), &["apply", "-f", "-"]),
+                &plaintext,
+            )
+            .await?;
+        }
+    }
+
     println!(">>> Waiting for providers in the target...");
     let infra_ns = &cfg.environment.infra_provider_namespace;
     let infra_name = &cfg.environment.infra_provider_name;
@@ -2951,6 +2986,18 @@ mod tests {
                 "curl"
             ]
         );
+    }
+
+    #[test]
+    fn sops_required_when_pivot_secrets_declared() {
+        // Environments declaring pivot-sops-secrets need sops on PATH (the
+        // pivot decrypts them with the operator's age key); the others
+        // don't.
+        let repo = repo_config();
+        let azure = required_tools(repo.environment("azure").unwrap());
+        assert!(azure.contains(&"sops"));
+        let aws = required_tools(repo.environment("aws").unwrap());
+        assert!(!aws.contains(&"sops"));
     }
 
     #[test]

--- a/bootstrap-rs/src/main.rs
+++ b/bootstrap-rs/src/main.rs
@@ -2794,7 +2794,7 @@ mod tests {
         let err = resolve_environment(Some("bogus"), None, &repo).unwrap_err();
         assert_eq!(
             err.to_string(),
-            "unsupported profile 'bogus' (expected 'local-host' or 'aws' or 'local-talos')"
+            "unsupported profile 'bogus' (expected 'local-host' or 'aws' or 'local-talos' or 'azure')"
         );
     }
 
@@ -2844,7 +2844,7 @@ mod tests {
             resolve_environment(Some("bogus"), Some("local-host"), &repo)
                 .unwrap_err()
                 .to_string(),
-            "unsupported profile 'bogus' (expected 'local-host' or 'aws' or 'local-talos')"
+            "unsupported profile 'bogus' (expected 'local-host' or 'aws' or 'local-talos' or 'azure')"
         );
     }
 

--- a/bootstrap-rs/src/teardown.rs
+++ b/bootstrap-rs/src/teardown.rs
@@ -1584,12 +1584,24 @@ pub async fn remove_registry_container(engine: Option<&str>, name: &str) {
     }
 }
 
+/// Environments whose teardown is not automated declare
+/// `[environments.<name>.teardown] manual = "..."` (issue #71); the run
+/// refuses before any preflight or mutation and prints the text.
+pub fn manual_teardown_refusal(env_name: &str, td: &crate::config::TeardownEnv) -> Option<String> {
+    td.manual
+        .as_ref()
+        .map(|text| format!("teardown is manual for the '{env_name}' environment:\n{text}"))
+}
+
 /// The full teardown run. Mirrors teardown.sh's flow with the
 /// post-pivot controller-host resolution.
 #[allow(clippy::too_many_arguments)]
 pub async fn run_teardown(cfg: &Config, tcfg: &TeardownConfig) -> Result<()> {
     let env = &cfg.environment;
     let td = &env.teardown;
+    if let Some(msg) = manual_teardown_refusal(&cfg.profile, td) {
+        bail!("{msg}");
+    }
 
     // Never let the AWS CLI open an interactive pager.
     std::env::set_var("AWS_PAGER", "");
@@ -2057,6 +2069,18 @@ pub async fn detect_engine() -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn manual_teardown_is_refused_with_text() {
+        let td = crate::config::TeardownEnv {
+            manual: Some("hand".into()),
+            ..Default::default()
+        };
+        let msg = manual_teardown_refusal("azure", &td).unwrap();
+        assert!(msg.starts_with("teardown is manual for the 'azure' environment:"));
+        assert!(msg.ends_with("hand"));
+        assert!(manual_teardown_refusal("aws", &crate::config::TeardownEnv::default()).is_none());
+    }
 
     #[test]
     fn guard_resolves_the_script_contract() {

--- a/bootstrap.toml
+++ b/bootstrap.toml
@@ -168,3 +168,41 @@ capi-workloads = []
 # Talos for the operator to re-use or PXE-boot fresh. No container-prefix
 # sweep (that is the local-host CAPD path) and no AWS orphan sweep.
 hardware-release = true
+
+[environments.azure]
+kind = "azure"
+# Flux syncs the GitHub repository (GitRepository + flux-github-pat), like aws.
+sync = "github"
+sync-path = "mgmt/azure"
+mgmt-cluster = "swedencentral-management"
+mgmt-ready-timeout = "40m"
+infra-provider-namespace = "capz-system"
+infra-provider-name = "azure"
+provider-manifests = [
+  "mgmt/azure/capi-providers/capi-system/namespace.yaml",
+  "mgmt/azure/capi-providers/capi-system/providers.yaml",
+  "mgmt/azure/capi-providers/capz-system/namespace.yaml",
+  "mgmt/azure/capi-providers/capz-system/capz-variables.yaml",
+  "mgmt/azure/capi-providers/capz-system/providers.yaml",
+  "mgmt/azure/capi-providers/caaph-system/namespace.yaml",
+  "mgmt/azure/capi-providers/caaph-system/addon-provider.yaml",
+]
+# SOPS-encrypted manifests decrypted with the operator's age key and applied
+# to the pivot target before `clusterctl move` (issue #71): the moved ASO
+# resources reference the aso-credentials Secret by annotation and the
+# AzureClusterIdentity references it by name; neither is moved by clusterctl
+# (the Secret carries no owner reference into the Cluster hierarchy).
+pivot-sops-secrets = [
+  "mgmt/azure/infrastructure/azure-identity/aso-credentials.sops.yaml",
+]
+
+[environments.azure.teardown]
+# Teardown is manual until the live acceptance run (issue #71 follow-up)
+# establishes the orphan sweep for AKS/ASO. The binary refuses to run and
+# prints this text.
+manual = """Azure teardown is not automated yet.
+  1. Suspend Flux: flux suspend kustomization --all
+  2. Delete the workload Cluster objects and wait for CAPZ to remove AKS
+  3. Delete the resource groups: az group delete --yes --name <rg>
+     (krops-swedencentral-workload-data, swedencentral-workload,
+      swedencentral-management, krops-shared, and every MC_* node group)"""

--- a/docs/bootstrap-cli.md
+++ b/docs/bootstrap-cli.md
@@ -91,6 +91,14 @@ teardown names against the Git manifests. Renovate updates the annotated chart
 pins together with their declarative counterparts. See
 [Dependencies](./dependencies.md).
 
+- `pivot-sops-secrets` (optional, list): SOPS-encrypted manifests the pivot
+  decrypts with `SOPS_AGE_KEY_FILE` (defaults to `AGE_KEY_FILE`) and applies to
+  the target before `clusterctl move`. Used by `azure` for the ASO/CAPZ
+  credential Secret that moved objects reference by name.
+- `teardown.manual` (optional, string): when set, `krops-bootstrap teardown`
+  refuses to run for that environment and prints the text. `azure` uses it
+  until the live acceptance run defines the Azure orphan sweep.
+
 ## Bootstrap and pivot controls
 
 | Variable | Default | Used by |

--- a/mgmt/azure/addons/flux-apps/flux-instance.yaml
+++ b/mgmt/azure/addons/flux-apps/flux-instance.yaml
@@ -1,0 +1,82 @@
+---
+# ══════════════════════════════════════════════════════════════════════════════
+# Per-cluster FluxInstance ConfigMaps for the Azure workload clusters, applied
+# by the ClusterResourceSets below (same mechanism as mgmt/aws/addons/).
+#
+# cluster-vars feeds postBuild substitution on the workload cluster:
+#   AZURE_* IDs and the ASO identity come from `mise -E azure run
+#   azure-bootstrap`; STORAGE_ACCOUNT_NAME is a globally unique literal.
+# ══════════════════════════════════════════════════════════════════════════════
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: flux-instance-swedencentral
+  namespace: default
+data:
+  flux-instance.yaml: |
+    apiVersion: v1
+    kind: Namespace
+    metadata:
+      name: flux-system
+    ---
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: cluster-vars
+      namespace: flux-system
+    data:
+      AZURE_LOCATION: "swedencentral"
+      CLUSTER_NAME: "swedencentral-workload"
+      AZURE_SUBSCRIPTION_ID: "00000000-0000-0000-0000-000000000000"
+      AZURE_TENANT_ID: "00000000-0000-0000-0000-000000000000"
+      AZURE_ASO_CLIENT_ID: "00000000-0000-0000-0000-000000000000"
+      AZURE_ASO_PRINCIPAL_ID: "00000000-0000-0000-0000-000000000000"
+      STORAGE_ACCOUNT_NAME: "kropsswcworkloadsksimc"
+    ---
+    apiVersion: fluxcd.controlplane.io/v1
+    kind: FluxInstance
+    metadata:
+      name: flux
+      namespace: flux-system
+      annotations:
+        fluxcd.controlplane.io/reconcileEvery: "1h"
+        fluxcd.controlplane.io/reconcileTimeout: "5m"
+    spec:
+      distribution:
+        version: "2.x"
+        registry: "ghcr.io/fluxcd"
+        artifact: "oci://ghcr.io/controlplaneio-fluxcd/flux-operator-manifests"
+      components:
+        - source-controller
+        - kustomize-controller
+        - helm-controller
+        - notification-controller
+      cluster:
+        type: kubernetes
+        size: small
+        multitenant: false
+        networkPolicy: true
+        domain: "cluster.local"
+      sync:
+        kind: GitRepository
+        url: "https://github.com/polarsquad/krops"
+        ref: "refs/heads/main"
+        path: "workload/swedencentral-01"
+        pullSecret: "flux-github-pat"
+---
+apiVersion: addons.cluster.x-k8s.io/v1beta1
+kind: ClusterResourceSet
+metadata:
+  name: flux-instance-swedencentral
+  namespace: default
+spec:
+  clusterSelector:
+    matchLabels:
+      fluxcd: enabled
+      region: swedencentral
+  strategy: ApplyOnce
+  resources:
+    - kind: ConfigMap
+      name: flux-instance-swedencentral
+    - kind: Secret
+      name: flux-pull-secret

--- a/mgmt/azure/addons/flux-apps/flux-operator.yaml
+++ b/mgmt/azure/addons/flux-apps/flux-operator.yaml
@@ -1,0 +1,31 @@
+---
+# ══════════════════════════════════════════════════════════════════════════════
+# HelmChartProxy: install the Flux Operator on every CAPI workload cluster
+# that carries the label fluxcd=enabled. CAAPH (AddonProvider helm) watches
+# for matching Cluster resources and installs the chart automatically.
+# ══════════════════════════════════════════════════════════════════════════════
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: flux-operator
+  namespace: default
+spec:
+  clusterSelector:
+    matchLabels:
+      fluxcd: enabled
+  repoURL: oci://ghcr.io/controlplaneio-fluxcd/charts
+  chartName: flux-operator
+  version: "0.58.0"
+  # Pin the Helm release name. Without it CAAPH generates
+  # "flux-operator-<epoch>" per HelmReleaseProxy, and the chart's
+  # keep-policy CRDs/ClusterRoles on a recreated workload cluster carry
+  # the previous generated name, so every subsequent install fails helm's
+  # ownership validation ("cannot be imported into the current release").
+  releaseName: flux-operator
+  namespace: flux-system
+  options:
+    waitForJobs: true
+    wait: true
+    timeout: 5m
+    install:
+      createNamespace: true

--- a/mgmt/azure/addons/flux-apps/flux-pull-secret.sops.yaml
+++ b/mgmt/azure/addons/flux-apps/flux-pull-secret.sops.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: flux-pull-secret
+    namespace: default
+type: addons.cluster.x-k8s.io/resource-set
+stringData:
+    flux-github-pat.yaml: ENC[AES256_GCM,data:2AqfU6YIcPoCcuMMLBxTYxgjAiwbAvT1jMW1XZK1kPYgywDVUPWzKqjq0ZJYrbf0lNmdLL1+CGOm7DRfBNZ08Jx+Hc82w43Y+oAGlkhjZN0/HUacR2U+n0zOpg8aU72zPJqO80a5W6FeE6cYDfiT49Q0zCVshkGAw6PcOPC6Fm7cOakU6OVeZV+s3UylA4niObVPxg3jeAkNFqpjkbn6GcsR8IuAxnYlNBK2GD7thooRO3a++Lyokyjh21KmbFlBiUxivAwrvsOC7T1+EkAPv31a1ON6lesrz2N69Cx7USIZ0svFKUAysrQ=,iv:NYGSADGVw9qVjXildETudLBAqbOhUYX5oHr40bluDMA=,tag:Bg8dqBzVm5pQhEuRoU4eOQ==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAzd0NpVFAyWmhJQnlOWVlL
+            N093a0pVTDNwSGd1Z1JaaVpZTDZnVXM2Q0VBCjhrTXU1UCtCV3lCdWNyS2U3TTI0
+            QzU2Yk9nUzZQZER3eTNnaFhLTGdzSEUKLS0tIE40QXl1QkdsSnpLdHR6UnlVMWFv
+            NEo2aGJMRkxzZXYrMGxid3VaN3liYzgKiB1taXRCmRf9jI+1Jsgo6wJvrazMLvEK
+            0Lg09YFT4L3P6i9cao8ieedL/JWL42ukdilBknnGgGF2ExCsCkonow==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1amqtgevmdxutg07rkr3wggua43620zgncgfq53vkww0283wrgspqv9q0jw
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-07-09T07:41:15Z"
+    mac: ENC[AES256_GCM,data:wKRLkjLFjBn+qSkItquZqHNYLl9qxemws3423Dei+9WRTuwosL+yOHpCDoCDNz8mXIMgN+yr/DyzG1qr8kPf+BYphyWzQuf6wsixbfi8OksdARURHtf+2bP7d6Xr7Hh6v733YSZY2yy7sGQCxNG0CI2Jo3UQT2PrwWGqItKNlJA=,iv:9n8KoaVC8LH+IPlUrROvMhMhJXhxmksx60c/EiZnnyU=,tag:6kJYnTFOuL3uOuOCVe93qA==,type:str]
+    version: 3.13.2

--- a/mgmt/azure/addons/flux-apps/kustomization.yaml
+++ b/mgmt/azure/addons/flux-apps/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flux-operator.yaml
+  - flux-instance.yaml
+  - flux-pull-secret.sops.yaml

--- a/mgmt/azure/addons/flux-ks.yaml
+++ b/mgmt/azure/addons/flux-ks.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: flux-apps
+  namespace: flux-system
+spec:
+  interval: 5m
+  retryInterval: 2m
+  timeout: 5m
+  prune: true
+  wait: false
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./mgmt/azure/addons/flux-apps
+  dependsOn:
+    - name: caaph-system
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age

--- a/mgmt/azure/capi-providers/caaph-system/addon-provider.yaml
+++ b/mgmt/azure/capi-providers/caaph-system/addon-provider.yaml
@@ -1,0 +1,8 @@
+# Helm add-on provider: HelmChartProxy / HelmReleaseProxy APIs for workload clusters.
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
+kind: AddonProvider
+metadata:
+  name: helm
+  namespace: caaph-system
+spec:
+  version: "v0.6.4"

--- a/mgmt/azure/capi-providers/caaph-system/kustomization.yaml
+++ b/mgmt/azure/capi-providers/caaph-system/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - addon-provider.yaml

--- a/mgmt/azure/capi-providers/caaph-system/namespace.yaml
+++ b/mgmt/azure/capi-providers/caaph-system/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: caaph-system

--- a/mgmt/azure/capi-providers/capi-system/kustomization.yaml
+++ b/mgmt/azure/capi-providers/capi-system/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - providers.yaml

--- a/mgmt/azure/capi-providers/capi-system/namespace.yaml
+++ b/mgmt/azure/capi-providers/capi-system/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: capi-system

--- a/mgmt/azure/capi-providers/capi-system/providers.yaml
+++ b/mgmt/azure/capi-providers/capi-system/providers.yaml
@@ -1,0 +1,26 @@
+# ── Core Provider ────────────────────────────────────────────────────────
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
+kind: CoreProvider
+metadata:
+  name: cluster-api
+  namespace: capi-system
+spec:
+  version: "v1.14.1"
+---
+# ── Kubeadm Bootstrap Provider ────────────────────────────────────────
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
+kind: BootstrapProvider
+metadata:
+  name: kubeadm
+  namespace: capi-system
+spec:
+  version: "v1.14.1"
+---
+# ── Kubeadm Control Plane Provider ──────────────────────────────────────
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
+kind: ControlPlaneProvider
+metadata:
+  name: kubeadm
+  namespace: capi-system
+spec:
+  version: "v1.14.1"

--- a/mgmt/azure/capi-providers/capz-system/capz-variables.yaml
+++ b/mgmt/azure/capi-providers/capz-system/capz-variables.yaml
@@ -1,0 +1,23 @@
+---
+# ══════════════════════════════════════════════════════════════════════════════
+# Variables the CAPI operator substitutes into the CAPZ manifest (configSecret).
+# Nothing here is secret (the operator requires a Secret, not a ConfigMap):
+# the Azure credential lives in an AzureClusterIdentity + SOPS Secret
+# (infrastructure/azure-identity/), never in environment variables.
+#
+# ASOAPI and MachinePool are GA defaults in CAPZ v1.27.0 (feature/feature.go:
+# ASOAPI {Default: true, GA}; MachinePool is in the main API), so no
+# feature-gate flags are needed here.
+#
+# ADDITIONAL_ASO_CRDS extends the ASO CRD set CAPZ installs beyond its own
+# needs (';'-separated patterns) so the bundled ASO can also reconcile the
+# identity resources in infrastructure/aso-workload-identity/.
+# ══════════════════════════════════════════════════════════════════════════════
+apiVersion: v1
+kind: Secret
+metadata:
+  name: capz-variables
+  namespace: capz-system
+type: Opaque
+stringData:
+  ADDITIONAL_ASO_CRDS: "managedidentity.azure.com/*;authorization.azure.com/RoleAssignment"

--- a/mgmt/azure/capi-providers/capz-system/kustomization.yaml
+++ b/mgmt/azure/capi-providers/capz-system/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - capz-variables.yaml
+  - providers.yaml

--- a/mgmt/azure/capi-providers/capz-system/namespace.yaml
+++ b/mgmt/azure/capi-providers/capz-system/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: capz-system

--- a/mgmt/azure/capi-providers/capz-system/providers.yaml
+++ b/mgmt/azure/capi-providers/capz-system/providers.yaml
@@ -1,0 +1,12 @@
+# CAPZ bundles Azure Service Operator (v2.19.0 in v1.27.0) into capz-system;
+# the AzureASOManaged* API drives AKS through inline ASO resources. Upgrade
+# ONE minor version at a time (ASO CRD migrations), see docs/azure.md.
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
+kind: InfrastructureProvider
+metadata:
+  name: azure
+  namespace: capz-system
+spec:
+  version: "v1.27.0"
+  configSecret:
+    name: capz-variables

--- a/mgmt/azure/capi-providers/flux-ks.yaml
+++ b/mgmt/azure/capi-providers/flux-ks.yaml
@@ -1,0 +1,67 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: capi-system
+  namespace: flux-system
+spec:
+  interval: 5m
+  retryInterval: 2m
+  timeout: 5m
+  prune: true
+  wait: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./mgmt/azure/capi-providers/capi-system
+  dependsOn:
+    - name: capi-operator
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: capz-system
+  namespace: flux-system
+spec:
+  interval: 5m
+  retryInterval: 2m
+  timeout: 5m
+  prune: true
+  wait: false
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./mgmt/azure/capi-providers/capz-system
+  dependsOn:
+    - name: capi-system
+  healthChecks:
+    - apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      name: azureasomanagedclusters.infrastructure.cluster.x-k8s.io
+    - apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      name: azureasomanagedcontrolplanes.infrastructure.cluster.x-k8s.io
+    - apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      name: userassignedidentities.managedidentity.azure.com
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: caaph-system
+  namespace: flux-system
+spec:
+  interval: 5m
+  retryInterval: 2m
+  timeout: 5m
+  prune: true
+  wait: false
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./mgmt/azure/capi-providers/caaph-system
+  dependsOn:
+    - name: capi-system
+  healthChecks:
+    - apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      name: helmchartproxies.addons.cluster.x-k8s.io

--- a/mgmt/azure/capi-providers/kustomization.yaml
+++ b/mgmt/azure/capi-providers/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - capi-system
+  - capz-system
+  - caaph-system

--- a/mgmt/azure/clusters/flux-ks.yaml
+++ b/mgmt/azure/clusters/flux-ks.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: swedencentral
+  namespace: flux-system
+spec:
+  interval: 10m
+  retryInterval: 2m
+  timeout: 20m
+  prune: true
+  wait: false
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./mgmt/azure/clusters/swedencentral
+  dependsOn:
+    - name: capz-system
+    - name: azure-identity

--- a/mgmt/azure/clusters/kustomization.yaml
+++ b/mgmt/azure/clusters/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - swedencentral

--- a/mgmt/azure/clusters/swedencentral/kustomization.yaml
+++ b/mgmt/azure/clusters/swedencentral/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - management

--- a/mgmt/azure/clusters/swedencentral/management/capi-nameref.yaml
+++ b/mgmt/azure/clusters/swedencentral/management/capi-nameref.yaml
@@ -1,0 +1,19 @@
+nameReference:
+  - kind: AzureASOManagedCluster
+    fieldSpecs:
+      - path: spec/infrastructureRef/name
+        kind: Cluster
+  - kind: AzureASOManagedControlPlane
+    fieldSpecs:
+      - path: spec/controlPlaneRef/name
+        kind: Cluster
+  - kind: AzureASOManagedMachinePool
+    fieldSpecs:
+      - path: spec/template/spec/infrastructureRef/name
+        kind: MachinePool
+  - kind: Cluster
+    fieldSpecs:
+      - path: spec/clusterName
+        kind: MachinePool
+      - path: spec/template/spec/clusterName
+        kind: MachinePool

--- a/mgmt/azure/clusters/swedencentral/management/cluster.yaml
+++ b/mgmt/azure/clusters/swedencentral/management/cluster.yaml
@@ -1,0 +1,112 @@
+---
+# ── AKS management Cluster ──────────────────────────────────────────────────
+# Created by CAPZ in the kind bootstrap cluster, moved by `clusterctl move`
+# (pivot), then reconciled from Git by the Flux instance inside it. Same
+# lifecycle as mgmt/aws/clusters/eu-north-1/management/.
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: management
+  namespace: default
+  labels:
+    region: swedencentral
+    # Deliberately NOT `fluxcd: enabled` (see the aws management cluster).
+spec:
+  controlPlaneRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: AzureASOManagedControlPlane
+    name: management
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: AzureASOManagedCluster
+    name: management
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureASOManagedCluster
+metadata:
+  name: management
+  namespace: default
+spec:
+  resources:
+    - apiVersion: resources.azure.com/v1api20200601
+      kind: ResourceGroup
+      metadata:
+        name: swedencentral-management
+        annotations:
+          serviceoperator.azure.com/credential-from: aso-credentials
+      spec:
+        location: swedencentral
+        tags:
+          managed-by: flux-capz
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureASOManagedControlPlane
+metadata:
+  name: management
+  namespace: default
+spec:
+  # Placeholder until `az aks get-versions --location swedencentral` is run
+  # against the real subscription (issue #71 follow-up).
+  version: v1.33.4
+  resources:
+    - apiVersion: containerservice.azure.com/v1api20240901
+      kind: ManagedCluster
+      metadata:
+        name: swedencentral-management
+        annotations:
+          serviceoperator.azure.com/credential-from: aso-credentials
+      spec:
+        owner:
+          name: swedencentral-management
+        location: swedencentral
+        dnsPrefix: krops-swedencentral-management
+        identity:
+          type: SystemAssigned
+        servicePrincipalProfile:
+          clientId: msi
+        networkProfile:
+          networkPlugin: azure
+        tags:
+          managed-by: flux-capz
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachinePool
+metadata:
+  name: management-pool
+  namespace: default
+spec:
+  clusterName: management
+  replicas: 2
+  template:
+    spec:
+      clusterName: management
+      bootstrap:
+        dataSecretName: ""
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: AzureASOManagedMachinePool
+        name: management-pool
+      version: v1.33.4
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureASOManagedMachinePool
+metadata:
+  name: management-pool
+  namespace: default
+spec:
+  resources:
+    - apiVersion: containerservice.azure.com/v1api20240901
+      kind: ManagedClustersAgentPool
+      metadata:
+        name: swedencentral-management-pool
+        annotations:
+          serviceoperator.azure.com/credential-from: aso-credentials
+      spec:
+        owner:
+          name: swedencentral-management
+        azureName: system
+        mode: System
+        type: VirtualMachineScaleSets
+        vmSize: Standard_D2s_v5
+        osDiskSizeGB: 64
+        # count is set by CAPZ from MachinePool.spec.replicas.

--- a/mgmt/azure/clusters/swedencentral/management/kustomization.yaml
+++ b/mgmt/azure/clusters/swedencentral/management/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namePrefix: swedencentral-
+configurations:
+  - capi-nameref.yaml
+resources:
+  - cluster.yaml

--- a/mgmt/azure/infrastructure/aso-workload-identity/identity.yaml
+++ b/mgmt/azure/infrastructure/aso-workload-identity/identity.yaml
@@ -1,0 +1,49 @@
+---
+# ══════════════════════════════════════════════════════════════════════════════
+# Identity for the ASO controllers on the WORKLOAD clusters (the Azure
+# counterpart of mgmt/aws/infrastructure/ack-pod-identity/).
+#
+# Reconciled by the ASO bundled with CAPZ on this (management) cluster:
+#   - the shared resource group and the user-assigned identity are created
+#     imperatively by `mise -E azure run azure-bootstrap` so their IDs can be
+#     committed ahead of cluster creation; ASO adopts them here (same name,
+#     same location) and owns them from then on;
+#   - the identity exports its principalId into a ConfigMap that the
+#     RoleAssignments below reference, so no ID has to be pasted twice.
+#
+# Authentication of the resources here: the `credential-from` annotation
+# points at the same SOPS-managed service principal CAPZ uses.
+# ══════════════════════════════════════════════════════════════════════════════
+apiVersion: resources.azure.com/v1api20200601
+kind: ResourceGroup
+metadata:
+  name: krops-shared
+  namespace: default
+  annotations:
+    serviceoperator.azure.com/credential-from: aso-credentials
+spec:
+  location: ${AZURE_LOCATION}
+  tags:
+    managed-by: flux-aso
+---
+apiVersion: managedidentity.azure.com/v1api20230131
+kind: UserAssignedIdentity
+metadata:
+  name: krops-aso
+  namespace: default
+  annotations:
+    serviceoperator.azure.com/credential-from: aso-credentials
+spec:
+  location: ${AZURE_LOCATION}
+  owner:
+    name: krops-shared
+  operatorSpec:
+    configMaps:
+      principalId:
+        name: krops-aso-identity
+        key: principalId
+      clientId:
+        name: krops-aso-identity
+        key: clientId
+  tags:
+    managed-by: flux-aso

--- a/mgmt/azure/infrastructure/aso-workload-identity/kustomization.yaml
+++ b/mgmt/azure/infrastructure/aso-workload-identity/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - identity.yaml
+  - swedencentral-workload.yaml

--- a/mgmt/azure/infrastructure/aso-workload-identity/swedencentral-workload.yaml
+++ b/mgmt/azure/infrastructure/aso-workload-identity/swedencentral-workload.yaml
@@ -1,0 +1,66 @@
+---
+# ══════════════════════════════════════════════════════════════════════════════
+# Per-cluster resources for swedencentral-workload:
+#   - the data resource group the workload ASO manages its resources in
+#     (the S3/RDS "account" boundary in AWS terms);
+#   - Contributor on that group for the krops-aso identity (least scope that
+#     covers storage, networking and PostgreSQL create/update/delete);
+#   - a federated credential trusting the workload cluster's OIDC issuer for
+#     the ASO service account (workload identity; no client secret leaves the
+#     management cluster). The issuer URL is exported by the ManagedCluster
+#     (clusters/swedencentral/staging/cluster.yaml, operatorSpec.configMaps)
+#     into the swedencentral-workload-oidc ConfigMap, so this file can be
+#     committed before the cluster exists: ASO retries until the ConfigMap
+#     appears, the same way ACK retries PodIdentityAssociations.
+# ══════════════════════════════════════════════════════════════════════════════
+apiVersion: resources.azure.com/v1api20200601
+kind: ResourceGroup
+metadata:
+  name: krops-swedencentral-workload-data
+  namespace: default
+  annotations:
+    serviceoperator.azure.com/credential-from: aso-credentials
+spec:
+  location: ${AZURE_LOCATION}
+  tags:
+    managed-by: flux-aso
+    cluster: swedencentral-workload
+---
+apiVersion: authorization.azure.com/v1api20220401
+kind: RoleAssignment
+metadata:
+  name: krops-aso-swedencentral-workload-contributor
+  namespace: default
+  annotations:
+    serviceoperator.azure.com/credential-from: aso-credentials
+spec:
+  owner:
+    group: resources.azure.com
+    kind: ResourceGroup
+    name: krops-swedencentral-workload-data
+  principalIdFromConfig:
+    name: krops-aso-identity
+    key: principalId
+  principalType: ServicePrincipal
+  # Built-in Contributor role.
+  roleDefinitionReference:
+    armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c
+---
+apiVersion: managedidentity.azure.com/v1api20230131
+kind: FederatedIdentityCredential
+metadata:
+  name: krops-aso-swedencentral-workload
+  namespace: default
+  annotations:
+    serviceoperator.azure.com/credential-from: aso-credentials
+spec:
+  owner:
+    name: krops-aso
+  audiences:
+    - api://AzureADTokenExchange
+  issuerFromConfig:
+    name: swedencentral-workload-oidc
+    key: issuer
+  # ASO chart default service account on the workload cluster
+  # (workload/azure-base/aso/helm.yaml).
+  subject: system:serviceaccount:azureserviceoperator-system:azureserviceoperator-default

--- a/mgmt/azure/infrastructure/azure-identity/aso-credentials.sops.yaml
+++ b/mgmt/azure/infrastructure/azure-identity/aso-credentials.sops.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: aso-credentials
+    namespace: default
+type: Opaque
+stringData:
+    AZURE_SUBSCRIPTION_ID: ENC[AES256_GCM,data:vHW28OBQfEGQGEM3rxImZt4NzBMZlr/3U6882xEud7pE38CM,iv:yQBIaLPtBKZi6EVrxaMRD6bY7WquBzzNVzqoS8QGiBY=,tag:t9VlPotAUNv1g6iOusyADg==,type:str]
+    AZURE_TENANT_ID: ENC[AES256_GCM,data:SZ8XGJzBJfbRoiuBI4ue6IimJHL5mycYEQ2M/QhtyGO+Avg2,iv:E/k4Vo47SEf7J5HC4YLriGjELvRjUCEdJSAstpAKK8Y=,tag:+Iu2tXmHjmbbSaOLPg00Qg==,type:str]
+    AZURE_CLIENT_ID: ENC[AES256_GCM,data:yDAqgNA1zjZzurjdMNfHkI++aHm7dxfNtt6Txp5qvynk5rvM,iv:87b+8BdQ8GIofnelsi7pKuiO33HosEP3AVPytf3uZsM=,tag:KR8vIQBIjUmZyH8/xD0mpw==,type:str]
+    AZURE_CLIENT_SECRET: ENC[AES256_GCM,data:YKy4TCsHn79B+w==,iv:3OW45YJU5LCvl8rG/U4hT3uQ8yNHSVBlpidBPGAIRvE=,tag:bljqUcPgblCDM9YNc8dDMw==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB3Tm11alNUb1ZRUkRmeTBj
+            ckZOM1ZaWXphNzMwVkdjZTlreEtmOUphcFY4Ck5wdW9xcGJ1TVJKOHlWazlPWmVV
+            ZVFacU9PZktRZlNtMnVjRTJJZk5iMTgKLS0tIEdSNkVUa2I1WDNjc05aU0pCU2s2
+            M0xhREgvdStuQy9qR1puU3B5UUNxSUEK/Kl4ZYRuUgJnu6FB6W9ovWsFvxzRoQvI
+            3VCH7bcA4iDUks+ySmB18KQIZT5WE7etSdDfrCU/yr9uoaxIOgGxJg==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1amqtgevmdxutg07rkr3wggua43620zgncgfq53vkww0283wrgspqv9q0jw
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-09-10T06:40:36Z"
+    mac: ENC[AES256_GCM,data:qcPew191bIjXi9lmZUsWhQlemBBxufcaOfxatBqrxNfRfEx3UU9jcD+9qPsnbwublejIPo/R5o+bSg1AqGbuUgNB9s8gD6WOmdVx1NX6Yj2bMQmA2eeeqIUIci2nh0Y7b8puM3npDvLGoVFLOKk/3GN/0RQ7/0JwOAZAayaw4ko=,iv:qCTckgv3egk3uwUaz+xrsX6D2TeTUywOV6ud621iDdo=,tag:2pxK5yaPs8dTMANrXPIFtg==,type:str]
+    version: 3.13.3

--- a/mgmt/azure/infrastructure/azure-identity/azure-vars.yaml
+++ b/mgmt/azure/infrastructure/azure-identity/azure-vars.yaml
@@ -1,0 +1,17 @@
+---
+# ══════════════════════════════════════════════════════════════════════════════
+# Non-secret Azure identifiers substituted into management-side manifests
+# (Flux postBuild.substituteFrom). Lives in flux-system because a
+# Kustomization can only substitute from ConfigMaps in its own namespace.
+# Values come from `mise -E azure run azure-bootstrap`.
+# ══════════════════════════════════════════════════════════════════════════════
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: azure-vars
+  namespace: flux-system
+data:
+  AZURE_SUBSCRIPTION_ID: "00000000-0000-0000-0000-000000000000"
+  AZURE_TENANT_ID: "00000000-0000-0000-0000-000000000000"
+  AZURE_CLIENT_ID: "00000000-0000-0000-0000-000000000000"
+  AZURE_LOCATION: "swedencentral"

--- a/mgmt/azure/infrastructure/azure-identity/cluster-identity.yaml
+++ b/mgmt/azure/infrastructure/azure-identity/cluster-identity.yaml
@@ -6,8 +6,10 @@
 # each ASO resource (see clusters/). Both point at the aso-credentials Secret
 # in `default`; CAPZ reads its `AZURE_CLIENT_SECRET` key.
 #
-# move-hierarchy: clusterctl move carries the identity (and the Secret it
-# references) to the pivot target with the Cluster.
+# move-hierarchy: clusterctl move carries the identity to the pivot target
+# with the Cluster. The aso-credentials Secret does NOT move (no
+# move-hierarchy label, no owner reference); the pivot applies it from
+# pivot-sops-secrets (bootstrap.toml) before the move.
 # ══════════════════════════════════════════════════════════════════════════════
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AzureClusterIdentity

--- a/mgmt/azure/infrastructure/azure-identity/cluster-identity.yaml
+++ b/mgmt/azure/infrastructure/azure-identity/cluster-identity.yaml
@@ -1,0 +1,26 @@
+---
+# ══════════════════════════════════════════════════════════════════════════════
+# AzureClusterIdentity: the credential CAPZ itself uses (kubeconfig retrieval,
+# AKS API calls). The bundled ASO reads the SAME service principal through the
+# `serviceoperator.azure.com/credential-from: aso-credentials` annotation on
+# each ASO resource (see clusters/). Both point at the aso-credentials Secret
+# in `default`; CAPZ reads its `AZURE_CLIENT_SECRET` key.
+#
+# move-hierarchy: clusterctl move carries the identity (and the Secret it
+# references) to the pivot target with the Cluster.
+# ══════════════════════════════════════════════════════════════════════════════
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureClusterIdentity
+metadata:
+  name: krops-capz
+  namespace: default
+  labels:
+    clusterctl.cluster.x-k8s.io/move-hierarchy: "true"
+spec:
+  type: ServicePrincipal
+  allowedNamespaces: {}
+  tenantID: "${AZURE_TENANT_ID}"
+  clientID: "${AZURE_CLIENT_ID}"
+  clientSecret:
+    name: aso-credentials
+    namespace: default

--- a/mgmt/azure/infrastructure/azure-identity/kustomization.yaml
+++ b/mgmt/azure/infrastructure/azure-identity/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# aso-credentials.sops.yaml is SOPS-encrypted and decrypted in-cluster by
+# Flux's kustomize-controller (docs/secrets.md). azure-vars.yaml carries the
+# non-secret IDs used by postBuild substitution (like AWS_ACCOUNT_ID in aws).
+resources:
+  - azure-vars.yaml
+  - cluster-identity.yaml
+  - aso-credentials.sops.yaml

--- a/mgmt/azure/infrastructure/capi-operator/helmrelease.yaml
+++ b/mgmt/azure/infrastructure/capi-operator/helmrelease.yaml
@@ -1,0 +1,28 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: capi-operator
+  namespace: flux-system
+spec:
+  interval: 1h
+  releaseName: capi-operator
+  targetNamespace: capi-operator-system
+  install:
+    createNamespace: true
+    crds: CreateReplace
+  upgrade:
+    crds: CreateReplace
+  dependsOn:
+    - name: cert-manager
+  chart:
+    spec:
+      chart: cluster-api-operator
+      version: "0.28.0"
+      sourceRef:
+        kind: HelmRepository
+        name: capi-operator
+        namespace: flux-system
+  values:
+    # Pass-through of core provider installation is handled by capi-providers.yaml
+    cert-manager:
+      enabled: false

--- a/mgmt/azure/infrastructure/capi-operator/helmrepo.yaml
+++ b/mgmt/azure/infrastructure/capi-operator/helmrepo.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: capi-operator
+  namespace: flux-system
+spec:
+  interval: 12h
+  url: https://kubernetes-sigs.github.io/cluster-api-operator

--- a/mgmt/azure/infrastructure/capi-operator/kustomization.yaml
+++ b/mgmt/azure/infrastructure/capi-operator/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrepo.yaml
+  - helmrelease.yaml

--- a/mgmt/azure/infrastructure/cert-manager/helmrelease.yaml
+++ b/mgmt/azure/infrastructure/cert-manager/helmrelease.yaml
@@ -1,0 +1,25 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: cert-manager
+  namespace: flux-system
+spec:
+  interval: 1h
+  releaseName: cert-manager
+  targetNamespace: cert-manager
+  install:
+    createNamespace: true
+    crds: CreateReplace
+  upgrade:
+    crds: CreateReplace
+  chart:
+    spec:
+      chart: cert-manager
+      version: "1.21.1"
+      sourceRef:
+        kind: HelmRepository
+        name: cert-manager
+        namespace: flux-system
+  values:
+    crds:
+      enabled: true

--- a/mgmt/azure/infrastructure/cert-manager/helmrepo.yaml
+++ b/mgmt/azure/infrastructure/cert-manager/helmrepo.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: cert-manager
+  namespace: flux-system
+spec:
+  interval: 12h
+  url: https://charts.jetstack.io

--- a/mgmt/azure/infrastructure/cert-manager/kustomization.yaml
+++ b/mgmt/azure/infrastructure/cert-manager/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrepo.yaml
+  - helmrelease.yaml

--- a/mgmt/azure/infrastructure/flux-ks.yaml
+++ b/mgmt/azure/infrastructure/flux-ks.yaml
@@ -1,0 +1,83 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cert-manager
+  namespace: flux-system
+spec:
+  interval: 5m
+  retryInterval: 2m
+  timeout: 5m
+  prune: true
+  wait: false
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./mgmt/azure/infrastructure/cert-manager
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: capi-operator
+  namespace: flux-system
+spec:
+  interval: 5m
+  retryInterval: 2m
+  timeout: 5m
+  prune: true
+  wait: false
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./mgmt/azure/infrastructure/capi-operator
+  dependsOn:
+    - name: cert-manager
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: azure-identity
+  namespace: flux-system
+spec:
+  interval: 5m
+  retryInterval: 2m
+  timeout: 5m
+  prune: true
+  wait: false
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./mgmt/azure/infrastructure/azure-identity
+  # The AzureClusterIdentity CRD ships with CAPZ.
+  dependsOn:
+    - name: capz-system
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: azure-vars
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: aso-workload-identity
+  namespace: flux-system
+spec:
+  interval: 5m
+  retryInterval: 2m
+  timeout: 10m
+  prune: true
+  wait: false
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./mgmt/azure/infrastructure/aso-workload-identity
+  dependsOn:
+    - name: azure-identity
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: azure-vars

--- a/mgmt/azure/infrastructure/kustomization.yaml
+++ b/mgmt/azure/infrastructure/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cert-manager
+  - capi-operator
+  - azure-identity
+  - aso-workload-identity

--- a/mgmt/azure/kustomization.yaml
+++ b/mgmt/azure/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - infrastructure/flux-ks.yaml
+  - capi-providers/flux-ks.yaml
+  - addons/flux-ks.yaml
+  - clusters/flux-ks.yaml

--- a/mise.azure.toml
+++ b/mise.azure.toml
@@ -1,0 +1,75 @@
+# azure environment task layer (issue #71).
+#
+# Like aws, this environment syncs mgmt/azure from GitHub and pivots into an
+# AKS management cluster built by CAPZ. The Azure CLI is only needed for the
+# one-time subscription preparation (azure-bootstrap) and for debugging;
+# nothing in bootstrap/pivot shells out to it.
+
+[env]
+KROPS_PROFILE = "azure"
+
+[tools]
+"pipx:azure-cli" = "2.90.0"
+
+[tasks.azure-bootstrap]
+description = "One-time subscription prep: register providers, create the CAPZ/ASO service principal, the shared resource group and the krops-aso identity; prints the values to commit"
+run = '''
+set -eu
+: "${AZURE_SUBSCRIPTION_ID:?set AZURE_SUBSCRIPTION_ID in .env or the shell}"
+AZURE_LOCATION="${AZURE_LOCATION:-swedencentral}"
+az account set --subscription "$AZURE_SUBSCRIPTION_ID"
+for ns in Microsoft.Compute Microsoft.Network Microsoft.ContainerService \
+          Microsoft.ManagedIdentity Microsoft.Authorization Microsoft.Storage \
+          Microsoft.DBforPostgreSQL; do
+  echo "==> register $ns"
+  az provider register --namespace "$ns" --wait >/dev/null
+done
+echo "==> resource group krops-shared"
+az group create --name krops-shared --location "$AZURE_LOCATION" --output none
+echo "==> user-assigned identity krops-aso (adopted by ASO from Git)"
+az identity create --name krops-aso --resource-group krops-shared \
+  --location "$AZURE_LOCATION" --output none
+CLIENT_ID=$(az identity show -g krops-shared -n krops-aso --query clientId -o tsv)
+PRINCIPAL_ID=$(az identity show -g krops-shared -n krops-aso --query principalId -o tsv)
+echo "==> service principal krops-capz (Contributor + RBAC Administrator on the subscription)"
+SP_JSON=$(az ad sp create-for-rbac --name krops-capz --role Contributor \
+  --scopes "/subscriptions/${AZURE_SUBSCRIPTION_ID}" --output json)
+SP_APP_ID=$(printf '%s' "$SP_JSON" | python3 -c 'import json,sys; print(json.load(sys.stdin)["appId"])')
+az role assignment create --assignee "$SP_APP_ID" \
+  --role "Role Based Access Control Administrator" \
+  --scope "/subscriptions/${AZURE_SUBSCRIPTION_ID}" --output none
+TENANT_ID=$(az account show --query tenantId -o tsv)
+cat <<EOF
+
+Commit these (non-secret) values:
+  mgmt/azure/infrastructure/azure-identity/azure-vars.yaml
+    AZURE_SUBSCRIPTION_ID: "${AZURE_SUBSCRIPTION_ID}"
+    AZURE_TENANT_ID:       "${TENANT_ID}"
+  mgmt/azure/addons/flux-apps/flux-instance.yaml (cluster-vars)
+    AZURE_ASO_CLIENT_ID:    "${CLIENT_ID}"
+    AZURE_ASO_PRINCIPAL_ID: "${PRINCIPAL_ID}"
+
+Put the service principal into the SOPS secret (docs/secrets.md, "Azure"):
+  mgmt/azure/infrastructure/azure-identity/aso-credentials.sops.yaml
+    AZURE_SUBSCRIPTION_ID, AZURE_TENANT_ID, AZURE_CLIENT_ID (appId), AZURE_CLIENT_SECRET (password)
+The password is printed ONCE below; store it, then run: mise run sops-encrypt <file>
+EOF
+printf '%s\n' "$SP_JSON"
+'''
+
+[tasks.kubeconfigs]
+description = "Export the AKS workload-cluster kubeconfig via clusterctl (no endpoint rewrite: AKS is remote)"
+run = '''
+KUBECONFIG_FILE="${KUBECONFIG_FILE:-$HOME/.kube/krops-workloads.yaml}"
+fail=0
+for location in $(find mgmt/azure/clusters -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | sort); do
+  cluster="${location}-workload"
+  echo "==> ${cluster}"
+  if ! clusterctl get kubeconfig "$cluster" -n default > "${KUBECONFIG_FILE}.${cluster}"; then
+    echo "    FAILED: ${cluster} — cluster not provisioned yet?" >&2
+    fail=1
+  fi
+done
+echo "Use with: KUBECONFIG=${KUBECONFIG_FILE}.<cluster> kubectl get nodes"
+exit $fail
+'''

--- a/mise.toml
+++ b/mise.toml
@@ -79,7 +79,7 @@ run = "sops --decrypt --input-type yaml --output-type yaml"
 [tasks.sops-updatekeys]
 description = "Re-encrypt all *.sops.yaml files to match recipients in .sops.yaml"
 run = """
-for f in $(find mgmt/aws -name '*.sops.yaml'); do
+for f in $(find mgmt -name '*.sops.yaml'); do
   echo "==> updatekeys $f"
   sops updatekeys --yes "$f"
 done
@@ -96,7 +96,7 @@ run = "scripts/toolbox-run.sh pivot"
 [tasks.mgmt-kubeconfig]
 description = "Export the management-cluster kubeconfig to ~/.kube/krops-mgmt.yaml"
 run = '''
-MGMT_CLUSTER="${MGMT_CLUSTER:-$(case "${KROPS_PROFILE:-aws}" in local-host) echo local-management;; local-talos) echo local-talos-management;; *) echo eu-north-1-management;; esac)}"
+MGMT_CLUSTER="${MGMT_CLUSTER:-$(case "${KROPS_PROFILE:-aws}" in local-host) echo local-management;; local-talos) echo local-talos-management;; azure) echo swedencentral-management;; *) echo eu-north-1-management;; esac)}"
 MGMT_KUBECONFIG="${MGMT_KUBECONFIG:-$HOME/.kube/krops-mgmt.yaml}"
 clusterctl get kubeconfig "$MGMT_CLUSTER" -n default > "$MGMT_KUBECONFIG"
 chmod 600 "$MGMT_KUBECONFIG"

--- a/renovate.json5
+++ b/renovate.json5
@@ -215,6 +215,15 @@
       "extractVersionTemplate": "^v(?<version>.+)",
       "autoReplaceStringTemplate": "talosctl = \"{{newValue}}\""
     },
+    {
+      "customType": "regex",
+      "description": "mise: azure-cli pin (pipx backend, azure environment layer, issue #71)",
+      "managerFilePatterns": ["/(^|/)mise\\.azure\\.toml$/"],
+      "matchStrings": ["\"pipx:azure-cli\" = \"(?<currentValue>[^\"]+)\""],
+      "depNameTemplate": "azure-cli",
+      "datasourceTemplate": "pypi",
+      "autoReplaceStringTemplate": "\"pipx:azure-cli\" = \"{{newValue}}\""
+    },
     // ── bootstrap.toml chart pins (annotation-driven) ─────────────────────
     // Datasource and depName live in `# renovate:` comments next to the
     // chart pins in bootstrap.toml (consumed by the Rust binary since the
@@ -286,7 +295,7 @@
       "customType": "regex",
       "description": "CAPI core, kubeadm, and CAPD provider versions (aws, local-host, local-talos)",
       "managerFilePatterns": [
-        "/(^|/)mgmt/(aws|local-host|local-talos)/capi-providers/(capi-system|capd-system)/.+\\.ya?ml$/"
+        "/(^|/)mgmt/(aws|azure|local-host|local-talos)/capi-providers/(capi-system|capd-system)/.+\\.ya?ml$/"
       ],
       "matchStrings": ["\\s{2}version: \"v(?<currentValue>[^\"]+)\""],
       "depNameTemplate": "kubernetes-sigs/cluster-api",
@@ -308,9 +317,21 @@
     },
     {
       "customType": "regex",
+      "description": "CAPZ (Azure infrastructure) provider version (issue #71)",
+      "managerFilePatterns": [
+        "/(^|/)mgmt/azure/capi-providers/capz-system/.+\\.ya?ml$/"
+      ],
+      "matchStrings": ["\\s{2}version: \"v(?<currentValue>[^\"]+)\""],
+      "depNameTemplate": "kubernetes-sigs/cluster-api-provider-azure",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.+)",
+      "autoReplaceStringTemplate": "  version: \"v{{newValue}}\""
+    },
+    {
+      "customType": "regex",
       "description": "CAAPH (helm add-on) provider version",
       "managerFilePatterns": [
-        "/(^|/)mgmt/(aws|local-host)/capi-providers/caaph-system/.+\\.ya?ml$/"
+        "/(^|/)mgmt/(aws|azure|local-host)/capi-providers/caaph-system/.+\\.ya?ml$/"
       ],
       "matchStrings": ["\\s{2}version: \"v(?<currentValue>[^\"]+)\""],
       "depNameTemplate": "kubernetes-sigs/cluster-api-addon-provider-helm",
@@ -424,14 +445,22 @@
       "groupName": "flux"
     },
     {
-      "description": "Group the CAPI family (core, kubeadm, CAPD, CAPA, CAAPH)",
+      "description": "Group the CAPI family (core, kubeadm, CAPD, CAPA, CAAPH, CAPZ)",
       "matchDatasources": ["github-releases"],
       "matchPackageNames": [
         "kubernetes-sigs/cluster-api",
         "kubernetes-sigs/cluster-api-provider-aws",
-        "kubernetes-sigs/cluster-api-addon-provider-helm"
+        "kubernetes-sigs/cluster-api-addon-provider-helm",
+        "kubernetes-sigs/cluster-api-provider-azure"
       ],
       "groupName": "cluster-api"
+    },
+    {
+      "description": "CAPZ bundles ASO, which must be upgraded one minor version at a time (issue #71)",
+      "matchDatasources": ["github-releases"],
+      "matchPackageNames": ["kubernetes-sigs/cluster-api-provider-azure"],
+      "separateMultipleMinor": true,
+      "groupName": null
     },
     {
       "description": "Group imperative pivot chart pins with their GitOps HelmReleases",

--- a/tests/test-bootstrap-config.py
+++ b/tests/test-bootstrap-config.py
@@ -22,16 +22,19 @@ CHART_MANIFESTS = {
     "flux-operator": [
         "mgmt/aws/addons/flux-apps/flux-operator.yaml",
         "mgmt/local-host/addons/flux-apps/flux-operator.yaml",
+        "mgmt/azure/addons/flux-apps/flux-operator.yaml",
     ],
     "cert-manager": [
         "mgmt/aws/infrastructure/cert-manager/helmrelease.yaml",
         "mgmt/local-host/infrastructure/cert-manager/helmrelease.yaml",
         "mgmt/local-talos/infrastructure/cert-manager/helmrelease.yaml",
+        "mgmt/azure/infrastructure/cert-manager/helmrelease.yaml",
     ],
     "capi-operator": [
         "mgmt/aws/infrastructure/capi-operator/helmrelease.yaml",
         "mgmt/local-host/infrastructure/capi-operator/helmrelease.yaml",
         "mgmt/local-talos/infrastructure/capi-operator/helmrelease.yaml",
+        "mgmt/azure/infrastructure/capi-operator/helmrelease.yaml",
     ],
 }
 

--- a/tests/test-bootstrap-config.py
+++ b/tests/test-bootstrap-config.py
@@ -60,6 +60,9 @@ def main() -> int:
         return 1
 
     charts = config.get("charts", {})
+    for required_env in ("local-host", "aws", "local-talos", "azure"):
+        if required_env not in config.get("environments", {}):
+            failures.append(f"environments.{required_env} section missing from bootstrap.toml")
     for chart, manifests in CHART_MANIFESTS.items():
         declared = charts.get(chart)
         if declared is None:
@@ -100,6 +103,14 @@ def main() -> int:
                     f"environments.{name} move-fallback manifest missing: "
                     f"{fallback.get('manifest')}"
                 )
+        # SOPS manifests the pivot decrypts and applies in the target before
+        # the move (issue #71): must exist and must follow the *.sops.yaml
+        # naming so .sops.yaml's creation rule covers them.
+        for manifest in env.get("pivot-sops-secrets", []):
+            if not (REPO_ROOT / manifest).is_file():
+                failures.append(f"environments.{name} pivot-sops-secret missing: {manifest}")
+            if not manifest.endswith(".sops.yaml"):
+                failures.append(f"environments.{name} pivot-sops-secret is not a *.sops.yaml: {manifest}")
 
         # ── teardown constants (issue #100) ─────────────────────────────
         td = env.get("teardown", {})

--- a/tests/test-renovate-coverage.py
+++ b/tests/test-renovate-coverage.py
@@ -46,6 +46,10 @@ EXPECTED = {
     },
     "mise.local-talos.toml": {"siderolabs/talos"},
     "mise.toml": {"astral-sh/uv"},
+    "mgmt/azure/capi-providers/capz-system/providers.yaml": {
+        "kubernetes-sigs/cluster-api-provider-azure",
+    },
+    "mise.azure.toml": {"azure-cli"},
 }
 
 REQUIRED_SINGLE_REGISTRY = {


### PR DESCRIPTION
## Summary
Management-side `azure` environment (issue #71, PR 1 of 3): `mgmt/azure/` (cert-manager, CAPI operator, CAPZ v1.27.0 with bundled ASO, CAAPH, Flux addons, AKS management cluster via `AzureASOManaged*`), ASO workload-identity plumbing, `bootstrap.toml` environment with two new config-driven knobs (`pivot-sops-secrets`, `teardown.manual`), `mise.azure.toml`, Renovate coverage.

## Not in this PR
Workload clusters and `workload/azure-base` (PR 2); `docs/azure.md` and README (PR 3). No live run: no subscription is available; placeholders (`00000000-...`, `v1.33.4`, storage account suffix) are called out in `docs/azure.md` (PR 3) and the follow-up issue.

## Verification
- `mise run validate`, `cargo fmt/clippy/test`, `tests/test-bootstrap-config.py`, `tests/test-renovate-coverage.py` all pass locally
- Renovate `--dry-run=full`: CAPZ 1.27.0 and azure-cli 2.90.0 extracted, 0 lookup failures
- konflate render on this PR shows only additions under `mgmt/azure/`

Refs #71
