### PR TITLE
feat: Azure workload cluster and ASO-managed workload resources

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -75,6 +75,9 @@ jobs:
       - name: bootstrap.toml cross-check
         run: python3 tests/test-bootstrap-config.py
 
+      - name: Azure identity chain cross-check
+        run: pip install --quiet pyyaml && python3 tests/test-azure-identity-chain.py
+
   yaml-lint:
     name: Lint YAML
     runs-on: ubuntu-latest

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -54,6 +54,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7.0.1
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v10.0.1
+        with:
+          version: "0.12.11"
+
       - name: Set up Node.js
         uses: actions/setup-node@v7.0.0
         with:
@@ -75,8 +80,12 @@ jobs:
       - name: bootstrap.toml cross-check
         run: python3 tests/test-bootstrap-config.py
 
+      # uv run resolves pyyaml from pyproject.toml/uv.lock, the same environment
+      # mise run validate uses for this cross-check.
       - name: Azure identity chain cross-check
-        run: pip install --quiet pyyaml && python3 tests/test-azure-identity-chain.py
+        run: |
+          uv sync --locked
+          uv run python tests/test-azure-identity-chain.py
 
   yaml-lint:
     name: Lint YAML

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,12 @@ resources. There is no app source code here, only declarative infrastructure.
   migrations). Teardown is manual until the live acceptance run.
 - `workload/`: synced by each WORKLOAD cluster's Flux.
   - `base/`: ACK controllers and S3/RDS/IAM custom resources.
+  - `azure-base/`: cert-manager, ASO (workload identity), and the Azure
+    resources (VNet + delegated subnet + private DNS, storage account +
+    container, PostgreSQL Flexible Server). `swedencentral-01/` points at it.
+    `tests/test-azure-identity-chain.py` (in `mise run validate` and CI)
+    cross-checks the ConfigMap/subject couplings between these and
+    `mgmt/azure/infrastructure/aso-workload-identity/`.
   - `<region>-01/`: per-cluster overlays pointing at `../base`.
 - `airgap/`: Zarf offline transfer bundle for the local-host profile.
   `zarf.yaml` + `images.txt` define the packages; `scripts/` builds,

--- a/mgmt/azure/clusters/swedencentral/kustomization.yaml
+++ b/mgmt/azure/clusters/swedencentral/kustomization.yaml
@@ -1,4 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - staging
   - management

--- a/mgmt/azure/clusters/swedencentral/management/cluster.yaml
+++ b/mgmt/azure/clusters/swedencentral/management/cluster.yaml
@@ -107,6 +107,8 @@ spec:
         azureName: system
         mode: System
         type: VirtualMachineScaleSets
-        vmSize: Standard_D2s_v5
+        # Cheapest AKS-eligible system-pool SKU in swedencentral (on-demand
+        # Linux): >= 2 vCPU and >= 4 GiB, no B series (AKS system-pool rules).
+        vmSize: Standard_D2as_v5
         osDiskSizeGB: 64
         # count is set by CAPZ from MachinePool.spec.replicas.

--- a/mgmt/azure/clusters/swedencentral/staging/capi-nameref.yaml
+++ b/mgmt/azure/clusters/swedencentral/staging/capi-nameref.yaml
@@ -1,0 +1,19 @@
+nameReference:
+  - kind: AzureASOManagedCluster
+    fieldSpecs:
+      - path: spec/infrastructureRef/name
+        kind: Cluster
+  - kind: AzureASOManagedControlPlane
+    fieldSpecs:
+      - path: spec/controlPlaneRef/name
+        kind: Cluster
+  - kind: AzureASOManagedMachinePool
+    fieldSpecs:
+      - path: spec/template/spec/infrastructureRef/name
+        kind: MachinePool
+  - kind: Cluster
+    fieldSpecs:
+      - path: spec/clusterName
+        kind: MachinePool
+      - path: spec/template/spec/clusterName
+        kind: MachinePool

--- a/mgmt/azure/clusters/swedencentral/staging/cluster.yaml
+++ b/mgmt/azure/clusters/swedencentral/staging/cluster.yaml
@@ -115,7 +115,9 @@ spec:
         azureName: system
         mode: System
         type: VirtualMachineScaleSets
-        vmSize: Standard_D2s_v5
+        # Cheapest AKS-eligible system-pool SKU in swedencentral (on-demand
+        # Linux): >= 2 vCPU and >= 4 GiB, no B series (AKS system-pool rules).
+        vmSize: Standard_D2as_v5
         osDiskSizeGB: 64
 ---
 # ── ARM user pool (Ampere Altra), the Graviton pool's counterpart ───────────
@@ -157,6 +159,10 @@ spec:
         azureName: arm
         mode: User
         type: VirtualMachineScaleSets
+        # Cheapest AKS-supported Arm64 SKU in swedencentral (on-demand Linux);
+        # Dplsv5 is the lowest-cost of the Dpsv5/Dplsv5/Epsv5 series AKS
+        # accepts for Arm64 pools. Cheaper ARM SKUs (Bpsv2, Dplsv6) are not
+        # AKS-supported.
         vmSize: Standard_D2pls_v5
         osDiskSizeGB: 64
         nodeLabels:

--- a/mgmt/azure/clusters/swedencentral/staging/cluster.yaml
+++ b/mgmt/azure/clusters/swedencentral/staging/cluster.yaml
@@ -1,0 +1,163 @@
+---
+# ── AKS workload Cluster ────────────────────────────────────────────────────
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: workload
+  namespace: default
+  labels:
+    fluxcd: enabled
+    region: swedencentral
+spec:
+  controlPlaneRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: AzureASOManagedControlPlane
+    name: workload
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: AzureASOManagedCluster
+    name: workload
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureASOManagedCluster
+metadata:
+  name: workload
+  namespace: default
+spec:
+  resources:
+    - apiVersion: resources.azure.com/v1api20200601
+      kind: ResourceGroup
+      metadata:
+        name: swedencentral-workload
+        annotations:
+          serviceoperator.azure.com/credential-from: aso-credentials
+      spec:
+        location: swedencentral
+        tags:
+          managed-by: flux-capz
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureASOManagedControlPlane
+metadata:
+  name: workload
+  namespace: default
+spec:
+  version: v1.33.4
+  resources:
+    - apiVersion: containerservice.azure.com/v1api20240901
+      kind: ManagedCluster
+      metadata:
+        name: swedencentral-workload
+        annotations:
+          serviceoperator.azure.com/credential-from: aso-credentials
+      spec:
+        owner:
+          name: swedencentral-workload
+        location: swedencentral
+        dnsPrefix: krops-swedencentral-workload
+        identity:
+          type: SystemAssigned
+        servicePrincipalProfile:
+          clientId: msi
+        networkProfile:
+          networkPlugin: azure
+        # Workload identity for the ASO controller on this cluster
+        # (mgmt/azure/infrastructure/aso-workload-identity/). The issuer URL
+        # is exported to a ConfigMap the FederatedIdentityCredential reads.
+        oidcIssuerProfile:
+          enabled: true
+        securityProfile:
+          workloadIdentity:
+            enabled: true
+        operatorSpec:
+          configMaps:
+            oidcIssuerProfile:
+              name: swedencentral-workload-oidc
+              key: issuer
+        tags:
+          managed-by: flux-capz
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachinePool
+metadata:
+  name: workload-system
+  namespace: default
+spec:
+  clusterName: workload
+  replicas: 1
+  template:
+    spec:
+      clusterName: workload
+      bootstrap:
+        dataSecretName: ""
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: AzureASOManagedMachinePool
+        name: workload-system
+      version: v1.33.4
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureASOManagedMachinePool
+metadata:
+  name: workload-system
+  namespace: default
+spec:
+  resources:
+    - apiVersion: containerservice.azure.com/v1api20240901
+      kind: ManagedClustersAgentPool
+      metadata:
+        name: swedencentral-workload-system
+        annotations:
+          serviceoperator.azure.com/credential-from: aso-credentials
+      spec:
+        owner:
+          name: swedencentral-workload
+        azureName: system
+        mode: System
+        type: VirtualMachineScaleSets
+        vmSize: Standard_D2s_v5
+        osDiskSizeGB: 64
+---
+# ── ARM user pool (Ampere Altra), the Graviton pool's counterpart ───────────
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachinePool
+metadata:
+  name: workload-arm
+  namespace: default
+spec:
+  clusterName: workload
+  replicas: 2
+  template:
+    spec:
+      clusterName: workload
+      bootstrap:
+        dataSecretName: ""
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: AzureASOManagedMachinePool
+        name: workload-arm
+      version: v1.33.4
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureASOManagedMachinePool
+metadata:
+  name: workload-arm
+  namespace: default
+spec:
+  resources:
+    - apiVersion: containerservice.azure.com/v1api20240901
+      kind: ManagedClustersAgentPool
+      metadata:
+        name: swedencentral-workload-arm
+        annotations:
+          serviceoperator.azure.com/credential-from: aso-credentials
+      spec:
+        owner:
+          name: swedencentral-workload
+        azureName: arm
+        mode: User
+        type: VirtualMachineScaleSets
+        vmSize: Standard_D2pls_v5
+        osDiskSizeGB: 64
+        nodeLabels:
+          node.kubernetes.io/arch: arm64

--- a/mgmt/azure/clusters/swedencentral/staging/kustomization.yaml
+++ b/mgmt/azure/clusters/swedencentral/staging/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namePrefix: swedencentral-
+configurations:
+  - capi-nameref.yaml
+resources:
+  - cluster.yaml

--- a/mise.toml
+++ b/mise.toml
@@ -44,6 +44,11 @@ if ! python3 tests/test-bootstrap-config.py; then
   echo "    FAILED: bootstrap.toml cross-check" >&2
   fail=1
 fi
+echo "==> azure identity chain"
+if ! uv run python tests/test-azure-identity-chain.py; then
+  echo "    FAILED: azure identity chain" >&2
+  fail=1
+fi
 for dir in $(find mgmt workload -name kustomization.yaml -exec dirname {} \; | sort -u); do
   echo "==> kustomize build $dir"
   if ! kubectl kustomize "$dir" >/dev/null; then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "Documentation website build for krops (GitHub Pages)"
 requires-python = ">=3.13"
 dependencies = [
   "mkdocs-material==9.7.7",
+  "pyyaml==6.0.3",
 ]
 
 [dependency-groups]

--- a/tests/test-azure-identity-chain.py
+++ b/tests/test-azure-identity-chain.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Cross-check the Azure workload-identity chain (issue #71).
+
+The management-side ASO resources and the workload-cluster ASO release are
+coupled by literal names that no renderer validates: the ConfigMap the
+ManagedCluster exports its OIDC issuer into must be the one the
+FederatedIdentityCredential reads; the ConfigMap the UserAssignedIdentity
+exports its principalId into must be the one each RoleAssignment reads; and
+the federated subject must name the ASO service account on the workload
+cluster. Requires PyYAML (mise's python provides it via `uv run`).
+"""
+
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+IDENTITY = REPO_ROOT / "mgmt/azure/infrastructure/aso-workload-identity"
+CLUSTERS = REPO_ROOT / "mgmt/azure/clusters"
+ASO_NAMESPACE = "azureserviceoperator-system"
+ASO_SERVICE_ACCOUNT = "azureserviceoperator-default"
+
+
+def docs(path: Path):
+    return [d for d in yaml.safe_load_all(path.read_text()) if d]
+
+
+def all_docs(root: Path):
+    for path in sorted(root.rglob("*.yaml")):
+        if path.name in ("kustomization.yaml", "capi-nameref.yaml"):
+            continue
+        for doc in docs(path):
+            yield path.relative_to(REPO_ROOT), doc
+
+
+def main() -> int:
+    failures = []
+    exported_oidc = set()
+    for _, doc in all_docs(CLUSTERS):
+        if doc.get("kind") != "AzureASOManagedControlPlane":
+            continue
+        for res in doc["spec"].get("resources", []):
+            cm = (res.get("spec", {}).get("operatorSpec", {}).get("configMaps", {})
+                  .get("oidcIssuerProfile", {}))
+            if cm:
+                exported_oidc.add((cm["name"], cm["key"]))
+
+    exported_principal = set()
+    for _, doc in all_docs(IDENTITY):
+        if doc.get("kind") == "UserAssignedIdentity":
+            cm = doc["spec"].get("operatorSpec", {}).get("configMaps", {}).get("principalId", {})
+            if cm:
+                exported_principal.add((cm["name"], cm["key"]))
+
+    for path, doc in all_docs(IDENTITY):
+        kind = doc.get("kind")
+        if kind == "FederatedIdentityCredential":
+            ref = doc["spec"].get("issuerFromConfig", {})
+            if (ref.get("name"), ref.get("key")) not in exported_oidc:
+                failures.append(f"{path}: issuerFromConfig {ref} is not exported by any ManagedCluster")
+            expected = f"system:serviceaccount:{ASO_NAMESPACE}:{ASO_SERVICE_ACCOUNT}"
+            if doc["spec"].get("subject") != expected:
+                failures.append(f"{path}: subject must be {expected}")
+        if kind == "RoleAssignment":
+            ref = doc["spec"].get("principalIdFromConfig", {})
+            if (ref.get("name"), ref.get("key")) not in exported_principal:
+                failures.append(f"{path}: principalIdFromConfig {ref} is not exported by any UserAssignedIdentity")
+
+    ns_doc = docs(REPO_ROOT / "workload/azure-base/aso/namespace.yaml")[0]
+    if ns_doc["metadata"]["name"] != ASO_NAMESPACE:
+        failures.append(f"workload/azure-base/aso/namespace.yaml: namespace must be {ASO_NAMESPACE}")
+
+    if failures:
+        print("azure identity chain FAILED:")
+        for f in failures:
+            print(f"  - {f}")
+        return 1
+    print(f"azure identity chain OK ({len(exported_oidc)} issuer exports, {len(exported_principal)} principal exports)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test-bootstrap-config.py
+++ b/tests/test-bootstrap-config.py
@@ -29,6 +29,7 @@ CHART_MANIFESTS = {
         "mgmt/local-host/infrastructure/cert-manager/helmrelease.yaml",
         "mgmt/local-talos/infrastructure/cert-manager/helmrelease.yaml",
         "mgmt/azure/infrastructure/cert-manager/helmrelease.yaml",
+        "workload/azure-base/cert-manager/helmrelease.yaml",
     ],
     "capi-operator": [
         "mgmt/aws/infrastructure/capi-operator/helmrelease.yaml",

--- a/uv.lock
+++ b/uv.lock
@@ -214,6 +214,7 @@ version = "0.0.0"
 source = { virtual = "." }
 dependencies = [
     { name = "mkdocs-material" },
+    { name = "pyyaml" },
 ]
 
 [package.dev-dependencies]
@@ -222,7 +223,10 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "mkdocs-material", specifier = "==9.7.7" }]
+requires-dist = [
+    { name = "mkdocs-material", specifier = "==9.7.7" },
+    { name = "pyyaml", specifier = "==6.0.3" },
+]
 
 [package.metadata.requires-dev]
 dev = [{ name = "pytest", specifier = "==9.1.1" }]

--- a/workload/azure-base/aso/flux-ks.yaml
+++ b/workload/azure-base/aso/flux-ks.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: aso
+  namespace: flux-system
+spec:
+  interval: 10m
+  retryInterval: 2m
+  timeout: 15m
+  prune: true
+  # wait: true so the resource Kustomizations below only apply once the ASO
+  # CRDs and controller are Ready.
+  wait: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./workload/azure-base/aso
+  dependsOn:
+    - name: cert-manager
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: cluster-vars

--- a/workload/azure-base/aso/helm.yaml
+++ b/workload/azure-base/aso/helm.yaml
@@ -1,0 +1,47 @@
+---
+# ══════════════════════════════════════════════════════════════════════════════
+# Azure Service Operator on the WORKLOAD cluster (the ACK controllers'
+# counterpart). Authentication: workload identity. The management cluster's
+# ASO created the krops-aso user-assigned identity, a federated credential
+# trusting this cluster's OIDC issuer for the service account below, and a
+# Contributor assignment on this cluster's data resource group
+# (mgmt/azure/infrastructure/aso-workload-identity/). No secret lands here.
+#
+# crdPattern limits the installed CRDs to the groups this repo uses.
+# Version: keep in step with the ASO bundled by CAPZ on the management
+# cluster (CAPZ v1.27.0 -> ASO v2.19.0); upgrade one minor at a time.
+# ══════════════════════════════════════════════════════════════════════════════
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: azure-service-operator
+  namespace: azureserviceoperator-system
+spec:
+  interval: 1h
+  url: https://raw.githubusercontent.com/Azure/azure-service-operator/main/v2/charts
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: azure-service-operator
+  namespace: azureserviceoperator-system
+spec:
+  interval: 10m
+  timeout: 10m
+  chart:
+    spec:
+      chart: azure-service-operator
+      version: "2.19.0"
+      sourceRef:
+        kind: HelmRepository
+        name: azure-service-operator
+  install:
+    crds: CreateReplace
+  upgrade:
+    crds: CreateReplace
+  values:
+    azureSubscriptionID: "${AZURE_SUBSCRIPTION_ID}"
+    azureTenantID: "${AZURE_TENANT_ID}"
+    azureClientID: "${AZURE_ASO_CLIENT_ID}"
+    useWorkloadIdentityAuth: true
+    crdPattern: "resources.azure.com/*;network.azure.com/*;storage.azure.com/*;dbforpostgresql.azure.com/*"

--- a/workload/azure-base/aso/kustomization.yaml
+++ b/workload/azure-base/aso/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - helm.yaml

--- a/workload/azure-base/aso/namespace.yaml
+++ b/workload/azure-base/aso/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: azureserviceoperator-system

--- a/workload/azure-base/cert-manager/flux-ks.yaml
+++ b/workload/azure-base/cert-manager/flux-ks.yaml
@@ -1,0 +1,20 @@
+---
+# ══════════════════════════════════════════════════════════════════════════════
+# cert-manager on the workload cluster: ASO's webhooks require it. wait: true
+# so the ASO HelmRelease only installs once the CA injector is Ready.
+# ══════════════════════════════════════════════════════════════════════════════
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cert-manager
+  namespace: flux-system
+spec:
+  interval: 10m
+  retryInterval: 2m
+  timeout: 10m
+  prune: true
+  wait: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./workload/azure-base/cert-manager

--- a/workload/azure-base/cert-manager/helmrelease.yaml
+++ b/workload/azure-base/cert-manager/helmrelease.yaml
@@ -1,0 +1,25 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: cert-manager
+  namespace: flux-system
+spec:
+  interval: 1h
+  releaseName: cert-manager
+  targetNamespace: cert-manager
+  install:
+    createNamespace: true
+    crds: CreateReplace
+  upgrade:
+    crds: CreateReplace
+  chart:
+    spec:
+      chart: cert-manager
+      version: "1.21.1"
+      sourceRef:
+        kind: HelmRepository
+        name: cert-manager
+        namespace: flux-system
+  values:
+    crds:
+      enabled: true

--- a/workload/azure-base/cert-manager/helmrepo.yaml
+++ b/workload/azure-base/cert-manager/helmrepo.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: cert-manager
+  namespace: flux-system
+spec:
+  interval: 12h
+  url: https://charts.jetstack.io

--- a/workload/azure-base/cert-manager/kustomization.yaml
+++ b/workload/azure-base/cert-manager/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrepo.yaml
+  - helmrelease.yaml

--- a/workload/azure-base/kustomization.yaml
+++ b/workload/azure-base/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cert-manager/flux-ks.yaml
+  - aso/flux-ks.yaml
+  - networking/flux-ks.yaml
+  - storage/flux-ks.yaml
+  - postgres/flux-ks.yaml

--- a/workload/azure-base/networking/flux-ks.yaml
+++ b/workload/azure-base/networking/flux-ks.yaml
@@ -1,0 +1,29 @@
+---
+# ══════════════════════════════════════════════════════════════════════════════
+# Flux Kustomization: networking baseline (VNet, delegated subnet, private
+# DNS zone) managed by this cluster's ASO.
+#
+# dependsOn: aso — the ASO CRDs and controller must be Ready (aso has
+# wait: true) before the networking CRs are applied.
+# ══════════════════════════════════════════════════════════════════════════════
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: networking
+  namespace: flux-system
+spec:
+  interval: 10m
+  retryInterval: 2m
+  timeout: 5m
+  prune: true
+  wait: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./workload/azure-base/networking
+  dependsOn:
+    - name: aso
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: cluster-vars

--- a/workload/azure-base/networking/kustomization.yaml
+++ b/workload/azure-base/networking/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - vnet.yaml

--- a/workload/azure-base/networking/vnet.yaml
+++ b/workload/azure-base/networking/vnet.yaml
@@ -1,0 +1,69 @@
+---
+# ══════════════════════════════════════════════════════════════════════════════
+# Networking baseline for the workload resources, reconciled by this
+# cluster's ASO in the per-cluster data resource group (created by the
+# management cluster; referenced by ARM ID so no cross-namespace owner).
+#
+# The subnet is delegated to PostgreSQL Flexible Server (private access);
+# the private DNS zone + link give the server a resolvable private name.
+# ══════════════════════════════════════════════════════════════════════════════
+apiVersion: network.azure.com/v1api20240301
+kind: VirtualNetwork
+metadata:
+  name: vnet
+  namespace: default
+spec:
+  azureName: krops-${CLUSTER_NAME}-vnet
+  location: ${AZURE_LOCATION}
+  owner:
+    armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/krops-${CLUSTER_NAME}-data
+  addressSpace:
+    addressPrefixes:
+      - 10.60.0.0/16
+  tags:
+    managed-by: flux-aso
+    cluster: ${CLUSTER_NAME}
+---
+apiVersion: network.azure.com/v1api20240301
+kind: VirtualNetworksSubnet
+metadata:
+  name: postgres
+  namespace: default
+spec:
+  azureName: postgres
+  owner:
+    name: vnet
+  addressPrefix: 10.60.1.0/24
+  delegations:
+    - name: postgres
+      serviceName: Microsoft.DBforPostgreSQL/flexibleServers
+---
+apiVersion: network.azure.com/v1api20240601
+kind: PrivateDnsZone
+metadata:
+  name: postgres-dns
+  namespace: default
+spec:
+  azureName: ${CLUSTER_NAME}.private.postgres.database.azure.com
+  location: global
+  owner:
+    armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/krops-${CLUSTER_NAME}-data
+  tags:
+    managed-by: flux-aso
+---
+apiVersion: network.azure.com/v1api20240601
+kind: PrivateDnsZonesVirtualNetworkLink
+metadata:
+  name: postgres-dns-vnet
+  namespace: default
+spec:
+  azureName: krops-${CLUSTER_NAME}-vnet
+  location: global
+  owner:
+    name: postgres-dns
+  virtualNetwork:
+    reference:
+      group: network.azure.com
+      kind: VirtualNetwork
+      name: vnet
+  registrationEnabled: false

--- a/workload/azure-base/postgres/flexible-server.yaml
+++ b/workload/azure-base/postgres/flexible-server.yaml
@@ -1,0 +1,65 @@
+---
+# ══════════════════════════════════════════════════════════════════════════════
+# Smallest-footprint PostgreSQL Flexible Server (the RDS instance's
+# counterpart in workload/base/rds-instances/). Private access through the
+# delegated subnet + private DNS zone (workload/azure-base/networking/).
+#
+# Authentication: Entra ID only, password auth disabled, so no master
+# password has to exist anywhere (RDS uses Secrets Manager for the same
+# reason). The krops-aso identity is the first Entra administrator so an
+# operator can grant further principals through it.
+#
+# API version: v20250801, the only ASO v2.19.0 group version that has the
+# FlexibleServersAdministrator kind (verified in v2/api/dbforpostgresql/).
+# ══════════════════════════════════════════════════════════════════════════════
+apiVersion: dbforpostgresql.azure.com/v20250801
+kind: FlexibleServer
+metadata:
+  name: db
+  namespace: default
+spec:
+  azureName: krops-${CLUSTER_NAME}-db
+  location: ${AZURE_LOCATION}
+  owner:
+    armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/krops-${CLUSTER_NAME}-data
+  version: "16"
+  sku:
+    name: Standard_B1ms
+    tier: Burstable
+  storage:
+    storageSizeGB: 32
+  backup:
+    backupRetentionDays: 7
+    geoRedundantBackup: Disabled
+  highAvailability:
+    mode: Disabled
+  authConfig:
+    activeDirectoryAuth: Enabled
+    passwordAuth: Disabled
+    tenantId: ${AZURE_TENANT_ID}
+  network:
+    delegatedSubnetResourceReference:
+      group: network.azure.com
+      kind: VirtualNetworksSubnet
+      name: postgres
+    privateDnsZoneArmResourceReference:
+      group: network.azure.com
+      kind: PrivateDnsZone
+      name: postgres-dns
+  tags:
+    managed-by: flux-aso
+    cluster: ${CLUSTER_NAME}
+---
+apiVersion: dbforpostgresql.azure.com/v20250801
+kind: FlexibleServersAdministrator
+metadata:
+  name: db-admin-krops-aso
+  namespace: default
+spec:
+  # The Entra object ID of the administrator is the resource name in ARM.
+  azureName: ${AZURE_ASO_PRINCIPAL_ID}
+  owner:
+    name: db
+  principalName: krops-aso
+  principalType: ServicePrincipal
+  tenantId: ${AZURE_TENANT_ID}

--- a/workload/azure-base/postgres/flux-ks.yaml
+++ b/workload/azure-base/postgres/flux-ks.yaml
@@ -1,0 +1,31 @@
+---
+# ══════════════════════════════════════════════════════════════════════════════
+# Flux Kustomization: PostgreSQL Flexible Server managed by this cluster's
+# ASO.
+#
+# dependsOn: networking — the delegated subnet and private DNS zone must be
+# Ready (networking has wait: true) before the server is created; the server
+# references them by name. timeout: 30m because server creation takes
+# 10-20 min.
+# ══════════════════════════════════════════════════════════════════════════════
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: postgres
+  namespace: flux-system
+spec:
+  interval: 10m
+  retryInterval: 2m
+  timeout: 30m
+  prune: true
+  wait: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./workload/azure-base/postgres
+  dependsOn:
+    - name: networking
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: cluster-vars

--- a/workload/azure-base/postgres/kustomization.yaml
+++ b/workload/azure-base/postgres/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flexible-server.yaml

--- a/workload/azure-base/storage/flux-ks.yaml
+++ b/workload/azure-base/storage/flux-ks.yaml
@@ -1,0 +1,29 @@
+---
+# ══════════════════════════════════════════════════════════════════════════════
+# Flux Kustomization: storage account + blob container managed by this
+# cluster's ASO.
+#
+# dependsOn: aso — the ASO CRDs and controller must be Ready (aso has
+# wait: true) before the storage CRs are applied.
+# ══════════════════════════════════════════════════════════════════════════════
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: storage
+  namespace: flux-system
+spec:
+  interval: 10m
+  retryInterval: 2m
+  timeout: 5m
+  prune: true
+  wait: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./workload/azure-base/storage
+  dependsOn:
+    - name: aso
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: cluster-vars

--- a/workload/azure-base/storage/kustomization.yaml
+++ b/workload/azure-base/storage/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - storage-account.yaml

--- a/workload/azure-base/storage/storage-account.yaml
+++ b/workload/azure-base/storage/storage-account.yaml
@@ -1,0 +1,56 @@
+---
+# ══════════════════════════════════════════════════════════════════════════════
+# Secure-by-default storage account + blob container (the S3 bucket's
+# counterpart in workload/base/s3-buckets/). Posture:
+#   - no anonymous blob access, HTTPS only, TLS 1.2 minimum
+#   - shared-key (account key) access disabled: Entra ID authorization only
+#   - blob versioning + 7-day soft delete
+#   - Microsoft-managed encryption at rest (default)
+# Account names are globally unique and 3-24 lowercase alphanumerics, so the
+# name is a committed literal in cluster-vars (STORAGE_ACCOUNT_NAME).
+# ══════════════════════════════════════════════════════════════════════════════
+apiVersion: storage.azure.com/v1api20230101
+kind: StorageAccount
+metadata:
+  name: data
+  namespace: default
+spec:
+  azureName: ${STORAGE_ACCOUNT_NAME}
+  location: ${AZURE_LOCATION}
+  owner:
+    armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/krops-${CLUSTER_NAME}-data
+  kind: StorageV2
+  sku:
+    name: Standard_LRS
+  accessTier: Hot
+  allowBlobPublicAccess: false
+  allowSharedKeyAccess: false
+  supportsHttpsTrafficOnly: true
+  minimumTlsVersion: TLS1_2
+  tags:
+    managed-by: flux-aso
+    cluster: ${CLUSTER_NAME}
+---
+apiVersion: storage.azure.com/v1api20230101
+kind: StorageAccountsBlobService
+metadata:
+  name: data-blob
+  namespace: default
+spec:
+  owner:
+    name: data
+  isVersioningEnabled: true
+  deleteRetentionPolicy:
+    enabled: true
+    days: 7
+---
+apiVersion: storage.azure.com/v1api20230101
+kind: StorageAccountsBlobServicesContainer
+metadata:
+  name: data
+  namespace: default
+spec:
+  azureName: data
+  owner:
+    name: data-blob
+  publicAccess: None

--- a/workload/swedencentral-01/kustomization.yaml
+++ b/workload/swedencentral-01/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../azure-base


### PR DESCRIPTION
## Summary
Azure workload side (issue #71, PR 2 of 3): `swedencentral-workload` AKS cluster (OIDC issuer + workload identity, system and ARM pools), `workload/azure-base` (cert-manager, ASO 2.19.0 via workload identity, VNet/subnet/private DNS, storage account + container, PostgreSQL Flexible Server with Entra-only auth), `workload/swedencentral-01`, and a cross-file identity-chain test wired into `mise run validate` and CI.

## Not in this PR
Docs (PR 3). No live run (no subscription); AKS version and IDs are placeholders.

## Verification
`mise run validate` (incl. new `azure identity chain OK`), `tests/test-bootstrap-config.py`, yamllint, konflate render.

Refs #71
