### PR TITLE
docs: Azure environment guide and cross-links

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,16 @@ mise -E local-talos run kubeconfigs
 mise -E local-talos run teardown  # releases the Hardware; never wipes the machine
 ```
 
+The `azure` environment builds an AKS management cluster with CAPZ and
+manages Azure resources with Azure Service Operator on the workload
+clusters; see [docs/azure.md](docs/azure.md):
+
+```sh
+mise -E azure install            # adds az
+mise -E azure run azure-bootstrap
+mise -E azure run bootstrap
+```
+
 ## The bootstrap CLI
 
 The single `krops-bootstrap` binary implements bootstrap, the default pivot, and
@@ -230,6 +240,7 @@ teardown controls, toolbox release, and current parity status.
 | [docs/secrets.md](docs/secrets.md) | SOPS + age secret management, key setup, credential rotation |
 | [docs/operations.md](docs/operations.md) | Toolbox runtime, prerequisites, quotas, bootstrap, pivot recovery, teardown, validation |
 | [docs/extending.md](docs/extending.md) | Adding a workload cluster, adding apps to the workload clusters, adding other providers (Azure, Talos, k0smotron) |
+| [docs/azure.md](docs/azure.md) | Azure environment: subscription prep, credentials, AKS clusters, ASO on workload clusters, upgrades |
 | [docs/airgap.md](docs/airgap.md) | Zarf air-gap bundle: package build, offline deploy, verification checklist, update drill |
 
 ## Repository layout
@@ -250,7 +261,7 @@ teardown controls, toolbox release, and current parity status.
 ├── website/                       Docs site assets: colour scheme CSS, CNAME
 ├── docs/                          Detailed documentation (see table above)
 ├── mise.toml / mise.*.toml        Pinned toolchain and per-environment
-│                                  task layers (aws, local-host, local-talos)
+│                                  task layers (aws, azure, local-host, local-talos)
 ├── renovate.json5                 Hosted Renovate discovery and grouping rules
 ├── mgmt/aws/                      Synced by the MANAGEMENT cluster's Flux
 │   ├── infrastructure/           cert-manager, CAPI operator, CAPA identity,
@@ -277,9 +288,12 @@ teardown controls, toolbox release, and current parity status.
 │   ├── capi-providers/           cabpt-system, cacppt-system, capi-system,
 │   │                              capt-system (Tinkerbell)
 │   └── clusters/                 management (self-managed)
+├── mgmt/azure/                    AKS management cluster (CAPZ + ASO)
 └── workload/                     Synced by each WORKLOAD cluster's Flux
     ├── base/                     ACK S3/RDS/IAM controllers, Bucket CRs,
     │                              DBInstance CRs, reader Role CRs
+    ├── azure-base/               cert-manager, ASO, and the Azure workload
+    │                              resources (VNet, storage, PostgreSQL)
     ├── local-host/               OCI-synced Podinfo workload overlay
     ├── eu-north-01/              Per-cluster overlay (sync target)
     └── eu-west-01/               Per-cluster overlay (sync target)

--- a/docs/azure.md
+++ b/docs/azure.md
@@ -1,0 +1,110 @@
+# Azure environment
+
+The `azure` environment mirrors `aws`: a kind bootstrap cluster runs Flux,
+CAPZ builds an AKS management cluster, the pivot moves the management
+objects into it, and each AKS workload cluster runs its own Azure Service
+Operator (ASO) that reconciles Azure resources from `workload/azure-base/`.
+
+| AWS (`aws`) | Azure (`azure`) |
+|---|---|
+| CAPA, `AWSManagedControlPlane` | CAPZ v1.27.0, `AzureASOManagedControlPlane` (AKS via inline ASO resources) |
+| ACK controllers on workload clusters | ASO 2.19.0 Helm release on workload clusters |
+| EKS Pod Identity (ACK IAM + EKS controllers on mgmt) | Workload identity: user-assigned identity + federated credential + role assignment, reconciled by the ASO bundled with CAPZ on mgmt |
+| S3 bucket | Storage account + blob container |
+| RDS PostgreSQL | PostgreSQL Flexible Server (private access, Entra-only auth) |
+| IAM reader role | none yet (follow-up) |
+
+## Prerequisites
+
+- An Azure subscription where you hold Owner (needed once, for
+  `azure-bootstrap`).
+- `mise -E azure install` (adds `az`), a GitHub PAT and an age key as for
+  `aws` (`.env`, see [operations.md](./operations.md)).
+- Resource providers, the service principal, the shared resource group and
+  the `krops-aso` identity are created by:
+
+  ```sh
+  export AZURE_SUBSCRIPTION_ID=<id>
+  mise -E azure run azure-bootstrap
+  ```
+
+  It prints the values to commit and the service-principal secret once.
+
+## Commit the identifiers
+
+1. `mgmt/azure/infrastructure/azure-identity/azure-vars.yaml`:
+   `AZURE_SUBSCRIPTION_ID`, `AZURE_TENANT_ID`, `AZURE_CLIENT_ID` (the SP
+   app ID).
+2. `mgmt/azure/addons/flux-apps/flux-instance.yaml` (`cluster-vars`):
+   the same two IDs plus `AZURE_ASO_CLIENT_ID`, `AZURE_ASO_PRINCIPAL_ID`
+   (the `krops-aso` identity) and `STORAGE_ACCOUNT_NAME` (globally unique,
+   3-24 lowercase alphanumerics; change it if creation fails with
+   `StorageAccountAlreadyTaken`).
+3. Pick the AKS version: `az aks get-versions --location swedencentral -o table`
+   and set `version:` in `mgmt/azure/clusters/swedencentral/*/cluster.yaml`
+   (control plane and every MachinePool).
+
+## Credentials
+
+One service principal serves CAPZ (`AzureClusterIdentity` in
+`azure-identity/cluster-identity.yaml`) and the bundled ASO
+(`serviceoperator.azure.com/credential-from: aso-credentials` on every
+management-side ASO resource). It lives SOPS-encrypted in
+`mgmt/azure/infrastructure/azure-identity/aso-credentials.sops.yaml`:
+
+```sh
+mise run sops-decrypt mgmt/azure/infrastructure/azure-identity/aso-credentials.sops.yaml > /tmp/aso.yaml
+# set stringData.AZURE_SUBSCRIPTION_ID / AZURE_TENANT_ID / AZURE_CLIENT_ID / AZURE_CLIENT_SECRET
+mv /tmp/aso.yaml mgmt/azure/infrastructure/azure-identity/aso-credentials.sops.yaml
+mise run sops-encrypt mgmt/azure/infrastructure/azure-identity/aso-credentials.sops.yaml
+```
+
+Workload clusters hold no Azure secret: their ASO authenticates with
+workload identity through the federated credential in
+`mgmt/azure/infrastructure/aso-workload-identity/`.
+
+## Bootstrap, pivot, teardown
+
+```sh
+mise -E azure run bootstrap        # kind + Flux + CAPZ; then pivot into swedencentral-management
+mise -E azure run mgmt-kubeconfig  # ~/.kube/krops-mgmt.yaml
+mise -E azure run kubeconfigs      # workload kubeconfigs via clusterctl
+```
+
+During the pivot the CLI decrypts `aso-credentials.sops.yaml` with your age
+key and applies it to the target before `clusterctl move`
+(`pivot-sops-secrets` in `bootstrap.toml`): the moved ASO resources
+reference the Secret by name and clusterctl does not carry it.
+
+Teardown is manual for now: `mise -E azure run teardown` refuses and prints
+the steps (`teardown.manual` in `bootstrap.toml`). Automating the Azure
+orphan sweep is tracked in the follow-up issue linked from #71.
+
+## Reconciliation order
+
+Management cluster: cert-manager, capi-operator, capi-system, capz-system
+(health check waits for the CAPZ and the additional ASO CRDs),
+azure-identity, aso-workload-identity, swedencentral (clusters), flux-apps.
+`azure-identity` substitutes from the `azure-vars` ConfigMap it creates
+itself, so its first reconcile fails once and succeeds on the 2-minute
+retry.
+
+Workload cluster: cert-manager, aso, then networking, storage, and
+postgres (postgres depends on networking).
+
+## Upgrading CAPZ and ASO
+
+CAPZ bundles a specific ASO version and ASO only supports upgrades one
+minor version at a time. Renovate proposes CAPZ minors one at a time
+(`separateMultipleMinor`); merge and let the management cluster settle
+before the next. Keep the workload ASO chart (`workload/azure-base/aso/helm.yaml`)
+within one minor of the management-side bundle.
+
+## Known limitations
+
+- No live acceptance run has been performed yet (no subscription at
+  implementation time); placeholders are listed above.
+- No GPU node pool: GPU quota is 0 on new subscriptions.
+- No reader identity (the `krops-reader` IAM counterpart).
+- The Flexible Server's only administrator is the `krops-aso` identity;
+  grant humans through `FlexibleServersAdministrator` resources.

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -80,41 +80,18 @@ CAPA is the provider this repo already runs; use it as the template:
 
 ### Azure (CAPZ)
 
-CAPZ v1.26.0 speaks v1beta2 and bundles Azure Service Operator (ASO) v2.18.0,
-which backs the managed-AKS path.
+CAPZ v1.27.0 speaks the v1beta1 contract (accepted by CAPI v1.14 until the v1beta1 removal) and bundles Azure Service Operator (ASO) v2.19.0, which backs the managed-AKS path.
 
-1. Create a service principal (`az ad sp create-for-rbac`) and store two
-   SOPS secrets in `mgmt/aws/capi-providers/capz-system/`:
-   - the SP client secret, referenced by an `AzureClusterIdentity` CR
-     (environment-variable auth is deprecated upstream; see the CAPZ
-     multitenancy docs);
-   - `aso-credentials.sops.yaml` with `AZURE_SUBSCRIPTION_ID`,
-     `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET` for the
-     bundled ASO controller.
-2. Declare the provider in `capz-system/providers.yaml`:
-
-   ```yaml
-   apiVersion: operator.cluster.x-k8s.io/v1alpha2
-   kind: InfrastructureProvider
-   metadata:
-     name: azure
-     namespace: capz-system
-   spec:
-     version: "v1.26.0"
-   ```
-
-   No feature gates are needed for the ASO managed-cluster path.
-3. Register a `capz-system` Kustomization in `flux-ks.yaml` with SOPS
-   decryption and a healthCheck on
-   `azureclusters.infrastructure.cluster.x-k8s.io` (add the
-   `azureasomanagedclusters...` CRD when using the AKS path).
-4. Define AKS clusters in `mgmt/aws/clusters/<location>/<env>/` with the
-   `AzureASOManagedCluster` / `AzureASOManagedControlPlane` /
-   `AzureASOManagedMachinePool` types, keeping the repo conventions:
-   `namePrefix` kustomization, `capi-nameref.yaml`, the `fluxcd: enabled` and
-   region labels, and `cluster-vars` substitutions for the Azure location in
-   place of `${AWS_REGION}`. The AWS-only steps (Pod Identity associations,
-   ACK controllers) have no Azure equivalent; skip them.
+The `azure` environment is the worked example: `mgmt/azure/` (see
+[azure.md](./azure.md)). Reuse it rather than adding CAPZ to `mgmt/aws/`:
+the provider is `capi-providers/capz-system/providers.yaml`
+(`InfrastructureProvider azure` v1.27.0 with `configSecret: capz-variables`
+carrying `ADDITIONAL_ASO_CRDS`), credentials are one SOPS Secret read by
+both `AzureClusterIdentity` and ASO's `credential-from` annotation, and
+clusters use `AzureASOManagedCluster` / `AzureASOManagedControlPlane` /
+`AzureASOManagedMachinePool` with the ASO resources inline (their names are
+literal final names: kustomize's `namePrefix` does not descend into
+`spec.resources`).
 
 ### Talos (CABPT + CACPPT)
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -253,6 +253,8 @@ mise -E local-host run bootstrap   # local-host environment
 mise -E local-talos run bootstrap  # local-talos environment
 ```
 
+Azure: see [azure.md](./azure.md) for the subscription prep step that precedes `mise -E azure run bootstrap`.
+
 > Before the first AWS bootstrap, generate an age key for SOPS. See
 > [Secret management](./secrets.md) for native and toolbox-only setup.
 
@@ -460,6 +462,8 @@ mise run teardown                 # aws
 mise -E local-host run teardown   # local-host
 mise -E local-talos run teardown  # local-talos
 ```
+
+Azure teardown is manual; the CLI prints the steps.
 
 Native equivalents are `krops-bootstrap teardown [PROFILE]` and the retained
 `./teardown.sh` reference path. The positional profile selects an environment

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -81,6 +81,19 @@ View a decrypted secret without changing it:
 mise run sops-decrypt <file>.sops.yaml
 ```
 
+## Setting / rotating the Azure service principal
+
+```sh
+# Rotate: az ad sp credential reset --id <appId> --years 1
+mise run sops-decrypt mgmt/azure/infrastructure/azure-identity/aso-credentials.sops.yaml > /tmp/aso.yaml
+# Set stringData.AZURE_CLIENT_SECRET (and the IDs on first setup), then:
+mv /tmp/aso.yaml mgmt/azure/infrastructure/azure-identity/aso-credentials.sops.yaml
+mise run sops-encrypt mgmt/azure/infrastructure/azure-identity/aso-credentials.sops.yaml
+```
+
+Both CAPZ and the bundled ASO read this one Secret; workload clusters use
+workload identity and hold no Azure secret ([azure.md](./azure.md)).
+
 ## Setting / rotating the GitHub PAT
 
 The management cluster's own `flux-github-pat` secret is created imperatively

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,6 +75,7 @@ nav:
   - Bootstrap CLI: bootstrap-cli.md
   - Extending: extending.md
   - Secrets: secrets.md
+  - Azure environment: azure.md
   - AWS authentication and IAM: aws-iam.md
   - Workload resources: workload-resources.md
   - PR review with konflate: konflate.md


### PR DESCRIPTION
## Summary
Documentation for the azure environment (issue #71, PR 3 of 3): `docs/azure.md` (prereqs, IDs to commit, credentials, bootstrap/pivot/teardown, reconciliation order, CAPZ/ASO upgrade rule, known limitations), README environment section and layout, corrected CAPZ/ASO versions in `docs/extending.md`, secrets rotation, mkdocs nav.

## Verification
`mise run docs-build` (strict) and `mise run docs-test` pass; no stale `v1.26.0`/`v2.18.0` references remain.

Refs #71
