### PR TITLE
aws: move node pools to cheapest offered ARM and x86

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -66,8 +66,8 @@ flowchart TD
     REPO --> FS
 
     subgraph aws["AWS"]
-        EKS1[EKS: eu-north-1-workload<br/>ARM + GPU node pools<br/>pod-identity agent addon]
-        EKS2[EKS: eu-west-1-workload<br/>ARM + GPU node pools<br/>pod-identity agent addon]
+        EKS1[EKS: eu-north-1-workload<br/>x86 + ARM node pools<br/>pod-identity agent addon]
+        EKS2[EKS: eu-west-1-workload<br/>x86 + ARM node pools<br/>pod-identity agent addon]
         ROLE[IAM Role: krops-ack-s3-controller<br/>trust: pods.eks.amazonaws.com]
         RDSROLE[IAM Role: krops-ack-rds-controller<br/>trust: pods.eks.amazonaws.com]
         IAMROLE[IAM Role: krops-ack-iam-controller<br/>trust: pods.eks.amazonaws.com]

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -218,7 +218,6 @@ You also need:
 | Quota | Code | Needed | Why |
 |---|---|---|---|
 | EC2-VPC Elastic IPs (per region) | `L-0263D0A3` | ≥ 3 free | One EIP per NAT gateway (3 AZs) |
-| Running On-Demand G and VT instances | `L-DB2E81BA` | ≥ 4 vCPUs | GPU node pool (g4dn.xlarge); some regions default to **0** |
 
 Request increases with
 `aws service-quotas request-service-quota-increase --service-code ec2 --quota-code <code> --desired-value <n> --region <region>`.

--- a/mgmt/aws/clusters/eu-north-1/management/cluster.yaml
+++ b/mgmt/aws/clusters/eu-north-1/management/cluster.yaml
@@ -81,6 +81,8 @@ metadata:
   name: management-pool
   namespace: default
 spec:
+  # Cheapest offered on-demand Linux ARM (Graviton2) at 2 vCPU / 4 GiB;
+  # AL2023 requires Graviton2+ (Graviton1 a1 excluded).
   instanceType: t4g.medium
   scaling:
     minSize: 2

--- a/mgmt/aws/clusters/eu-north-1/staging/cluster.yaml
+++ b/mgmt/aws/clusters/eu-north-1/staging/cluster.yaml
@@ -55,12 +55,13 @@ spec:
 
 ---
 # ══════════════════════════════════════════════════════════════════════════════
-# Node Pool 1: GPU – single cheapest NVIDIA GPU instance (g4dn.xlarge, 1x T4)
+# Node Pool 1: x86 – cheapest on-demand Linux x86 (t3.medium, 2 vCPU / 4 GiB)
+# Replaces the former g4dn.xlarge GPU pool; no GPU label/taint (no accelerator).
 # ══════════════════════════════════════════════════════════════════════════════
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachinePool
 metadata:
-  name: workload-gpu
+  name: workload-x86
   namespace: default
 spec:
   clusterName: workload
@@ -73,28 +74,23 @@ spec:
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
         kind: AWSManagedMachinePool
-        name: workload-gpu
+        name: workload-x86
       version: "1.34.6"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: AWSManagedMachinePool
 metadata:
-  name: workload-gpu
+  name: workload-x86
   namespace: default
 spec:
-  instanceType: g4dn.xlarge
+  # Cheapest offered on-demand Linux x86 at 2 vCPU / 4 GiB in eu-north-1
+  # (t3a.medium is not offered in this region).
+  instanceType: t3.medium
   scaling:
     minSize: 1
     maxSize: 2
-  amiType: AL2023_x86_64_NVIDIA
+  amiType: AL2023_x86_64_STANDARD
   capacityType: onDemand
-  labels:
-    node.kubernetes.io/gpu: "true"
-    nvidia.com/gpu.present: "true"
-  taints:
-    - key: nvidia.com/gpu
-      value: "true"
-      effect: no-schedule
 
 ---
 # ══════════════════════════════════════════════════════════════════════════════
@@ -125,6 +121,8 @@ metadata:
   name: workload-arm
   namespace: default
 spec:
+  # Cheapest offered on-demand Linux ARM (Graviton2) at 2 vCPU / 4 GiB;
+  # AL2023 requires Graviton2+ (Graviton1 a1 excluded).
   instanceType: t4g.medium
   scaling:
     minSize: 3

--- a/mgmt/aws/clusters/eu-west-1/staging/cluster.yaml
+++ b/mgmt/aws/clusters/eu-west-1/staging/cluster.yaml
@@ -55,12 +55,13 @@ spec:
 
 ---
 # ══════════════════════════════════════════════════════════════════════════════
-# Node Pool 1: GPU – single cheapest NVIDIA GPU instance (g4dn.xlarge, 1x T4)
+# Node Pool 1: x86 – cheapest on-demand Linux x86 (t3a.medium, 2 vCPU / 4 GiB)
+# Replaces the former g4dn.xlarge GPU pool; no GPU label/taint (no accelerator).
 # ══════════════════════════════════════════════════════════════════════════════
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachinePool
 metadata:
-  name: workload-gpu
+  name: workload-x86
   namespace: default
 spec:
   clusterName: workload
@@ -73,28 +74,23 @@ spec:
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
         kind: AWSManagedMachinePool
-        name: workload-gpu
+        name: workload-x86
       version: "1.34.6"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: AWSManagedMachinePool
 metadata:
-  name: workload-gpu
+  name: workload-x86
   namespace: default
 spec:
-  instanceType: g4dn.xlarge
+  # Cheapest offered on-demand Linux x86 at 2 vCPU / 4 GiB in eu-west-1
+  # (t3a, AMD; cheaper than t3.medium).
+  instanceType: t3a.medium
   scaling:
     minSize: 1
     maxSize: 2
-  amiType: AL2023_x86_64_NVIDIA
+  amiType: AL2023_x86_64_STANDARD
   capacityType: onDemand
-  labels:
-    node.kubernetes.io/gpu: "true"
-    nvidia.com/gpu.present: "true"
-  taints:
-    - key: nvidia.com/gpu
-      value: "true"
-      effect: no-schedule
 
 ---
 # ══════════════════════════════════════════════════════════════════════════════
@@ -125,6 +121,8 @@ metadata:
   name: workload-arm
   namespace: default
 spec:
+  # Cheapest offered on-demand Linux ARM (Graviton2) at 2 vCPU / 4 GiB;
+  # AL2023 requires Graviton2+ (Graviton1 a1 excluded).
   instanceType: t4g.medium
   scaling:
     minSize: 3


### PR DESCRIPTION
## Summary

Move every AWS node pool to the cheapest instance AWS actually offers for its
architecture, mirroring the provenance-comment approach used for the Azure SKUs.

**x86 pools (the two `workload-gpu` pools) → `workload-x86`:**

| Cluster | Before | After | Price (on-demand Linux) |
|---|---|---|---|
| eu-north-1/staging | g4dn.xlarge (GPU) | `t3.medium` | $0.0432/hr (t3a.medium not offered in eu-north-1) |
| eu-west-1/staging | g4dn.xlarge (GPU) | `t3a.medium` | $0.0408/hr (cheaper than t3.medium $0.0456) |

- Renamed `workload-gpu` → `workload-x86` (MachinePool + AWSManagedMachinePool + `nameReference`).
- AMI family `AL2023_x86_64_NVIDIA` → `AL2023_x86_64_STANDARD`.
- Dropped the `nvidia.com/gpu` no-schedule taint and the `node.kubernetes.io/gpu` / `nvidia.com/gpu.present` labels (no accelerator).

**ARM pools (`workload-arm`, `management-pool`): no change.**
Already on `t4g.medium`, the cheapest offered 2 vCPU / 4 GiB ARM (Graviton2) in
both regions ($0.0344 eu-north-1 / $0.0368 eu-west-1). AL2023 requires Graviton2+
so Graviton1 `a1` is excluded. Provenance comment added, same style as Azure.

**Docs:** dropped the now-stale G/VT (g4dn) AWS quota row in `docs/operations.md`.

## Pricing basis

On-demand Linux, shared tenancy, from the AWS per-region price feed
(`pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonEC2/current/<region>/index.json`,
`BoxUsage` / USD Hrs), captured 2026-09-10. Small t3/t3a/t4g nano–small SKUs are
excluded as a usable-node floor, matching the pool-minimum floor applied on Azure.

## Verification

`mise run validate` (bash syntax, airgap digest pins, bootstrap cross-check, azure
identity chain, all kustomize builds), yamllint on the changed files, renovate
coverage, and `mise run docs-build`/`docs-test` (strict, 0 warnings / 9 passed).

## Caveat

Per-region instance availability/quota is not live-verified (pricing data is the
public price feed; no AWS session used). A live reconcile should confirm the SKUs
are available in the target AZs.

Refs #233
