### PR TITLE
bootstrap-rs: post-kind-create-task and pivot-manifests knobs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,9 +82,11 @@ resources. There is no app source code here, only declarative infrastructure.
   rerun-safe-by-default semantics. Chart versions it installs imperatively
   are Renovate-annotated constants in `src/main.rs`. CI (bootstrap-rs
   workflow) runs fmt/clippy/build/test; the toolchain is pinned in
-  `rust-toolchain.toml`. Two config-driven knobs added for azure:
+  `rust-toolchain.toml`. Four config-driven knobs added for azure:
   `pivot-sops-secrets` (SOPS manifests applied in the pivot target before
-  the move) and `teardown.manual` (refuse with operator text).
+  the move), `teardown.manual` (refuse with operator text),
+  `post-kind-create-task` (mise task run after kind creation) and
+  `pivot-manifests` (plain manifests applied in the target before the move).
 - `bootstrap.sh` / `pivot.sh` / `teardown.sh`: the shell equivalents of the
   CLI's phases. Kept until the binary completes full parity runs per
   environment, then retired (issues #92/#95/#100). The lifecycle mise tasks

--- a/bootstrap-rs/src/config.rs
+++ b/bootstrap-rs/src/config.rs
@@ -78,6 +78,18 @@ pub struct Environment {
     /// Cluster hierarchy. Relative to the repository root.
     #[serde(default)]
     pub pivot_sops_secrets: Vec<String>,
+    /// Mise task run once the kind bootstrap cluster exists (issue #236):
+    /// provider-specific setup that must be in place before Flux installs
+    /// anything (azure: Arc OIDC federation so CAPZ/ASO can use workload
+    /// identity instead of a service-principal secret).
+    #[serde(default)]
+    pub post_kind_create_task: Option<String>,
+    /// Plain (unencrypted) manifests applied to the pivot target before
+    /// `clusterctl move` (issue #236): non-secret objects the moved resources
+    /// reference by name that clusterctl does not carry (the workload-identity
+    /// replacement for pivot-sops-secrets). Relative to the repository root.
+    #[serde(default)]
+    pub pivot_manifests: Vec<String>,
     /// Teardown constants for this environment (issue #100).
     #[serde(default)]
     pub teardown: TeardownEnv,
@@ -386,6 +398,29 @@ manifest = "mgmt/aws/infrastructure/aws-identity/identity.yaml"
         let aws = config.environment("aws").unwrap();
         assert!(aws.pivot_sops_secrets.is_empty());
         assert!(aws.teardown.manual.is_none());
+    }
+
+    #[test]
+    fn parses_post_kind_create_task_and_pivot_manifests() {
+        let text = format!(
+            "{MINIMAL}\n[environments.azure]\nkind = \"azure\"\nsync = \"github\"\n\
+             sync-path = \"mgmt/azure\"\nmgmt-cluster = \"swedencentral-management\"\n\
+             mgmt-ready-timeout = \"40m\"\ninfra-provider-namespace = \"capz-system\"\n\
+             infra-provider-name = \"azure\"\nprovider-manifests = []\n\
+             post-kind-create-task = \"arc-federate\"\n\
+             pivot-manifests = [\"mgmt/azure/infrastructure/azure-identity/aso-credentials.yaml\"]\n"
+        );
+        let config = parse(&text).unwrap();
+        let azure = config.environment("azure").unwrap();
+        assert_eq!(azure.post_kind_create_task.as_deref(), Some("arc-federate"));
+        assert_eq!(
+            azure.pivot_manifests,
+            vec!["mgmt/azure/infrastructure/azure-identity/aso-credentials.yaml"]
+        );
+        // Existing environments default to no hook and no plain manifests.
+        let aws = config.environment("aws").unwrap();
+        assert!(aws.post_kind_create_task.is_none());
+        assert!(aws.pivot_manifests.is_empty());
     }
 
     #[test]

--- a/bootstrap-rs/src/main.rs
+++ b/bootstrap-rs/src/main.rs
@@ -1848,6 +1848,21 @@ async fn pivot_install_capi_in_target(
         .await?;
     }
 
+    // Plain pivot manifests (issue #236): non-secret objects the moved
+    // resources reference by name that clusterctl does not carry (the
+    // workload-identity aso-credentials Secret). Applied pre-move for the
+    // same reason as pivot-sops-secrets below, minus the decryption.
+    if !cfg.environment.pivot_manifests.is_empty() {
+        println!(">>> Applying pivot manifests in the target...");
+        for manifest in &cfg.environment.pivot_manifests {
+            run(
+                "kubectl",
+                &kubectl_cmd(Some(kc), &["apply", "-f", manifest]),
+            )
+            .await?;
+        }
+    }
+
     if cfg.profile == "aws" {
         // CAPA credentials: the InfrastructureProvider above references the
         // aws-credentials secret (configSecret.name). On the bootstrap
@@ -2731,6 +2746,32 @@ mod tests {
     fn post_kind_create_hook_command_uses_profile_and_task() {
         let args = post_kind_create_hook_args("azure", "arc-federate");
         assert_eq!(args, vec!["-E", "azure", "run", "arc-federate"]);
+    }
+
+    #[test]
+    fn pivot_manifests_apply_after_provider_manifests() {
+        // Guard the Phase 3 ordering contract: pivot-manifests are applied
+        // after provider CRs (CAPZ must exist before its identity Secret is
+        // meaningful) and before pivot-sops-secrets. The ordering lives in
+        // pivot_install_capi_in_target; this test pins the source order.
+        let src = include_str!("main.rs");
+        let providers = src
+            .find("for manifest in &cfg.environment.provider_manifests")
+            .unwrap();
+        let plain = src
+            .find("for manifest in &cfg.environment.pivot_manifests")
+            .unwrap();
+        let sops = src
+            .find("for manifest in &cfg.environment.pivot_sops_secrets")
+            .unwrap();
+        assert!(
+            providers < plain,
+            "pivot-manifests must apply after provider-manifests"
+        );
+        assert!(
+            plain < sops,
+            "pivot-manifests must apply before pivot-sops-secrets"
+        );
     }
 
     #[test]

--- a/bootstrap-rs/src/main.rs
+++ b/bootstrap-rs/src/main.rs
@@ -425,6 +425,12 @@ fn required_tools(env: &Environment) -> Vec<&'static str> {
     tools
 }
 
+/// argv for the optional post-kind-create hook (issue #236): the named mise
+/// task in the active profile, same invocation shape as aws-credentials.
+fn post_kind_create_hook_args<'a>(profile: &'a str, task: &'a str) -> Vec<&'a str> {
+    vec!["-E", profile, "run", task]
+}
+
 /// Whether the GitHub/age preflight (PAT, repo branch probe, sops age
 /// key) must run: gated on the sync source (issue #105 scope item 6),
 /// not the profile name. AWS-only credential steps stay profile-gated.
@@ -2384,6 +2390,17 @@ async fn run_bootstrap(cfg: &Config, http: &reqwest::Client) -> Result<()> {
     // Step 1: ensure the kind management cluster (reuse by default; --recreate replaces).
     ensure_kind_cluster(cfg, &preflight.engine_sock).await?;
 
+    // Optional provider hook (issue #236): runs on both the fresh-create and
+    // healthy-reuse paths so a rerun re-asserts the setup (e.g. azure Arc
+    // federation). A non-zero exit aborts the bootstrap before Flux installs.
+    if let Some(task) = &cfg.environment.post_kind_create_task {
+        println!(
+            ">>> Running post-kind-create task '{task}' (mise -E {} run {task})...",
+            cfg.profile
+        );
+        run("mise", &post_kind_create_hook_args(&cfg.profile, task)).await?;
+    }
+
     // Step 1.5: bootstrap the local container registry (local-host only).
     if cfg.is_local() {
         bootstrap_local_registry(cfg, &preflight.engine, http).await?;
@@ -2708,6 +2725,12 @@ mod tests {
         assert!(local.len() > base.len());
         assert!(local.contains(&"flux"));
         assert!(local.contains(&"curl"));
+    }
+
+    #[test]
+    fn post_kind_create_hook_command_uses_profile_and_task() {
+        let args = post_kind_create_hook_args("azure", "arc-federate");
+        assert_eq!(args, vec!["-E", "azure", "run", "arc-federate"]);
     }
 
     #[test]

--- a/docs/bootstrap-cli.md
+++ b/docs/bootstrap-cli.md
@@ -95,6 +95,14 @@ pins together with their declarative counterparts. See
   decrypts with `SOPS_AGE_KEY_FILE` (defaults to `AGE_KEY_FILE`) and applies to
   the target before `clusterctl move`. Used by `azure` for the ASO/CAPZ
   credential Secret that moved objects reference by name.
+- `pivot-manifests` (optional, list): plain (unencrypted) manifests applied to
+  the target before `clusterctl move`, after the provider CRs. The
+  workload-identity replacement for `pivot-sops-secrets`; used by `azure` for
+  the secret-free `aso-credentials` Secret (issue #236).
+- `post-kind-create-task` (optional, string): name of a mise task in the
+  active profile (`mise.<env>.toml`) run once the kind bootstrap cluster
+  exists, on both the create and healthy-reuse paths; a non-zero exit aborts
+  the bootstrap. `azure` uses it for Arc OIDC federation (issue #236).
 - `teardown.manual` (optional, string): when set, `krops-bootstrap teardown`
   refuses to run for that environment and prints the text. `azure` uses it
   until the live acceptance run defines the Azure orphan sweep.

--- a/tests/test-bootstrap-config.py
+++ b/tests/test-bootstrap-config.py
@@ -112,6 +112,21 @@ def main() -> int:
                 failures.append(f"environments.{name} pivot-sops-secret missing: {manifest}")
             if not manifest.endswith(".sops.yaml"):
                 failures.append(f"environments.{name} pivot-sops-secret is not a *.sops.yaml: {manifest}")
+        # Plain manifests the pivot applies in the target before the move
+        # (issue #236): the workload-identity replacement for
+        # pivot-sops-secrets, so the naming must be plain, not *.sops.yaml.
+        for manifest in env.get("pivot-manifests", []):
+            if not (REPO_ROOT / manifest).is_file():
+                failures.append(f"environments.{name} pivot-manifest missing: {manifest}")
+            elif manifest.endswith(".sops.yaml"):
+                failures.append(f"environments.{name} pivot-manifest must be plain, not *.sops.yaml: {manifest}")
+        hook = env.get("post-kind-create-task")
+        if hook:
+            mise_toml = REPO_ROOT / f"mise.{name}.toml"
+            if not mise_toml.is_file():
+                failures.append(f"environments.{name} post-kind-create-task but no {mise_toml.name}")
+            elif f"[tasks.{hook}]" not in mise_toml.read_text():
+                failures.append(f"environments.{name} post-kind-create-task '{hook}' has no [tasks.{hook}] in {mise_toml.name}")
 
         # ── teardown constants (issue #100) ─────────────────────────────
         td = env.get("teardown", {})


### PR DESCRIPTION
## Summary

Two new optional `[environments.<name>]` knobs for the krops-bootstrap CLI (issue #236). No behavior change for existing environments (both default to empty/absent).

- **`post-kind-create-task`** (optional string): name of a mise task in the active profile (`mise.<env>.toml`) that runs once the kind bootstrap cluster exists, on both the fresh-create and healthy-reuse paths (a rerun re-asserts the setup). Non-zero exit aborts the bootstrap before Flux installs anything. Same invocation shape as the existing `mise -E <profile> run aws-credentials` pivot call.
- **`pivot-manifests`** (optional list): plain (unencrypted) manifests applied to the pivot target before `clusterctl move`, after the provider CRs and before `pivot-sops-secrets`. The workload-identity replacement for `pivot-sops-secrets`.

## Pre-flight (Task 0.1)

Verified against the CAPZ v1.27.0 infrastructure-components manifest (41,270 lines) before any code:

- `AzureClusterIdentity` CRD `spec.type` enum includes `WorkloadIdentity`.
- Service accounts in `capz-system`: `capz-manager` (CAPZ), `azureserviceoperator-default` (bundled ASO).
- Both deployments project SA tokens with audience `api://AzureADTokenExchange` (ASO at `/var/run/secrets/tokens`, CAPZ at `/var/run/secrets/azure/tokens`).
- `connectedk8s` az CLI extension version 1.11.3 (used by the follow-up PR's `arc-federate` task).
- GNU sed 4.9 in the kind node; the apiserver issuer patch simulation against a real kind `kube-apiserver.yaml` verified (arc issuer becomes the first `--service-account-issuer` flag, kubeadm default kept second).

## Changes

- `bootstrap-rs/src/config.rs`: `post_kind_create_task: Option<String>` and `pivot_manifests: Vec<String>` on `Environment` (serde defaults).
- `bootstrap-rs/src/main.rs`: hook runs right after `ensure_kind_cluster`; pivot manifests applied in `pivot_install_capi_in_target` (Phase 3); source-order test pins provider-manifests < pivot-manifests < pivot-sops-secrets.
- `tests/test-bootstrap-config.py`: validates pivot-manifests files exist and are not `*.sops.yaml`; validates the hook task exists in `mise.<env>.toml`.
- `docs/bootstrap-cli.md`, `AGENTS.md`: knob documentation.

## Verification

`cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test --locked` (56 passed), `tests/test-bootstrap-config.py` (`OK (3 charts, 4 environments)`), `mise run validate`, `mise run docs-build` (strict, 0 warnings) / `docs-test` (9 passed). Both validator failure branches were exercised with deliberate fixtures.

Refs #236
