### PR TITLE
chore(renovate): propose latest dependency version only

### DIFF
--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -41,8 +41,10 @@ Renovate discovers and updates versions in:
 
 Grouping rules keep Flux updates together, CAPI updates together, imperative
 chart pins with their declarative counterparts, and node-version updates
-separate. Base images in `bootstrap-rs/Dockerfile` and air-gap images are
-digest-pinned while retaining readable tags. Nothing automerges.
+separate. Renovate proposes one PR at the newest available version for each
+dependency, rather than parallel major and non-major update PRs. Base images
+in `bootstrap-rs/Dockerfile` and air-gap images are digest-pinned while
+retaining readable tags. Nothing automerges.
 
 ## Toolbox release version
 

--- a/renovate.json5
+++ b/renovate.json5
@@ -21,6 +21,7 @@
   "schedule": ["after 6am on monday"],
   "timezone": "Europe/Helsinki",
   "rangeStrategy": "pin",
+  "separateMajorMinor": false,
   "commitBody": "Refs: #74",
   "suppressNotifications": ["prEditedNotification", "prIgnoreNotification"],
   "rebaseWhen": "conflicted",


### PR DESCRIPTION
## Summary

- configure Renovate to use one latest-version PR per dependency
- avoid parallel major and non-major update PRs

## Validation

- `git diff --check`
- Renovate dry-run not run: this environment has no GitHub auth token available