### PR TITLE
chore: group and pin GitHub Actions updates

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -41,9 +41,9 @@ jobs:
       - name: Build
         run: uv run python tools/assemble_docs.py && uv run mkdocs build --strict
       - name: Configure Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6.0.0
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5.0.0
         with:
           path: build/site
 
@@ -58,4 +58,4 @@ jobs:
     steps:
       - name: Deploy
         id: deploy
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5.0.1

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -67,6 +67,9 @@ jobs:
       - name: Install Renovate
         run: npm install --global renovate@44.69.8
 
+      - name: Verify only actions join the GitHub Actions group
+        run: python3 tests/test-renovate-actions-grouping.py
+
       - name: Verify airgap digest pinning
         env:
           RENOVATE_GITHUB_COM_TOKEN: ${{ github.token }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,7 +203,11 @@ discovered) and the digest-pinning test run in CI only (the validate.yml
 shared harness `tests/renovate_harness.py` (issue #97): a new Renovate test
 is a file list plus assertions, never a copy of the subprocess/parsing
 logic. The harness needs Node >= 24.11 (renovate's `engines` field);
-locally: `mise x node@24 -- python3 tests/test-renovate-coverage.py`. They
+locally: `mise x node@24 -- python3 tests/test-renovate-coverage.py`.
+The offline unit test `tests/test-renovate-actions-grouping.py` also runs in
+that CI job and uses the shared harness to apply Renovate’s real package-rule
+engine, checking that only action dependencies join the GitHub Actions group.
+Run locally with Renovate on PATH and Node >= 24.11. These tests
 do not cover lookup liveness or the replacement path; only the
 dry-run and the handlebars simulation cover those.
 

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -39,7 +39,8 @@ Renovate discovers and updates versions in:
   and grouped with `bootstrap.toml` and the Git manifests until the native
   shell path retires.
 
-Grouping rules keep Flux updates together, CAPI updates together, imperative
+Grouping rules keep GitHub Actions updates together (excluding workflow container
+images and runners), Flux updates together, CAPI updates together, imperative
 chart pins with their declarative counterparts, and node-version updates
 separate. Base images in `bootstrap-rs/Dockerfile` and air-gap images are
 digest-pinned while retaining readable tags. Nothing automerges.

--- a/renovate.json5
+++ b/renovate.json5
@@ -435,6 +435,12 @@
       "automerge": false
     },
     {
+      "description": "Group GitHub Actions only, excluding workflow images and runners",
+      "matchManagers": ["github-actions"],
+      "matchDepTypes": ["action"],
+      "groupName": "github-actions"
+    },
+    {
       "description": "Group Flux controller images and CLI updates",
       "matchDatasources": ["docker", "github-releases", "helm"],
       "matchPackageNames": [

--- a/tests/renovate_harness.py
+++ b/tests/renovate_harness.py
@@ -147,3 +147,41 @@ def _parse(returncode, stdout, fixture_files):
                         package.get("deps", [])
                     )
     return result
+
+
+def apply_package_rules(dependencies, repo_root=REPO_ROOT):
+    """Apply the real config with Renovate's rule engine, offline (Node >=24.11).
+
+    Resolve modules beside the installed CLI so local and CI tests use the same
+    Renovate version without maintaining a second JavaScript dependency install.
+    """
+    executable = shutil.which("renovate")
+    if executable is None:
+        raise RuntimeError("renovate must be installed and on PATH")
+    renovate_root = Path(executable).resolve().parent.parent
+    script = r"""
+import { createRequire } from 'node:module';
+import { pathToFileURL } from 'node:url';
+import fs from 'node:fs';
+const [root, configPath] = process.argv.slice(1);
+const require = createRequire(`${root}/package.json`);
+const JSON5 = require('json5');
+const { applyPackageRules } = await import(
+    pathToFileURL(`${root}/dist/util/package-rules/index.js`).href
+);
+const { packageRules } = JSON5.parse(fs.readFileSync(configPath, 'utf8'));
+const dependencies = JSON.parse(fs.readFileSync(0, 'utf8'));
+const results = [];
+for (const dependency of dependencies) {
+    const result = await applyPackageRules({ ...dependency, packageRules });
+    results.push({ groupName: result.groupName ?? null });
+}
+process.stdout.write(JSON.stringify(results));
+"""
+    completed = subprocess.run(
+        ["node", "--input-type=module", "-e", script,
+         str(renovate_root), str(repo_root / "renovate.json5")],
+        input=json.dumps(dependencies), text=True, capture_output=True,
+        check=True, env={**os.environ, "LOG_LEVEL": "fatal"},
+    )
+    return json.loads(completed.stdout)

--- a/tests/test-renovate-actions-grouping.py
+++ b/tests/test-renovate-actions-grouping.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Offline unit test of the action group's boundaries using Renovate's engine."""
+
+import unittest
+
+from renovate_harness import apply_package_rules
+
+
+class ActionsGroupingTest(unittest.TestCase):
+    def test_only_actions_join_group(self):
+        cases = [
+            ("actions/checkout", "action", "github-tags", "github-actions", True),
+            ("astral-sh/setup-uv", "action", "github-tags", "github-actions", True),
+            ("actions/checkout", "action", "github-digest", "github-actions", True),
+            ("registry", "service", "docker", "github-actions", False),
+            ("node", "container", "docker", "github-actions", False),
+            ("ubuntu", "github-runner", "github-runners", "github-actions", False),
+            ("node", "uses-with", "node-version", "github-actions", False),
+            ("astral-sh/uv", "uses-with", "github-releases", "github-actions", False),
+            ("jdx/mise", "uses-with", "github-releases", "github-actions", False),
+            ("example/workflows", "workflow", "github-tags", "github-actions", False),
+            ("actions/checkout", "action", "github-tags", "custom.regex", False),
+        ]
+        dependencies = [
+            {
+                "depName": name, "packageName": name, "depType": dep_type,
+                "datasource": datasource, "manager": manager,
+                "packageFile": ".github/workflows/test.yml",
+            }
+            for name, dep_type, datasource, manager, _ in cases
+        ]
+        results = apply_package_rules(dependencies)
+        self.assertEqual(len(results), len(cases))
+        for case, result in zip(cases, results):
+            with self.subTest(dependency=case[:4]):
+                self.assertEqual(result["groupName"] == "github-actions", case[4])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Group only GitHub Actions references in Renovate, excluding workflow images, runners, tool versions, and reusable workflows. Pin the remaining Pages action references to exact versions.

Add an offline unit test using Renovate’s rule engine, wire it into CI, and document the grouping scope. The test passes all 11 cases and rejects the original broad rule in all seven non-action workflow cases.

Validation: `mise run validate`, Renovate configuration validation and full dry-run, the grouping unit test, and `git diff --check` passed.
