### PR TITLE
docs: use a straight apostrophe in agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,7 +209,7 @@ is a file list plus assertions, never a copy of the subprocess/parsing
 logic. The harness needs Node >= 24.11 (renovate's `engines` field);
 locally: `mise x node@24 -- python3 tests/test-renovate-coverage.py`.
 The offline unit test `tests/test-renovate-actions-grouping.py` also runs in
-that CI job and uses the shared harness to apply Renovate’s real package-rule
+that CI job and uses the shared harness to apply Renovate's real package-rule
 engine, checking that only action dependencies join the GitHub Actions group.
 Run locally with Renovate on PATH and Node >= 24.11. These tests
 do not cover lookup liveness or the replacement path; only the


### PR DESCRIPTION
Replace the curly apostrophe in `Renovate's` in AGENTS.md with a straight apostrophe, as requested in the review of #242. This PR changes only that character.

Validation: `mise run validate` and `git diff --check` passed.
